### PR TITLE
Almost equal assertions

### DIFF
--- a/lib/interface/assert.js
+++ b/lib/interface/assert.js
@@ -59,6 +59,34 @@ module.exports = function (chai) {
     new Assertion(val, msg).is.ok;
   };
 
+
+  /**
+   * # .almostEqual(actual, expected, [decimal, message])
+   *
+   * The same as NumPy's assert_almost_equal, for scalars.
+   * Assert near equality: abs(expected-actual) < 0.5 * 10**(-decimal)
+   *
+   *      assert.almostEqual(3.1416, 3.14159, 3, 'these numbers are almost equal');
+   *
+   * @name equal
+   * @param {Number} actual
+   * @param {Number} expected
+   * @param {Number} decimal
+   * @param {String} message
+   * @api public
+   */
+
+  assert.almostEqual = function(act, exp, dec, msg) {
+    var test = new Assertion(act, msg);
+    dec = dec || 7
+    
+    test.assert(
+        Math.abs(test.obj - exp) < 0.5 * Math.pow(10, -dec)
+      , 'expected ' + test.inspect + ' to equal ' + inspect(exp) + ' up to ' + inspect(dec) + ' decimal places'
+      , 'expected ' + test.inspect + ' to not equal ' + inspect(exp) + ' up to ' + inspect(dec) + ' decimal places')
+  };
+    
+
   /**
    * # .equal(actual, expected, [message])
    *
@@ -157,6 +185,47 @@ module.exports = function (chai) {
 
   assert.deepEqual = function (act, exp, msg) {
     new Assertion(act, msg).to.eql(exp);
+  };
+  
+  /**
+   * # .deepAlmostEqual(actual, expected, [decimal, message])
+   *
+   * The same as NumPy's assert_almost_equal, for objects whose leaves are all numbers.
+   * Assert near equality: abs(expected-actual) < 0.5 * 10**(-decimal) for every leaf
+   *
+   *      assert.almostEqual({pi: 3.1416}, {pi: 3.14159}, 3);
+   *
+   * @name equal
+   * @param {*} actual
+   * @param {*} expected
+   * @param {Number} decimal
+   * @param {String} message
+   * @api public
+   */
+
+  assert.deepAlmostEqual = function(act, exp, dec, msg) {
+    var test = new Assertion(act, msg);
+    dec = dec || 7;
+    var tol = 0.5 * Math.pow(10, -dec);
+    
+    var deepEq = function(act, exp) {
+      if (Object(act) === act){
+        for (var k in act) {
+          if (!(deepEq(act[k], exp[k]))) {
+            return false;
+          }
+        }
+        return true;
+      }
+      else {
+        return Math.abs(act - exp) < tol;
+      }
+    };
+    
+    test.assert(
+        deepEq(test.obj, exp)
+      , 'expected ' + test.inspect + ' to equal ' + inspect(exp) + ' up to ' + inspect(dec) + ' decimal places'
+      , 'expected ' + test.inspect + ' to not equal ' + inspect(exp) + ' up to ' + inspect(dec) + ' decimal places')
   };
 
   /**


### PR DESCRIPTION
Hello,

This pull request adds 'almost equal' assertions like NumPy's. See http://docs.scipy.org/doc/numpy/reference/generated/numpy.testing.assert_almost_equal.html . These are useful for testing special functions (for example, http://en.wikipedia.org/wiki/Gamma_function) and other numerical functions in which fine implementation details such as order of operations can slightly affect the result.

Anand
