### PR TITLE
Allow inclusion of stack trace for Assert error messages to be configurable

### DIFF
--- a/docs/out/code/expect.html
+++ b/docs/out/code/expect.html
@@ -176,6 +176,29 @@ _gaq.push(['_trackPageview']);
 <p>The <code>should</code> interface extends <code>Object.prototype</code> to provide a single getter as<br />the starting point for your language assertions. Most browser don't like<br />extensions to <code>Object.prototype</code> so it is not recommended for browser use.</p>
           </div>
         </article>
+        <article id="undefined-section" class="codeblock">
+          <div class="header"><h1>Assertion.includeStack</h1>
+          </div>
+          <div class="ctx">
+            <h3>Assertion.includeStack
+            </h3>
+          </div>
+          <div class="tags">
+            <div class="tag"><span class="type">&#64;api</span><span class="visibility">public</span>
+            </div>
+          </div>
+          <div class="description"><pre><code>Assertion.includeStack = true;  // enable stack on error
+</code></pre>
+
+<p>User configurable property, influences whether stack trace<br />is included in Assertion error message. Default of false<br />suppresses stack trace in the error message</p>
+          </div>
+          <div class="view-source">View Source
+          </div>
+          <div class="code-wrap">
+            <pre class="source prettyprint"><code>Assertion.includeStack = false;</code>
+            </pre>
+          </div>
+        </article>
         <article id="to-section" class="codeblock">
           <div class="header"><h1>to</h1>
           </div>

--- a/lib/assertion.js
+++ b/lib/assertion.js
@@ -47,6 +47,20 @@ var AssertionError = require('./error')
 
 module.exports = Assertion;
 
+/**
+  * # Assertion.includeStack
+  *
+  *     Assertion.includeStack = true;  // enable stack on error
+  *
+  * User configurable property, influences whether stack trace
+  * is included in Assertion error message. Default of false
+  * suppresses stack trace in the error message
+  *
+  * @api public
+  * 
+  */
+Assertion.includeStack = false;
+
 /*!
  * # Assertion Constructor
  *
@@ -81,7 +95,7 @@ Assertion.prototype.assert = function (expr, msg, negateMsg) {
     throw new AssertionError({
       operator: this.msg,
       message: msg,
-      stackStartFunction: this.ssfi
+      stackStartFunction: (Assertion.includeStack) ? this.assert : this.ssfi
     });
   }
 };

--- a/test/assert-config.js
+++ b/test/assert-config.js
@@ -1,0 +1,33 @@
+if (!chai) {
+  var chai = require('..');
+}
+
+var assert = chai.assert;
+
+suite('assert-config', function () {
+
+  function fooThrows () {
+    assert.equal('foo', 'bar');        
+  }
+  
+  test('Assertion.includeStack is true, stack trace available', function () {
+    chai.Assertion.includeStack = true;
+    try {
+      fooThrows();
+      assert.ok(false, 'should not get here because error thrown');
+    } catch (err) {
+      assert.include(err.stack, 'at fooThrows', 'should have stack trace in error message');
+    }
+  });
+
+  test('Assertion.includeStack is false, stack trace not available', function () {
+    chai.Assertion.includeStack = false;
+    try {
+      fooThrows();
+      assert.ok(false, 'should not get here because error thrown');
+    } catch (err) {
+      assert.equal(err.stack.indexOf('at fooThrows'), -1, 'should not have stack trace in error message');
+    }
+  });
+
+});


### PR DESCRIPTION
Allow inclusion of stack trace for Assert error messages to be configurable

``` javascript
Assertion.includeStack = true;  // enable stack trace to be included on error
```

Default value is false, resulting in less cluttered error results.
Allow user to configure this to true, to see stack trace to where error
occurred.
