### PR TITLE
Fix deep object comparison between 'true', {}, and []. Fixes #156.

### DIFF
--- a/chai.js
+++ b/chai.js
@@ -3118,6 +3118,12 @@ function _deepEqual(actual, expected, memos) {
   if (actual === expected) {
     return true;
 
+  } else if (typeof actual !== typeof expected) {
+    return false;
+
+  } else if (Object.prototype.toString.call(actual) !== Object.prototype.toString.call(expected)) {
+    return false;
+
   } else if (Buffer.isBuffer(actual) && Buffer.isBuffer(expected)) {
     if (actual.length != expected.length) return false;
 

--- a/lib/chai/utils/eql.js
+++ b/lib/chai/utils/eql.js
@@ -21,6 +21,12 @@ function _deepEqual(actual, expected, memos) {
   if (actual === expected) {
     return true;
 
+  } else if (typeof actual !== typeof expected) {
+    return false;
+
+  } else if (Object.prototype.toString.call(actual) !== Object.prototype.toString.call(expected)) {
+    return false;
+
   } else if (Buffer.isBuffer(actual) && Buffer.isBuffer(expected)) {
     if (actual.length != expected.length) return false;
 

--- a/test/expect.js
+++ b/test/expect.js
@@ -283,6 +283,12 @@ suite('expect', function () {
     expect({ foo: 'bar' }).to.eql({ foo: 'bar' });
     expect(1).to.eql(1);
     expect('4').to.not.eql(4);
+    expect(true).to.not.eql({});
+    expect(true).to.not.eql([]);
+    expect({}).to.not.eql([]);
+    expect([]).to.not.eql({});
+    expect({}).to.eql({});
+    expect([]).to.eql([]);
 
     err(function(){
       expect(4).to.eql(3, 'blah');

--- a/test/should.js
+++ b/test/should.js
@@ -270,6 +270,12 @@ suite('should', function() {
     ({ foo: 'bar' }).should.eql({ foo: 'bar' });
     (1).should.eql(1);
     '4'.should.not.eql(4);
+    true.should.not.eql({});
+    true.should.not.eql([]);
+    ({}).should.not.eql([]);
+    ([]).should.not.eql({});
+    ({}).should.eql({});
+    ([]).should.eql([]);
 
     err(function(){
       (4).should.eql(3, 'blah');


### PR DESCRIPTION
I've made changes to the eql.js file that fixes issue #156. I've also added tests for expect() and should() that validate these changes. All tests pass with node v0.10.5, Chrome 26, and Firefox 20.
