### PR TITLE
fixes assert.isObject()

### DIFF
--- a/lib/interface/assert.js
+++ b/lib/interface/assert.js
@@ -289,7 +289,7 @@ assert.isFunction = function (val, msg) {
  */
 
 assert.isObject = function (val, msg) {
-  new Assertion(val, msg).to.be.an('object');
+  new Assertion(val, msg).to.be.a('object');
 };
 
 /**

--- a/test/assert.js
+++ b/test/assert.js
@@ -95,4 +95,23 @@ suite('Assert', function () {
       assert.instanceOf(5, Foo);
     }, "expected 5 to be an instance of Foo");
   });
+
+  test('isObject', function () {
+    function Foo(){}
+    assert.isObject({});
+    assert.isObject(new Foo());
+
+    err(function() {
+      assert.isObject(true);
+    }, "expected true to be a object");
+
+    err(function() {
+      assert.isObject(Foo);
+    }, "expected [Function: Foo] to be a object");
+
+    err(function() {
+      assert.isObject('foo');
+    }, "expected 'foo' to be a object");
+  });
+
 });


### PR DESCRIPTION
assert.isObject() is broken.  this patch fixes it.
