### PR TITLE
Check for 'actual' type

### DIFF
--- a/lib/chai/utils/getActual.js
+++ b/lib/chai/utils/getActual.js
@@ -15,5 +15,5 @@
 
 module.exports = function (obj, args) {
   var actual = args[4];
-  return 'undefined' !== actual ? actual : obj._obj;
+  return 'undefined' !== typeof actual ? actual : obj._obj;
 };


### PR DESCRIPTION
At least on Node.js actual property isn't correctly populated because of strict string comparison.
