### PR TITLE
Document that "should" works in browsers other than IE

### DIFF
--- a/lib/assertion.js
+++ b/lib/assertion.js
@@ -26,11 +26,11 @@
  * #### Differences
  *
  * The `expect` interface provides a function as a starting point for chaining
- * your language assertions. It works on both node.js and in the browser.
+ * your language assertions. It works on node.js and in all browsers.
  *
  * The `should` interface extends `Object.prototype` to provide a single getter as
- * the starting point for your language assertions. Most browser don't like
- * extensions to `Object.prototype` so it is not recommended for browser use.
+ * the starting point for your language assertions. It works on node.js and in
+ * all browsers except Internet Explorer.
  *
  * #### Configuration
  *


### PR DESCRIPTION
I tested this with FF 10, Chrome 18, Safari 5.1 (all work), and
IE 9 (does not work).
