### PR TITLE
Make `chai.use` a no-op if the function has already been used.

### DIFF
--- a/lib/chai.js
+++ b/lib/chai.js
@@ -4,6 +4,7 @@
  * MIT Licensed
  */
 
+var used = [];
 var exports = module.exports = {};
 
 exports.version = '0.2.4';
@@ -14,7 +15,11 @@ exports.AssertionError = require('./error');
 exports.inspect = require('./utils/inspect');
 
 exports.use = function (fn) {
-  fn(this);
+  if (used.indexOf(fn) === -1) {
+    fn(this);
+    used.push(fn);
+  }
+
   return this;
 };
 


### PR DESCRIPTION
Fixes issue discussed in #9, where if two test scripts call `chai.use(extension)`, property redefinition errors occur.
