### PR TITLE
Add `deep` flag for equality and property value.

### DIFF
--- a/lib/assertion.js
+++ b/lib/assertion.js
@@ -169,6 +169,28 @@ Object.defineProperty(Assertion.prototype, 'not',
 });
 
 /**
+ * ### .deep
+ *
+ * Sets the `deep` flag, later used by the `equal` and
+ * `property` assertions.
+ *
+ *     expect(foo).to.deep.equal({ bar: 'baz' });
+ *     expect({ foo: { bar: { baz: 'quux' } } })
+ *       .to.have.deep.property('foo.bar.baz', 'quux');
+ *
+ * @name deep
+ * @api public
+ */
+
+Object.defineProperty(Assertion.prototype, 'deep',
+  { get: function () {
+      flag(this, 'deep', true);
+      return this;
+    }
+  , configurable: true
+});
+
+/**
  * ### .a(type)
  *
  * The `a` and `an` assertions are aliases that can be
@@ -492,10 +514,14 @@ Object.defineProperty(Assertion.prototype, 'arguments',
  * ### .equal(value)
  *
  * Asserts that the target is strictly equal (`===`) to `value`.
+ * Alternately, if the `deep` flag is set, asserts that
+ * the target is deeply equal to `value`.
  *
  *     expect('hello').to.equal('hello');
  *     expect(42).to.equal(42);
  *     expect(1).to.not.equal(true);
+ *     expect({ foo: 'bar' }).to.not.equal({ foo: 'bar' });
+ *     expect({ foo: 'bar' }).to.deep.equal({ foo: 'bar' });
  *
  * @name equal
  * @param {Mixed} value
@@ -503,11 +529,16 @@ Object.defineProperty(Assertion.prototype, 'arguments',
  */
 
 Assertion.prototype.equal = function (val) {
-  this.assert(
-      val === flag(this, 'object')
-    , 'expected #{this} to equal #{exp}'
-    , 'expected #{this} to not equal #{exp}'
-    , val );
+  var obj = flag(this, 'object');
+  if (flag(this, 'deep')) {
+    new Assertion(obj).to.eql(val);
+  } else {
+    this.assert(
+        val === obj
+      , 'expected #{this} to equal #{exp}'
+      , 'expected #{this} to not equal #{exp}'
+      , val);
+  }
 
   return this;
 };
