### PR TITLE
Determine beforehand which properties to exclude

### DIFF
--- a/lib/chai/utils/addChainableMethod.js
+++ b/lib/chai/utils/addChainableMethod.js
@@ -42,6 +42,11 @@ module.exports = function (ctx, name, method, chainingBehavior) {
   if (typeof chainingBehavior !== 'function')
     chainingBehavior = function () { };
 
+  // This method will need to add properties to a function.
+  // However, some Function.prototype methods cannot be overwritten,
+  // and there seems no easy cross-platform way to detect them (@see chaijs/chai/issues/69).
+  var excludeNames = /^(?:length|name|arguments|caller)$/;
+
   Object.defineProperty(ctx, name,
     { get: function () {
         chainingBehavior.call(this);
@@ -54,12 +59,10 @@ module.exports = function (ctx, name, method, chainingBehavior) {
         // Re-enumerate every time to better accomodate plugins.
         var asserterNames = Object.getOwnPropertyNames(ctx);
         asserterNames.forEach(function (asserterName) {
-          var pd = Object.getOwnPropertyDescriptor(ctx, asserterName)
-            , functionProtoPD = Object.getOwnPropertyDescriptor(Function.prototype, asserterName);
-          // Avoid trying to overwrite things that we can't, like `length` and `arguments`.
-          if (functionProtoPD && !functionProtoPD.configurable) return;
-          if (asserterName === 'arguments') return; // @see chaijs/chai/issues/69
-          Object.defineProperty(assert, asserterName, pd);
+          if (!excludeNames.test(asserterName)) {
+            var pd = Object.getOwnPropertyDescriptor(ctx, asserterName);
+            Object.defineProperty(assert, asserterName, pd);
+          }
         });
 
         transferFlags(this, assert);


### PR DESCRIPTION
`addChainableMethod` checks every time if a method belongs to `Function.prototype`.
In this patch, the list of prohibited methods is generated only once.

The following performance test takes 19.1s with the patch instead of 22.6s without:

``` JavaScript
for (var i = 0; i < 100000; i++)
  'x'.should.be.a('string');
```

That's still a lot, but this patch nonetheless helps the performance issue #127.
