### PR TITLE
Fix assertions on functions that throw primitives

### DIFF
--- a/lib/chai/core/assertions.js
+++ b/lib/chai/core/assertions.js
@@ -1052,20 +1052,21 @@ module.exports = function (chai, _) {
         if (!errMsg) return this;
       }
       // next, check message
-      if (err.message && errMsg && errMsg instanceof RegExp) {
+      var message = typeof(err) === 'object' && "message" in err ? err.message : '' + err;
+      if (message && errMsg && errMsg instanceof RegExp) {
         this.assert(
-            errMsg.exec(err.message)
-          , 'expected #{this} to throw error matching ' + errMsg + ' but got ' + _.inspect(err.message)
+            errMsg.exec(message)
+          , 'expected #{this} to throw error matching ' + errMsg + ' but got ' + _.inspect(message)
           , 'expected #{this} to throw error not matching ' + errMsg
         );
         return this;
-      } else if (err.message && errMsg && 'string' === typeof errMsg) {
+      } else if (message && errMsg && 'string' === typeof errMsg) {
         this.assert(
-            ~err.message.indexOf(errMsg)
+            ~message.indexOf(errMsg)
           , 'expected #{this} to throw error including #{exp} but got #{act}'
           , 'expected #{this} to throw error not including #{act}'
           , errMsg
-          , err.message
+          , message
         );
         return this;
       } else {

--- a/test/should.js
+++ b/test/should.js
@@ -492,6 +492,7 @@ suite('should', function() {
 
     var goodFn = function () { 1==1; }
       , badFn = function () { throw new Error('testing'); }
+      , stringErrFn = function () { throw 'testing'; }
       , refErrFn = function () { throw new ReferenceError('hello'); }
       , ickyErrFn = function () { throw new PoorlyConstructedError(); }
       , specificErrFn = function () { throw specificError; };
@@ -503,6 +504,9 @@ suite('should', function() {
     (badFn).should.throw(Error);
     (badFn).should.not.throw(ReferenceError);
     (badFn).should.not.throw(specificError);
+    (stringErrFn).should.throw();
+    (stringErrFn).should.not.throw(ReferenceError);
+    (stringErrFn).should.not.throw(specificError);
     (refErrFn).should.throw();
     (refErrFn).should.throw(ReferenceError);
     (refErrFn).should.throw(Error);
@@ -517,8 +521,14 @@ suite('should', function() {
     (badFn).should.throw(/testing/);
     (badFn).should.throw('testing');
     (badFn).should.not.throw(/hello/);
+    (badFn).should.not.throw('hello');
     (badFn).should.throw(Error, /testing/);
     (badFn).should.throw(Error, 'testing');
+
+    (stringErrFn).should.throw(/testing/);
+    (stringErrFn).should.throw('testing');
+    (stringErrFn).should.not.throw(/hello/);
+    (stringErrFn).should.not.throw('hello');
 
     should.throw(badFn);
     should.throw(refErrFn, ReferenceError);
@@ -559,6 +569,22 @@ suite('should', function() {
     err(function(){
       (badFn).should.not.throw(Error);
     }, "expected [Function] to not throw Error but [Error: testing] was thrown");
+
+    err(function(){
+      (stringErrFn).should.not.throw();
+    }, "expected [Function] to not throw an error but 'testing' was thrown");
+
+    err(function(){
+      (stringErrFn).should.throw(ReferenceError);
+    }, "expected [Function] to throw ReferenceError but 'testing' was thrown");
+
+    err(function(){
+      (stringErrFn).should.throw(specificError);
+    }, "expected [Function] to throw [RangeError: boo] but 'testing' was thrown");
+
+    err(function(){
+      (stringErrFn).should.not.throw('testing');
+    }, "expected [Function] to throw error not including 'testing'");
 
     err(function(){
       (refErrFn).should.not.throw(ReferenceError);


### PR DESCRIPTION
Although [not recommended](http://www.devthought.com/2011/12/22/a-string-is-not-an-error/), JavaScript functions [can throw anything](https://developer.mozilla.org/en-US/docs/JavaScript/Reference/Statements/throw#Description), _i.e.,_ not necessarily an `Error`.

However, Chai does not nicely deal with them. Consider the following snippet of code:

``` JavaScript
(function () { throw "test"; }).should.throw("test");
(function () { throw "test"; }).should.throw("whatever");
(function () { throw "test"; }).should.not.throw("whatever");
```

Currently, line 2 incorrectly doesn't cause an error, but line 3 does:

```
expected [Function] to not throw an error but 'test' was thrown
```

This pull request adds support for primitive errors, correctly resulting in this error for line 2:

```
expected [Function] to throw error including 'whatever' but got 'test'
```
