### PR TITLE
Restore the `call` and `apply` methods when adding a chainable method

### DIFF
--- a/lib/chai/utils/addChainableMethod.js
+++ b/lib/chai/utils/addChainableMethod.js
@@ -22,6 +22,10 @@ var hasProtoSupport = '__proto__' in Object;
 // and there seems no easy cross-platform way to detect them (@see chaijs/chai/issues/69).
 var excludeNames = /^(?:length|name|arguments|caller)$/;
 
+// Cache `Function` properties
+var call  = Function.prototype.call,
+    apply = Function.prototype.apply;
+
 /**
  * ### addChainableMethod (ctx, name, method, chainingBehavior)
  *
@@ -65,7 +69,11 @@ module.exports = function (ctx, name, method, chainingBehavior) {
 
         // Use `__proto__` if available
         if (hasProtoSupport) {
-          assert.__proto__ = this;
+          // Inherit all properties from the object by replacing the `Function` prototype
+          var prototype = assert.__proto__ = Object.create(this);
+          // Restore the `call` and `apply` methods from `Function`
+          prototype.call = call;
+          prototype.apply = apply;
         }
         // Otherwise, redefine all properties (slow!)
         else {

--- a/test/utilities.js
+++ b/test/utilities.js
@@ -217,6 +217,7 @@ suite('utilities', function () {
           new chai.Assertion(this._obj).to.be.equal('x');
         }
       , function () {
+          this._obj = this._obj || {};
           this._obj.__x = 'X!'
         }
       );
@@ -227,6 +228,14 @@ suite('utilities', function () {
       expect(function () {
         expect("foo").x();
       }).to.throw(_chai.AssertionError);
+
+      // Verify whether the original Function properties are present.
+      // see https://github.com/chaijs/chai/commit/514dd6ce4#commitcomment-2593383
+      var propertyDescriptor = Object.getOwnPropertyDescriptor(chai.Assertion.prototype, "x");
+      expect(propertyDescriptor.get).to.have.property("call", Function.prototype.call);
+      expect(propertyDescriptor.get).to.have.property("apply", Function.prototype.apply);
+      expect(propertyDescriptor.get()).to.have.property("call", Function.prototype.call);
+      expect(propertyDescriptor.get()).to.have.property("apply", Function.prototype.apply);
 
       var obj = {};
       expect(obj).x.to.be.ok;


### PR DESCRIPTION
@domenic [found](https://github.com/chaijs/chai/commit/514dd6ce4#commitcomment-2593383) that properties of `Function.prototype` where not present anymore on chainable methods after [`__proto__` support was added](https://github.com/chaijs/chai/commit/514dd6ce4) to speed things up.

This pull request fixes this. However, I would like to debate first whether it should be added.
Below are my arguments.
### pro
- It makes chai behave identically on all platforms, regardless of the presence of `__proto__`.
- It fixes the bug this caused in chai as promised (domenic/chai-as-promised#18).
### contra
- The bug in chai as promised has already been [fixed](https://github.com/domenic/chai-as-promised/commit/3ebd37257eee3a0a2af3fedc8d96a6634a86e901).
- chai as promised is probably the only plugin affected. _[citation needed]_
- It makes things more complicated.

Note that the associated commit currently only adds `call` and `apply`, and not others such as `length`, `arguments`, `name`, `caller`, `bind`, `toString`. If you think this is necessary, let me know.

Also note that the property case was never broken (<i>i.e.,</i> the assertions on [lines 235 and 236](https://github.com/RubenVerborgh/chai/commit/caf2a151c0a4961dde185f8c7f88484c4899ac4e#L1R235) pass without the modification). Only when the property was called as a method, things didn't go as expected.
