### PR TITLE
Fix tests failing with .bin/karma: No such file or directory

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
       "component": "*"
     , "coveralls": "2.0.16"
     , "jscoverage": "0.3.7"
-    , "karma": "canary"
+    , "karma": "~0.10.5"
     , "karma-mocha": "*"
     , "karma-sauce-launcher": "git://github.com/embarkmobile/karma-sauce-launcher.git#feature-passfail"
     , "mocha": "1.8.2"


### PR DESCRIPTION
I try to run tests like this:

```
npm install
make test
```

It fails with:

```
==> [Test :: Karma (PhantomJS)]
make: ./node_modules/.bin/karma: No such file or directory
make: *** [test-phantom] Error 1
```

Using `karma` version 0.10.x instead of canary fixes it for me.
