### PR TITLE
Don't inspect() assertion arguments if the assertion passes

### DIFF
--- a/lib/chai/assertion.js
+++ b/lib/chai/assertion.js
@@ -83,11 +83,11 @@ Assertion.overwriteMethod = function (name, fn) {
  */
 
 Assertion.prototype.assert = function (expr, msg, negateMsg, expected, _actual) {
-  var msg = util.getMessage(this, arguments)
-    , actual = util.getActual(this, arguments)
-    , ok = util.test(this, arguments);
+  var ok = util.test(this, arguments);
 
   if (!ok) {
+    var msg = util.getMessage(this, arguments)
+      , actual = util.getActual(this, arguments);
     throw new AssertionError({
         message: msg
       , actual: actual

--- a/test/assert.js
+++ b/test/assert.js
@@ -113,6 +113,12 @@ suite('assert', function () {
     err(function () {
       assert.instanceOf(5, Foo);
     }, "expected 5 to be an instance of Foo");
+
+    function CrashyObject() {};
+    CrashyObject.prototype.inspect = function () {
+      throw new Error("Arg's inspect() called even though the test passed");
+    };
+    assert.instanceOf(new CrashyObject(), CrashyObject);
   });
 
   test('notInstanceOf', function () {


### PR DESCRIPTION
I stumbled upon this while trying to assert that an XHR instance is indeed an instance of XHR for a JavaScript API that I'm developing. The inspect() implementation in chai.js throws an error on an in-progress XHR.

Details aside, it seems like it's a good idea to avoid inspect()ing the arguments of an assertion if it passes. I hope you'll consider merging this change.

Thank you so, so much for chai.js! I'm really happy to have expect() and assert() available in browser tests by including one single library!
