### PR TITLE
Add .equals as an alias of .equal

### DIFF
--- a/chai.js
+++ b/chai.js
@@ -257,38 +257,6 @@
 
   }); // module: chai/assertion.js
 
-  require.register("chai/browser/error.js", function(module, exports, require){
-    /*!
-     * chai
-     * Copyright(c) 2011-2012 Jake Luer <jake@alogicalparadox.com>
-     * MIT Licensed
-     */
-
-    module.exports = AssertionError;
-
-    function AssertionError (options) {
-      options = options || {};
-      this.message = options.message;
-      this.actual = options.actual;
-      this.expected = options.expected;
-      this.operator = options.operator;
-
-      if (options.stackStartFunction && Error.captureStackTrace) {
-        var stackStartFunction = options.stackStartFunction;
-        Error.captureStackTrace(this, stackStartFunction);
-      }
-    }
-
-    AssertionError.prototype = Object.create(Error.prototype);
-    AssertionError.prototype.name = 'AssertionError';
-    AssertionError.prototype.constructor = AssertionError;
-
-    AssertionError.prototype.toString = function() {
-      return this.message;
-    };
-
-  }); // module: chai/browser/error.js
-
   require.register("chai/core/assertions.js", function(module, exports, require){
     /*!
      * chai
@@ -643,6 +611,7 @@
        *     expect({ foo: 'bar' }).to.deep.equal({ foo: 'bar' });
        *
        * @name equal
+       * @alias equals
        * @alias eq
        * @alias deep.equal
        * @param {Mixed} value
@@ -2389,6 +2358,38 @@
     };
 
   }); // module: chai/interface/should.js
+
+  require.register("chai/browser/error.js", function(module, exports, require){
+    /*!
+     * chai
+     * Copyright(c) 2011-2012 Jake Luer <jake@alogicalparadox.com>
+     * MIT Licensed
+     */
+
+    module.exports = AssertionError;
+
+    function AssertionError (options) {
+      options = options || {};
+      this.message = options.message;
+      this.actual = options.actual;
+      this.expected = options.expected;
+      this.operator = options.operator;
+
+      if (options.stackStartFunction && Error.captureStackTrace) {
+        var stackStartFunction = options.stackStartFunction;
+        Error.captureStackTrace(this, stackStartFunction);
+      }
+    }
+
+    AssertionError.prototype = Object.create(Error.prototype);
+    AssertionError.prototype.name = 'AssertionError';
+    AssertionError.prototype.constructor = AssertionError;
+
+    AssertionError.prototype.toString = function() {
+      return this.message;
+    };
+
+  }); // module: chai/browser/error.js
 
   require.register("chai/utils/addChainableMethod.js", function(module, exports, require){
     /*!

--- a/lib/chai/core/assertions.js
+++ b/lib/chai/core/assertions.js
@@ -351,6 +351,7 @@ module.exports = function (chai, _) {
    *     expect({ foo: 'bar' }).to.deep.equal({ foo: 'bar' });
    *
    * @name equal
+   * @alias equals
    * @alias eq
    * @alias deep.equal
    * @param {Mixed} value


### PR DESCRIPTION
It's mentioned a couple times in the docs, but obviously doesn't actually work. This fixes that :D

I didn't add it as an @alias in the docs because it seemed redundant, especially with two other aliases already. I also didn't add a test since there aren't any for .key vs. .keys and such. But if it needs it I'd be happy to add whatever!

Also, folio is totally rad.
