### PR TITLE
Make it possible to run utilities tests with --watch

### DIFF
--- a/test/utilities.js
+++ b/test/utilities.js
@@ -1,6 +1,13 @@
 describe('utilities', function () {
   var expect = chai.expect;
 
+  after(function() {
+    // Some clean-up so we can run tests in a --watch
+    delete chai.Assertion.prototype.eqqqual;
+    delete chai.Assertion.prototype.result;
+    delete chai.Assertion.prototype.doesnotexist;
+  });
+
   it('_obj', function () {
     var foo = 'bar'
       , test = expect(foo);


### PR DESCRIPTION
Hey! I'm starting to play around with possibilities for an `overwriteChainableMethod` utility to address issue #215, and I was trying to run the utilities tests with:

``` bash
mocha --watch --require ./test/bootstrap --reporter spec test/utilities.js
```

But the tests fail if they run more than once because they expect certain methods to not be part of the `Assertion` prototype. Would it be okay for me to add some cleanup in an `after()` block?
