### PR TITLE
Assertions for unexpected values (undefined and NaN)

### DIFF
--- a/lib/chai/core/assertions.js
+++ b/lib/chai/core/assertions.js
@@ -647,7 +647,9 @@ module.exports = function (chai, _) {
         ? _.getPathValue(name, obj)
         : obj[name];
 
-    var wants_undefined_val = arguments.length >= 2 && val === undefined;
+    var wantsUndefinedVal = arguments.length >= 2
+                              && name in Object(obj)
+                              && val === undefined;
 
     var eql = function( a, b ){
       //from underscore:
@@ -666,7 +668,7 @@ module.exports = function (chai, _) {
       }
     } else {
       this.assert(
-          undefined !== value || wants_undefined_val
+          undefined !== value || wantsUndefinedVal
         , 'expected #{this} to have a ' + descriptor + _.inspect(name)
         , 'expected #{this} to not have ' + descriptor + _.inspect(name));
     }

--- a/test/assert.js
+++ b/test/assert.js
@@ -391,9 +391,11 @@ suite('assert', function () {
     var obj = { foo: { bar: 'baz' } };
     var simpleObj = { foo: 'bar' };
     var evilObj   = { gone: undefined, dubious: NaN };
+    var evilObj2 = Object.create(evilObj);
 
     assert.property(obj, 'foo');
     assert.propertyVal(evilObj, 'gone', undefined);
+    assert.propertyVal(evilObj2, 'gone', undefined);
     assert.propertyVal(evilObj, 'dubious', NaN);
     assert.deepProperty(obj, 'foo.bar');
     assert.notProperty(obj, 'baz');
@@ -423,8 +425,13 @@ suite('assert', function () {
     }, "expected { foo: 'bar' } to have a property 'foo' of 'ball', but got 'bar'");
 
     err(function () {
+      assert.propertyVal(evilObj, 'foo', undefined);
+    }, "expected { gone: undefined, dubious: NaN } to have a property 'foo'");
+
+    err(function () {
       assert.deepPropertyVal(obj, 'foo.bar', 'ball');
     }, "expected { foo: { bar: 'baz' } } to have a deep property 'foo.bar' of 'ball', but got 'baz'");
+
 
     err(function () {
       assert.propertyNotVal(simpleObj, 'foo', 'bar');


### PR DESCRIPTION
As I understood the semantics of `assert.propertyVal`,  it should simply check if a given key has a given value associated. But it doesn't behave that way when the value is `undefined` or `NaN`.

That is, the following assertions fail:

``` javascript
assert.propertyVal({evil: undefined}, 'evil', undefined)
assert.propertyVal({camus: NaN}, 'camus', NaN)
```

But they shouldn't. This PR addresses that (or, rather, tries to :) )
