### PR TITLE
Support for expected and actual parameters in assert-style error object

### DIFF
--- a/lib/interface/assert.js
+++ b/lib/interface/assert.js
@@ -102,7 +102,10 @@ module.exports = function (chai) {
     test.assert(
         exp == test.obj
       , 'expected ' + test.inspect + ' to equal ' + inspect(exp)
-      , 'expected ' + test.inspect + ' to not equal ' + inspect(exp));
+      , 'expected ' + test.inspect + ' to not equal ' + inspect(exp)
+      , exp
+      , act
+    );
   };
 
   /**
@@ -125,7 +128,10 @@ module.exports = function (chai) {
     test.assert(
         exp != test.obj
       , 'expected ' + test.inspect + ' to equal ' + inspect(exp)
-      , 'expected ' + test.inspect + ' to not equal ' + inspect(exp));
+      , 'expected ' + test.inspect + ' to not equal ' + inspect(exp)
+      , exp
+      , act
+    );
   };
 
   /**


### PR DESCRIPTION
Minor fix to pass optional parameters to `Assertion.js::assert` (which already has support for it). See [this](http://tjholowaychuk.com/post/18574009869/mocha-string-diffs) for motivation.
