### PR TITLE
respondTo and functions

### DIFF
--- a/chai.js
+++ b/chai.js
@@ -1040,8 +1040,15 @@ Assertion.prototype.Throw = function (constructor, msg) {
  *
  * Asserts that the object or class target will respond to a method.
  *
+ *     Klass.prototype.bar = function(){};
  *     expect(Klass).to.respondTo('bar');
  *     expect(obj).to.respondTo('bar');
+ *
+ * To check if a constructor will respond to a static function,
+ * set the `itself` flag.
+ *
+ *    Klass.baz = function(){};
+ *    expect(Klass).itself.to.respondTo('baz');
  *
  * @name respondTo
  * @param {String} method
@@ -1050,7 +1057,8 @@ Assertion.prototype.Throw = function (constructor, msg) {
 
 Assertion.prototype.respondTo = function (method) {
   var obj = flag(this, 'object')
-    , context = ('function' === typeof obj)
+    , itself = flag(this, 'itself')
+    , context = ('function' === typeof obj && !itself)
       ? obj.prototype[method]
       : obj[method];
 
@@ -1064,6 +1072,29 @@ Assertion.prototype.respondTo = function (method) {
 
   return this;
 };
+
+/**
+ * ### .itself
+ *
+ * Sets the `itself` flag, later used by the `respondTo` assertion.
+ *
+ *    function Foo() {}
+ *    Foo.bar = function() {}
+ *    Foo.prototype.baz = function() {}
+ *
+ *    expect(Foo).itself.to.respondTo('bar');
+ *    expect(Foo).itself.not.to.respondTo('baz');
+ *
+ * @name itself
+ * @api public
+ */
+Object.defineProperty(Assertion.prototype, 'itself',
+  { get: function () {
+      flag(this, 'itself', true);
+      return this;
+    }
+  , configurable: true
+});
 
 /**
  * ### .satisfy(method)

--- a/lib/assertion.js
+++ b/lib/assertion.js
@@ -987,8 +987,15 @@ Assertion.prototype.Throw = function (constructor, msg) {
  *
  * Asserts that the object or class target will respond to a method.
  *
+ *     Klass.prototype.bar = function(){};
  *     expect(Klass).to.respondTo('bar');
  *     expect(obj).to.respondTo('bar');
+ *
+ * To check if a constructor will respond to a static function,
+ * set the `itself` flag.
+ *
+ *    Klass.baz = function(){};
+ *    expect(Klass).itself.to.respondTo('baz');
  *
  * @name respondTo
  * @param {String} method
@@ -997,7 +1004,8 @@ Assertion.prototype.Throw = function (constructor, msg) {
 
 Assertion.prototype.respondTo = function (method) {
   var obj = flag(this, 'object')
-    , context = ('function' === typeof obj)
+    , itself = flag(this, 'itself')
+    , context = ('function' === typeof obj && !itself)
       ? obj.prototype[method]
       : obj[method];
 
@@ -1011,6 +1019,29 @@ Assertion.prototype.respondTo = function (method) {
 
   return this;
 };
+
+/**
+ * ### .itself
+ *
+ * Sets the `itself` flag, later used by the `respondTo` assertion.
+ *
+ *    function Foo() {}
+ *    Foo.bar = function() {}
+ *    Foo.prototype.baz = function() {}
+ *
+ *    expect(Foo).itself.to.respondTo('bar');
+ *    expect(Foo).itself.not.to.respondTo('baz');
+ *
+ * @name itself
+ * @api public
+ */
+Object.defineProperty(Assertion.prototype, 'itself',
+  { get: function () {
+      flag(this, 'itself', true);
+      return this;
+    }
+  , configurable: true
+});
 
 /**
  * ### .satisfy(method)

--- a/test/expect.js
+++ b/test/expect.js
@@ -590,18 +590,21 @@ suite('expect', function () {
   test('respondTo', function(){
     function Foo(){};
     Foo.prototype.bar = function(){};
+    Foo.func = function() {};
 
     var bar = {};
     bar.foo = function(){};
 
     expect(Foo).to.respondTo('bar');
     expect(Foo).to.not.respondTo('foo');
+    expect(Foo).itself.to.respondTo('func');
+    expect(Foo).itself.not.to.respondTo('bar');
 
     expect(bar).to.respondTo('foo');
 
     err(function(){
       expect(Foo).to.respondTo('baz');
-    }, "expected [Function: Foo] to respond to \'baz\'");
+    }, "expected { [Function: Foo] func: [Function] } to respond to \'baz\'");
 
     err(function(){
       expect(bar).to.respondTo('baz');

--- a/test/should.js
+++ b/test/should.js
@@ -548,18 +548,21 @@ suite('should', function() {
   test('respondTo', function(){
     function Foo(){};
     Foo.prototype.bar = function(){};
+    Foo.func = function(){};
 
     var bar = {};
     bar.foo = function(){};
 
     Foo.should.respondTo('bar');
     Foo.should.not.respondTo('foo');
+    Foo.should.itself.respondTo('func');
+    Foo.should.itself.not.respondTo('bar');
 
     bar.should.respondTo('foo');
 
     err(function(){
       Foo.should.respondTo('baz');
-    }, "expected [Function: Foo] to respond to \'baz\'");
+    }, "expected { [Function: Foo] func: [Function] } to respond to \'baz\'");
 
     err(function(){
       bar.should.respondTo('baz');


### PR DESCRIPTION
Currently, it is assumed by `respondTo` that a function is a constructor.

But it might also be used as an object, where the direct properties can be called:

``` javascript
function a() {};
a.b = function() {};
```

In this scenario, `respondTo` will fail:

``` javascript
expect(function() {
    expect(a).to.respondTo('b')
}).to.throw();
```

This could be fixed in three ways:
1. Check both func.prototype[method] and func[method]
2. Add a language keyword for checking on instances (breaks compatibility)
3. Add a language keyword for checking on direct properties
## Check both func.prototype and func

This would be an easy fix, but leaves the possibility for confusion:

``` javascript
function a() {};
a.prototype = { b: function() {} }
a.b = 'abc';

// What should be the result of this call?
expect(a).to.respondTo('b')
```
## Add a language keyword for checking on instances

The keyword could be `instance` and set a flag that means 'check the prototype':

``` javascript
function a() {};
a.prototype = { b: function() {}, c: 'abc' }
a.b = 'abc';
a.c = function() {};
// Notice that `b` and `c` is flipped

expect(a).instance.to.respondTo('b').and.not.respondTo('c')
expect(a).not.respondTo('b').and.to.respondTo('c')
```

This way around (which I think makes the most sense) would break compatibility with old code, but it would make it more in line with testing on non-function objects:

``` javascript
var a = function() {};
a.c = function() {};
var b = { c: function() {} };

expect(a).to.respondTo('c');
expect(b).to.respondTo('c');
```
## Add a language keyword for checking on direct properties

A keyword such as `itself` could set a flag that means check on the object itself and not the prototype:

``` javascript
function a() {};
a.prototype = { b: function() {}, c: 'abc' }
a.b = 'abc';
a.c = function() {};
// Notice that `b` and `c` is flipped

expect(a).to.respondTo('b').and.not.respondTo('c')
expect(a).itself.not.respondTo('b').and.to.respondTo('c')
```
## Conclusion

I think the second way (the `instance` keyword) would make the most sense, as asserting on a function would give the same results as on any other object.

But I do see the argument for not breaking compatibility, which means that the third option (the `itself` keyword) might be better.

I don't like the first option, as it brings too much confusion and makes the tests less readable.

Any thoughts on this?
## Real code broken by this

All code here will pass the first test but fail the second (the two lines should pass and fail together):

``` javascript
expect(Date.now).to.be.a('function')
expect(Date).to.respondTo('now')
```

``` javascript
expect(Object.keys).to.be.a('function')
expect(Object).to.respondTo('keys')
```

``` javascript
expect(Array.isArray).to.be.a('function')
expect(Array).to.respondTo('isArray')
```

``` javascript
expect(chai.expect().an.instanceof).to.be.a('function')
expect(chai.expect().an).to.respondTo('instanceof')
```
