### PR TITLE
Fill AssertError.extraMessage

### DIFF
--- a/lib/chai/assertion.js
+++ b/lib/chai/assertion.js
@@ -102,11 +102,13 @@ module.exports = function (_chai, util) {
 
     if (!ok) {
       var msg = util.getMessage(this, arguments)
-        , actual = util.getActual(this, arguments);
+        , actual = util.getActual(this, arguments)
+        , extraMessage = flag(this, 'message');
       throw new AssertionError(msg, {
           actual: actual
         , expected: expected
         , showDiff: showDiff
+        , extraMessage: extraMessage
       }, (Assertion.includeStack) ? this.assert : flag(this, 'ssfi'));
     }
   };


### PR DESCRIPTION
Copy the `message` flag to AssertError.extraMessage. This allows test
frameworks like Mocha to preserve extra message in cases where the framework
provides a custom assertion message.
