### PR TITLE
Fix documented name for assert interface's isDefined method

### DIFF
--- a/lib/chai/interface/assert.js
+++ b/lib/chai/interface/assert.js
@@ -303,7 +303,7 @@ module.exports = function (chai, util) {
    *     var tea = 'cup of chai';
    *     assert.isDefined(tea, 'tea has been defined');
    *
-   * @name isUndefined
+   * @name isDefined
    * @param {Mixed} value
    * @param {String} message
    * @api public


### PR DESCRIPTION
The assert interface's isDefined method is incorrectly documented with the name isUndefined, which results in two isUndefined menu items in the [documentation](http://chaijs.com/api/assert/). This is a correction for the @name in the inline documentation.
