### PR TITLE
Make Assertion.prototype properties configurable

### DIFF
--- a/lib/assertion.js
+++ b/lib/assertion.js
@@ -98,7 +98,8 @@ Assertion.prototype.assert = function (expr, msg, negateMsg) {
 Object.defineProperty(Assertion.prototype, 'inspect',
   { get: function () {
       return inspect(this.obj);
-    }
+    },
+    configurable: true
 });
 
 /**
@@ -113,7 +114,8 @@ Object.defineProperty(Assertion.prototype, 'inspect',
 Object.defineProperty(Assertion.prototype, 'to',
   { get: function () {
       return this;
-    }
+    },
+    configurable: true
 });
 
 /**
@@ -128,7 +130,8 @@ Object.defineProperty(Assertion.prototype, 'to',
 Object.defineProperty(Assertion.prototype, 'be',
   { get: function () {
       return this;
-    }
+    },
+    configurable: true
 });
 
 /**
@@ -145,7 +148,8 @@ Object.defineProperty(Assertion.prototype, 'been',
   { get: function () {
       this.tense = 'past';
       return this;
-    }
+    },
+    configurable: true
 });
 
 /**
@@ -160,7 +164,8 @@ Object.defineProperty(Assertion.prototype, 'been',
 Object.defineProperty(Assertion.prototype, 'an',
   { get: function () {
       return this;
-    }
+    },
+    configurable: true
 });
 /**
  * # is
@@ -174,7 +179,8 @@ Object.defineProperty(Assertion.prototype, 'an',
 Object.defineProperty(Assertion.prototype, 'is',
   { get: function () {
       return this;
-    }
+    },
+    configurable: true
 });
 
 /**
@@ -189,7 +195,8 @@ Object.defineProperty(Assertion.prototype, 'is',
 Object.defineProperty(Assertion.prototype, 'and',
   { get: function () {
       return this;
-    }
+    },
+    configurable: true
 });
 
 /**
@@ -204,7 +211,8 @@ Object.defineProperty(Assertion.prototype, 'and',
 Object.defineProperty(Assertion.prototype, 'have',
   { get: function () {
       return this;
-    }
+    },
+    configurable: true
 });
 
 /**
@@ -219,7 +227,8 @@ Object.defineProperty(Assertion.prototype, 'have',
 Object.defineProperty(Assertion.prototype, 'with',
   { get: function () {
       return this;
-    }
+    },
+    configurable: true
 });
 
 /**
@@ -235,7 +244,8 @@ Object.defineProperty(Assertion.prototype, 'not',
   { get: function () {
       this.negate = true;
       return this;
-    }
+    },
+    configurable: true
 });
 
 /**
@@ -260,7 +270,8 @@ Object.defineProperty(Assertion.prototype, 'ok',
         , 'expected ' + this.inspect + ' to be falsey');
 
       return this;
-    }
+    },
+    configurable: true
 });
 
 /**
@@ -280,7 +291,8 @@ Object.defineProperty(Assertion.prototype, 'true',
         , 'expected ' + this.inspect + ' to be false');
 
       return this;
-    }
+    },
+    configurable: true
 });
 
 /**
@@ -300,7 +312,8 @@ Object.defineProperty(Assertion.prototype, 'false',
         , 'expected ' + this.inspect + ' to be true');
 
       return this;
-    }
+    },
+    configurable: true
 });
 
 /**
@@ -325,7 +338,8 @@ Object.defineProperty(Assertion.prototype, 'exist',
         , 'expected ' + this.inspect + ' to not exist');
 
       return this;
-    }
+    },
+    configurable: true
 });
 
 /**
@@ -349,7 +363,8 @@ Object.defineProperty(Assertion.prototype, 'empty',
         , 'expected ' + this.inspect + ' not to be empty');
 
       return this;
-    }
+    },
+    configurable: true
 });
 
 /**
@@ -373,7 +388,8 @@ Object.defineProperty(Assertion.prototype, 'arguments',
         , 'expected ' + this.inspect + ' to not be arguments');
 
       return this;
-    }
+    },
+    configurable: true
 });
 
 /**
@@ -698,7 +714,8 @@ Object.defineProperty(Assertion.prototype, 'contain',
   { get: function () {
       this.contains = true;
       return this;
-    }
+    },
+    configurable: true
 });
 
 /**


### PR DESCRIPTION
This allows plugins to install object-specific behavior for built-in
assertions.

I'm working on an assertion library for jQuery (inspired by https://github.com/velesin/jasmine-jquery).
The goal is to write assertions like:

```
$('#foo').should.exist;
$('#foo').should.contain('#bar');
```

These would be implemented by overriding the existing properties, e.g.:

```
chai.use(function (chai) {
  var chaiExist = Object.getOwnPropertyDescriptor(chai.Assertion.prototype, 'exist');
  Object.defineProperty(chai.Assertion.prototype, 'exist', {
    get : function () {
      if (this.obj instanceof jQuery) {
        this.assert(
            this.obj.length > 0
          , 'expected ' + inspect(this.obj.selector) + ' to exist'
          , 'expected ' + inspect(this.obj.selector) + ' not to exist');
        return this;
      } else {
        return chaiExist.get.call(this);
      }
    }
  });
});
```

But in order for this to work, the original `Object.defineProperty` needs to have
been passed `configurable: true`.

I'm also amenable to other suggestions as to how to accomplish this.
