### PR TITLE
Fix defect #137 assertThrow always passes when message is empty

### DIFF
--- a/lib/chai/core/assertions.js
+++ b/lib/chai/core/assertions.js
@@ -1053,14 +1053,14 @@ module.exports = function (chai, _) {
       }
       // next, check message
       var message = typeof(err) === 'object' && "message" in err ? err.message : '' + err;
-      if (message && errMsg && errMsg instanceof RegExp) {
+      if ((message != null) && errMsg && errMsg instanceof RegExp) {
         this.assert(
             errMsg.exec(message)
           , 'expected #{this} to throw error matching ' + errMsg + ' but got ' + _.inspect(message)
           , 'expected #{this} to throw error not matching ' + errMsg
         );
         return this;
-      } else if (message && errMsg && 'string' === typeof errMsg) {
+      } else if ((message != null) && errMsg && 'string' === typeof errMsg) {
         this.assert(
             ~message.indexOf(errMsg)
           , 'expected #{this} to throw error including #{exp} but got #{act}'

--- a/test/assert.js
+++ b/test/assert.js
@@ -444,6 +444,14 @@ suite('assert', function () {
     err(function () {
       assert.throws(function() {});
      }, "expected [Function] to throw an error");
+
+    err(function () {
+        assert.throws(function() { throw new Error('') }, 'bar');
+    }, "expected [Function] to throw error including 'bar' but got ''");
+
+    err(function () {
+        assert.throws(function() { throw new Error('') }, /bar/);
+    }, "expected [Function] to throw error matching /bar/ but got ''");
   });
 
   test('doesNotThrow', function() {


### PR DESCRIPTION
Add 2 tests cases for Error with empty message is thrown.
And test the message existence by using `message != null` rather than `message`
