### PR TITLE
Fix to highlight code example

### DIFF
--- a/chai.js
+++ b/chai.js
@@ -1762,11 +1762,11 @@ module.exports = function (chai, _) {
    * Asserts that the target is a superset of `set`,
    * or that the target and `set` have the same members.
    *
-   *    expect([1, 2, 3]).to.include.members([3, 2]);
-   *    expect([1, 2, 3]).to.not.include.members([3, 2, 8]);
+   *     expect([1, 2, 3]).to.include.members([3, 2]);
+   *     expect([1, 2, 3]).to.not.include.members([3, 2, 8]);
    *
-   *    expect([4, 2]).to.have.members([2, 4]);
-   *    expect([5, 2]).to.not.have.members([5, 2, 1]);
+   *     expect([4, 2]).to.have.members([2, 4]);
+   *     expect([5, 2]).to.not.have.members([5, 2, 1]);
    *
    * @name members
    * @param {Array} set

--- a/lib/chai/core/assertions.js
+++ b/lib/chai/core/assertions.js
@@ -1230,11 +1230,11 @@ module.exports = function (chai, _) {
    * Asserts that the target is a superset of `set`,
    * or that the target and `set` have the same members.
    *
-   *    expect([1, 2, 3]).to.include.members([3, 2]);
-   *    expect([1, 2, 3]).to.not.include.members([3, 2, 8]);
+   *     expect([1, 2, 3]).to.include.members([3, 2]);
+   *     expect([1, 2, 3]).to.not.include.members([3, 2, 8]);
    *
-   *    expect([4, 2]).to.have.members([2, 4]);
-   *    expect([5, 2]).to.not.have.members([5, 2, 1]);
+   *     expect([4, 2]).to.have.members([2, 4]);
+   *     expect([5, 2]).to.not.have.members([5, 2, 1]);
    *
    * @name members
    * @param {Array} set


### PR DESCRIPTION
The indent count for code example sould be 4 not 3.

before:
![2013-06-27 18 30 22](https://f.cloud.github.com/assets/290782/715045/add04a1e-df0f-11e2-9d31-04e295b10371.png)

after:
![2013-06-27 18 37 13](https://f.cloud.github.com/assets/290782/715047/b169709c-df0f-11e2-8dc5-2b3f83927d2b.png)
