### PR TITLE
Add alias eqls for eql

### DIFF
--- a/lib/chai/core/assertions.js
+++ b/lib/chai/core/assertions.js
@@ -396,12 +396,13 @@ module.exports = function (chai, _) {
    *     expect([ 1, 2, 3 ]).to.eql([ 1, 2, 3 ]);
    *
    * @name eql
+   * @alias eqls
    * @param {Mixed} value
    * @param {String} message _optional_
    * @api public
    */
 
-  Assertion.addMethod('eql', function (obj, msg) {
+  function assertEql(obj, msg) {
     if (msg) flag(this, 'message', msg);
     this.assert(
         _.eql(obj, flag(this, 'object'))
@@ -411,7 +412,10 @@ module.exports = function (chai, _) {
       , this._obj
       , true
     );
-  });
+  }
+
+  Assertion.addMethod('eql', assertEql);
+  Assertion.addMethod('eqls', assertEql);
 
   /**
    * ### .above(value)


### PR DESCRIPTION
Analogous to the `equals` alias for `equal`, `eql` should have an `eqls` alias.
