### PR TITLE
Added support (and tests) for circular references when checking deep (in)equality.

### DIFF
--- a/lib/chai/utils/eql.js
+++ b/lib/chai/utils/eql.js
@@ -13,7 +13,7 @@ try {
   };
 }
 
-function _deepEqual(actual, expected) {
+function _deepEqual(actual, expected, memos) {
 
   // 7.1. All identical values are equivalent, as determined by ===.
   if (actual === expected) {
@@ -45,7 +45,7 @@ function _deepEqual(actual, expected) {
   // corresponding key, and an identical 'prototype' property. Note: this
   // accounts for both named and indexed properties on Arrays.
   } else {
-    return objEquiv(actual, expected);
+    return objEquiv(actual, expected, memos);
   }
 }
 
@@ -57,11 +57,25 @@ function isArguments(object) {
   return Object.prototype.toString.call(object) == '[object Arguments]';
 }
 
-function objEquiv(a, b) {
+function objEquiv(a, b, memos) {
   if (isUndefinedOrNull(a) || isUndefinedOrNull(b))
     return false;
+
   // an identical 'prototype' property.
   if (a.prototype !== b.prototype) return false;
+
+  // check if we have already compared a and b
+  var i;
+  if (memos) {
+    for(i = 0; i < memos.length; i++) {
+      if ((memos[i][0] === a && memos[i][1] === b) ||
+          (memos[i][0] === b && memos[i][1] === a))
+        return true;
+    }
+  } else {
+    memos = [];
+  }
+
   //~~~I've managed to break Object.keys through screwy arguments passing.
   //   Converting to array solves the problem.
   if (isArguments(a)) {
@@ -70,19 +84,21 @@ function objEquiv(a, b) {
     }
     a = pSlice.call(a);
     b = pSlice.call(b);
-    return _deepEqual(a, b);
+    return _deepEqual(a, b, memos);
   }
   try {
     var ka = Object.keys(a),
         kb = Object.keys(b),
-        key, i;
+        key;
   } catch (e) {//happens when one is a string literal and the other isn't
     return false;
   }
+
   // having the same number of owned properties (keys incorporates
   // hasOwnProperty)
   if (ka.length != kb.length)
     return false;
+
   //the same set of keys (although not necessarily the same order),
   ka.sort();
   kb.sort();
@@ -91,11 +107,16 @@ function objEquiv(a, b) {
     if (ka[i] != kb[i])
       return false;
   }
+
+  // remember objects we have compared to guard against circular references
+  memos.push([ a, b ]);
+
   //equivalent values for every corresponding key, and
   //~~~possibly expensive deep test
   for (i = ka.length - 1; i >= 0; i--) {
     key = ka[i];
-    if (!_deepEqual(a[key], b[key])) return false;
+    if (!_deepEqual(a[key], b[key], memos)) return false;
   }
+
   return true;
 }

--- a/test/assert.js
+++ b/test/assert.js
@@ -189,12 +189,40 @@ suite('assert', function () {
     }, "expected { tea: \'chai\' } to deeply equal { tea: \'black\' }");
   });
 
+  test('deepEqual (circular)', function() {
+    var circularObject = {}
+      , secondCircularObject = {};
+    circularObject.field = circularObject;
+    secondCircularObject.field = secondCircularObject;
+
+    assert.deepEqual(circularObject, secondCircularObject);
+
+    err(function() {
+      secondCircularObject.field2 = secondCircularObject;
+      assert.deepEqual(circularObject, secondCircularObject);
+    }, "expected { field: [Circular] } to deeply equal { Object (field, field2) }");
+  });
+
   test('notDeepEqual', function() {
     assert.notDeepEqual({tea: 'jasmine'}, {tea: 'chai'});
 
     err(function () {
       assert.notDeepEqual({tea: 'chai'}, {tea: 'chai'});
     }, "expected { tea: \'chai\' } to not deeply equal { tea: \'chai\' }");
+  });
+
+  test('notDeepEqual (circular)', function() {
+    var circularObject = {}
+      , secondCircularObject = { tea: 'jasmine' };
+    circularObject.field = circularObject;
+    secondCircularObject.field = secondCircularObject;
+
+    assert.notDeepEqual(circularObject, secondCircularObject);
+
+    err(function() {
+      delete secondCircularObject.tea;
+      assert.notDeepEqual(circularObject, secondCircularObject);
+    }, "expected { field: [Circular] } to not deeply equal { field: [Circular] }");
   });
 
   test('isNull', function() {


### PR DESCRIPTION
I needed this for a project I'm working on, so I've taken a crack at a solution.  This is my first pull request, so please let me know if I'm missing anything.

The implementation is inspired by jasmine's [compareObjects](https://github.com/pivotal/jasmine/blob/master/src/core/Env.js#L171) function: simply marking each object with a (hopefully) unique field (`__chai_was_here__`), and checking against those fields to prevent recursing.

Master spec passes, and some specs have been added (drawn from chaijs/chai#98).