@@ -636,10 +667,11 @@ Assertion.prototype.instanceOf = function (constructor) {
  *
  * Asserts that the target has a property `name`, optionally asserting that
  * the value of that property is strictly equal to  `value`.
- * Can use dot-notation for deep reference.
+ * If the `deep` flag is set, you can use dot- and bracket-notation for deep
+ * references into objects and arrays.
  *
- *     // legacy / simple referencing
- *     var obj = { foo: 'bar' }
+ *     // simple referencing
+ *     var obj = { foo: 'bar' };
  *     expect(obj).to.have.property('foo');
  *     expect(obj).to.have.property('foo', 'bar');
  *     expect(obj).to.have.property('foo').to.be.a('string');
@@ -650,9 +682,9 @@ Assertion.prototype.instanceOf = function (constructor) {
  *       , teas: [ 'chai', 'matcha', { tea: 'konacha' } ]
  *     };
 
- *     expect(deepObj).to.have.property('green.tea', 'matcha');
- *     expect(deepObj).to.have.property('teas[1]', 'matcha');
- *     expect(deepObj).to.have.property('teas[2].tea', 'konacha');
+ *     expect(deepObj).to.have.deep.property('green.tea', 'matcha');
+ *     expect(deepObj).to.have.deep.property('teas[1]', 'matcha');
+ *     expect(deepObj).to.have.deep.property('teas[2].tea', 'konacha');
  *
  * @name property
  * @param {String} name
@@ -663,25 +695,26 @@ Assertion.prototype.instanceOf = function (constructor) {
 
 Assertion.prototype.property = function (name, val) {
   var obj = flag(this, 'object')
-    , value = util.getPathValue(name, obj)
+    , value = flag(this, 'deep') ? util.getPathValue(name, obj) : obj[name]
+    , descriptor = flag(this, 'deep') ? 'deep property ' : 'property '
     , negate = flag(this, 'negate');
 
   if (negate && undefined !== val) {
     if (undefined === value) {
-      throw new Error(util.inspect(obj) + ' has no property ' + util.inspect(name));
+      throw new Error(util.inspect(obj) + ' has no ' + descriptor + util.inspect(name));
     }
   } else {
     this.assert(
         undefined !== value
-      , 'expected #{this} to have a property ' + util.inspect(name)
-      , 'expected #{this} to not have property ' + util.inspect(name));
+      , 'expected #{this} to have a ' + descriptor + util.inspect(name)
+      , 'expected #{this} to not have ' + descriptor + util.inspect(name));
   }
 
   if (undefined !== val) {
     this.assert(
         val === value
-      , 'expected #{this} to have a property ' + util.inspect(name) + ' of #{exp}, but got #{act}'
-      , 'expected #{this} to not have a property ' + util.inspect(name) + ' of #{act}'
+      , 'expected #{this} to have a ' + descriptor + util.inspect(name) + ' of #{exp}, but got #{act}'
+      , 'expected #{this} to not have a ' + descriptor + util.inspect(name) + ' of #{act}'
       , val
       , value
     );

--- a/lib/interface/assert.js
+++ b/lib/interface/assert.js
@@ -674,9 +674,9 @@ module.exports = function (chai, util) {
   /**
    * ### .property(object, property, [message])
    *
-   * Assert that `object` has property. Can use dot-notation for deep reference.
+   * Assert that `object` has property.
    *
-   *      assert.property({ tea: { green: 'matcha' }}, 'tea.green');
+   *      assert.property({ tea: { green: 'matcha' }}, 'tea');
    *
    * @name property
    * @param {Object} object
@@ -690,13 +690,13 @@ module.exports = function (chai, util) {
   };
 
   /**
-   * ### .notOwnProperty(object, property, [message])
+   * ### .notProperty(object, property, [message])
    *
-   * Assert that `object` does not have property. Can use dot-notation for deep reference.
+   * Assert that `object` does not have property.
    *
-   *      assert.ownProperty({ tea: { green: 'matcha' }}, 'tea.oolong');
+   *      assert.notProperty({ tea: { green: 'matcha' }}, 'coffee');
    *
-   * @name notOwnProperty
+   * @name notProperty
    * @param {Object} object
    * @param {String} property address
    * @param {String} message
@@ -708,12 +708,47 @@ module.exports = function (chai, util) {
   };
 
   /**
+   * ### .deepProperty(object, property, [message])
+   *
+   * Assert that `object` has property. Can use dot-notation for deep reference.
+   *
+   *      assert.deepProperty({ tea: { green: 'matcha' }}, 'tea.green');
+   *
+   * @name deepProperty
+   * @param {Object} object
+   * @param {String} Property address
+   * @param {String} message
+   * @api public
+   */
+
+  assert.deepProperty = function (obj, prop, msg) {
+    new Assertion(obj, msg).to.have.deep.property(prop);
+  };
+
+  /**
+   * ### .notDeepProperty(object, property, [message])
+   *
+   * Assert that `object` does not have property. Can use dot-notation for deep reference.
+   *
+   *      assert.notDeepProperty({ tea: { green: 'matcha' }}, 'tea.oolong');
+   *
+   * @name notDeepProperty
+   * @param {Object} object
+   * @param {String} property address
+   * @param {String} message
+   * @api public
+   */
+
+  assert.notDeepProperty = function (obj, prop, msg) {
+    new Assertion(obj, msg).to.not.have.deep.property(prop);
+  };
+
+  /**
    * ### .propertyVal(object, property, value, [message])
    *
    * Assert that `object` has property with `value`.
-   * Can use dot-notation for deep reference.
    *
-   *      assert.propertyVal({ tea: { green: 'matcha' }}, 'tea.green', 'matcha');
+   *      assert.propertyVal({ tea: 'is good' }, 'tea', 'is good');
    *
    * @name propertyVal
    * @param {Object} object
@@ -731,9 +766,9 @@ module.exports = function (chai, util) {
    * ### .propertyNotVal(object, property, value, [message])
    *
    * Assert that `object` has property but `value`
-   * does not equal  `value`. Can use dot-notation for deep reference.
+   * does not equal  `value`.
    *
-   *      assert.propertyNotVal({ tea: { green: 'matcha' }}, 'tea.green', 'konacha');
+   *      assert.propertyNotVal({ tea: 'is good' }, 'tea', 'is bad');
    *
    * @name propertyNotVal
    * @param {Object} object
@@ -744,6 +779,46 @@ module.exports = function (chai, util) {
    */
   assert.propertyNotVal = function (obj, prop, val, msg) {
     new Assertion(obj, msg).to.not.have.property(prop, val);
+  };
+
+  /**
+   * ### .deepPropertyVal(object, property, value, [message])
+   *
+   * Assert that `object` has property with `value`.
+   * Can use dot-notation for deep reference.
+   *
+   *      assert.deepPropertyVal({ tea: { green: 'matcha' }}, 'tea.green', 'matcha');
+   *
+   * @name deepPropertyVal
+   * @param {Object} object
+   * @param {String} property address
+   * @param {Mixed} value
+   * @param {String} message
+   * @api public
+   */
+
+  assert.deepPropertyVal = function (obj, prop, val, msg) {
+    new Assertion(obj, msg).to.have.deep.property(prop, val);
+  };
+
+  /**
+   * ### .deepPropertyNotVal(object, property, value, [message])
+   *
+   * Assert that `object` has property but `value`
+   * does not equal  `value`. Can use dot-notation for deep reference.
+   *
+   *      assert.deepPropertyNotVal({ tea: { green: 'matcha' }}, 'tea.green', 'konacha');
+   *
+   * @name deepPropertyNotVal
+   * @param {Object} object
+   * @param {String} property address
+   * @param {Mixed} value
+   * @param {String} message
+   * @api public
+   */
+
+  assert.deepPropertyNotVal = function (obj, prop, val, msg) {
+    new Assertion(obj, msg).to.not.have.deep.property(prop, val);
   };
 
   /**

--- a/test/assert.js
+++ b/test/assert.js
@@ -354,37 +354,47 @@ suite('assert', function () {
   });
 
   test('property', function () {
-    var obj = { foo: { bar: 'baz' }};
+    var obj = { foo: { bar: 'baz' } };
+    var simpleObj = { foo: 'bar' };
     assert.property(obj, 'foo');
-    assert.property(obj, 'foo.bar');
+    assert.deepProperty(obj, 'foo.bar');
     assert.notProperty(obj, 'baz');
-    assert.notProperty(obj, 'foo.baz');
-    assert.propertyVal(obj, 'foo.bar', 'baz');
-    assert.propertyNotVal(obj, 'foo.bar', 'flow');
+    assert.notProperty(obj, 'foo.bar');
+    assert.notDeepProperty(obj, 'foo.baz');
+    assert.deepPropertyVal(obj, 'foo.bar', 'baz');
+    assert.deepPropertyNotVal(obj, 'foo.bar', 'flow');
 
     err(function () {
       assert.property(obj, 'baz');
     }, "expected { foo: { bar: 'baz' } } to have a property 'baz'");
 
     err(function () {
-      assert.property(obj, 'foo.baz');
-    }, "expected { foo: { bar: 'baz' } } to have a property 'foo.baz'");
+      assert.deepProperty(obj, 'foo.baz');
+    }, "expected { foo: { bar: 'baz' } } to have a deep property 'foo.baz'");
 
     err(function () {
       assert.notProperty(obj, 'foo');
     }, "expected { foo: { bar: 'baz' } } to not have property 'foo'");
 
     err(function () {
-      assert.notProperty(obj, 'foo.bar');
-    }, "expected { foo: { bar: 'baz' } } to not have property 'foo.bar'");
+      assert.notDeepProperty(obj, 'foo.bar');
+    }, "expected { foo: { bar: 'baz' } } to not have deep property 'foo.bar'");
 
     err(function () {
-      assert.propertyVal(obj, 'foo.bar', 'ball');
-    }, "expected { foo: { bar: 'baz' } } to have a property 'foo.bar' of 'ball', but got 'baz'");
+      assert.propertyVal(simpleObj, 'foo', 'ball');
+    }, "expected { foo: 'bar' } to have a property 'foo' of 'ball', but got 'bar'");
 
     err(function () {
-      assert.propertyNotVal(obj, 'foo.bar', 'baz');
-    }, "expected { foo: { bar: 'baz' } } to not have a property 'foo.bar' of 'baz'");
+      assert.deepPropertyVal(obj, 'foo.bar', 'ball');
+    }, "expected { foo: { bar: 'baz' } } to have a deep property 'foo.bar' of 'ball', but got 'baz'");
+
+    err(function () {
+      assert.propertyNotVal(simpleObj, 'foo', 'bar');
+    }, "expected { foo: 'bar' } to not have a property 'foo' of 'bar'");
+
+    err(function () {
+      assert.deepPropertyNotVal(obj, 'foo.bar', 'baz');
+    }, "expected { foo: { bar: 'baz' } } to not have a deep property 'foo.bar' of 'baz'");
   });
 
   test('throws', function() {

--- a/test/expect.js
+++ b/test/expect.js
@@ -228,6 +228,10 @@ suite('expect', function () {
     }, "expected '4' to equal 4");
   });
 
+  test('deep.equal(val)', function(){
+    expect({ foo: 'bar' }).to.deep.equal({ foo: 'bar' });
+  });
+
   test('empty', function(){
     function FakeArgs() {};
     FakeArgs.prototype.length = 0;
@@ -278,14 +282,30 @@ suite('expect', function () {
     expect('test').to.have.property('length');
     expect(4).to.not.have.property('length');
 
-    expect({ foo: { bar: 'baz' }})
+    expect({ 'foo.bar': 'baz' })
       .to.have.property('foo.bar');
-    expect({ foo: { bar: 'baz' }})
-      .to.not.have.property('foo.bar.baz');
+    expect({ foo: { bar: 'baz' } })
+      .to.not.have.property('foo.bar');
 
     err(function(){
       expect('asd').to.have.property('foo');
     }, "expected 'asd' to have a property 'foo'");
+    err(function(){
+      expect({ foo: { bar: 'baz' } })
+        .to.have.property('foo.bar');
+    }, "expected { foo: { bar: 'baz' } } to have a property 'foo.bar'");
+  });
+
+  test('deep.property(name)', function(){
+    expect({ 'foo.bar': 'baz'})
+      .to.not.have.deep.property('foo.bar');
+    expect({ foo: { bar: 'baz' } })
+      .to.have.deep.property('foo.bar');
+
+    err(function(){
+      expect({ 'foo.bar': 'baz' })
+        .to.have.deep.property('foo.bar');
+    }, "expected { 'foo.bar': 'baz' } to have a deep property 'foo.bar'");
   });
 
   test('property(name, val)', function(){
@@ -307,6 +327,24 @@ suite('expect', function () {
     err(function(){
       expect('asd').to.have.property('constructor', Number);
     }, "expected 'asd' to have a property 'constructor' of [Function: Number], but got [Function: String]");
+  });
+
+  test('deep.property(name, val)', function(){
+    expect({ foo: { bar: 'baz' } })
+      .to.have.deep.property('foo.bar', 'baz');
+
+    err(function(){
+      expect({ foo: { bar: 'baz' } })
+        .to.have.deep.property('foo.bar', 'quux');
+    }, "expected { foo: { bar: 'baz' } } to have a deep property 'foo.bar' of 'quux', but got 'baz'");
+    err(function(){
+      expect({ foo: { bar: 'baz' } })
+        .to.not.have.deep.property('foo.bar', 'baz');
+    }, "expected { foo: { bar: 'baz' } } to not have a deep property 'foo.bar' of 'baz'");
+    err(function(){
+      expect({ foo: 5 })
+        .to.not.have.deep.property('foo.bar', 'baz');
+    }, "{ foo: 5 } has no deep property 'foo.bar'");
   });
 
   test('ownProperty(name)', function(){


### PR DESCRIPTION
See #63 for more discussion.

Also adds to the assert interface:
- deepProperty
- notDeepProperty
- deepPropertyVal
- deepPropertyNotVal

Please review; the changes, especially to the tests, were nontrivial. Everything should be fine, but I'd like another pair of eyes on this.
