### PR TITLE
Fix `utils.inspect` with custom object-returning inspect()s.

### DIFF
--- a/lib/chai/utils/inspect.js
+++ b/lib/chai/utils/inspect.js
@@ -65,7 +65,11 @@ function formatValue(ctx, value, recurseTimes) {
       value.inspect !== exports.inspect &&
       // Also filter out any prototype objects using the circular check.
       !(value.constructor && value.constructor.prototype === value)) {
-    return value.inspect(recurseTimes);
+    var ret = value.inspect(recurseTimes);
+    if (typeof ret !== 'string') {
+      ret = formatValue(ctx, ret, recurseTimes);
+    }
+    return ret;
   }
 
   // Primitive types cannot have properties

--- a/test/utilities.js
+++ b/test/utilities.js
@@ -210,6 +210,20 @@ suite('utilities', function () {
     });
   });
 
+  test('inspect with custom object-returning inspect()s', function () {
+    chai.use(function (_chai, _) {
+      var obj = {
+        outer: {
+          inspect: function () {
+            return { foo: 'bar' };
+          }
+        }
+      };
+
+      expect(_.inspect(obj)).to.equal('{ outer: { foo: \'bar\' } }');
+    });
+  });
+
   test('addChainableMethod', function () {
     chai.use(function (_chai, _) {
       _chai.Assertion.addChainableMethod('x',


### PR DESCRIPTION
This code is lifted from the latest node utils.js: https://github.com/joyent/node/blob/896b2aa7074fc886efd7dd0a397d694763cac7ce/lib/util.js#L205-L209

Without it, if an object contains another object whose custom `inspect()` method returns a non-string, `utils.inspect` gets confused and tries to do `nonString.indexOf`.

This fixes domenic/chai-as-promised#32, where Chai as Promised was trying to call `utils.inspect` on an `AssertionError` which contained as its "actual" property a Q promise. Since Q promises have custom `inspect` methods that return objects, not strings, this was triggered.

---

Would love a patch release with this soon :)
