### PR TITLE
add change assertion - enforce a change to a value

### DIFF
--- a/lib/chai/core/assertions.js
+++ b/lib/chai/core/assertions.js
@@ -1267,4 +1267,79 @@ module.exports = function (chai, _) {
         , subset
     );
   });
+
+  /**
+   * ### .change(getValue)
+   *
+   * Asserts that the value returned by `getValue`
+   * changes after the function has run:
+   *
+   *     var x = 0;
+   *     expect(function() { x += 1; }).to.change(function() { return x });
+   *
+   *     expect(function() {}).not.to.change(function() { return x });
+   *
+   * You can pass options to be specific about the changes expected. Use the `from` 
+   * key to enforce a starting value, a `to` key for and ending value, and a
+   * `by` key to enforce a numeric change.
+   *
+   *     expect(function() { x += 1 }).to.change(function() { return x },{by: 1});
+   *     expect(function() { x += 1 }).to.change(function() { return x },{from: x});
+   *     expect(function() { x += 1 }).to.change(function() { return x },{from: x, to: x + 1});
+   *     expect(function() { x += 1 }).to.change(function() { return x },{to: x + 1});
+   *
+   * @name change
+   * @param {Function} changer
+   * @param {Function} getValue
+   * @param {Object} options _optional_
+   * @api public
+   */
+
+  function assertChange (changeWatcher, changeSpec, msg) {
+    if(msg) flag(this, 'message', msg);
+    var body = flag(this, 'object');
+    var negated = flag(this,'negate');
+
+    changeSpec = changeSpec || {}
+    if(changeSpec) new Assertion(changeSpec).is.a('object');
+
+    new Assertion(body, msg).is.a('function');
+    new Assertion(changeWatcher, msg).is.a('function');
+
+    var before = changeWatcher();
+
+    if('by' in changeSpec) {
+      if(typeof changeSpec.by !== 'number' || 
+          (changeSpec.from != null && typeof changeSpec.from !== 'number')) {
+        throw new Error('change "by" assertions only work with numbers specified in "by" and or "from" options');
+      }
+      changeSpec.to = before + changeSpec.by;
+    }
+    if('from' in changeSpec && changeSpec.from !== before) {
+      throw new Error("change 'from' value wasn't equal to " + _.inspect(before));
+    }
+
+    body();
+    var after = changeWatcher();
+
+    if('to' in changeSpec) {
+      this.assert(
+          after === changeSpec.to
+        , 'expected ' + _.inspect(before) + ' to change to ' + _.inspect(changeSpec.to) + ', instead changed to ' + _.inspect(after)
+        , 'didn\'t expect ' + _.inspect(before) + ' to have changed to ' + _.inspect(changeSpec.to)
+      );
+    } else {
+      this.assert(
+          after !== before
+        , 'expected value to have changed from '  + _.inspect(before)
+        , 'expected value to have remained unchanged from ' + _.inspect(before) + ', but changed to ' + _.inspect(after)
+      );
+    }
+
+    return this;
+
+  };
+  Assertion.addMethod('change', assertChange);
+  Assertion.addMethod('changes', assertChange);
+
 };

--- a/lib/chai/interface/assert.js
+++ b/lib/chai/interface/assert.js
@@ -1059,6 +1059,66 @@ module.exports = function (chai, util) {
     new Assertion(superset, msg).to.include.members(subset);
   }
 
+
+  /**
+   * ### .change(getValue)
+   *
+   * Asserts that the value returned by `getValue`
+   * changes after the `affect` function has run:
+   *
+   *     var x = 0;
+   *     assert.change(function() { x += 1; },function() { return x });
+   *
+   * You can pass options to be specific about the changes expected. Use the `from` 
+   * key to enforce a starting value, a `to` key for and ending value, and a
+   * `by` key to enforce a numeric change.
+   *
+   *     assert.change(function() { x += 1 },function() { return x },{by: 1});
+   *     assert.change(function() { x += 1 },function() { return x },{from: x});
+   *     assert.change(function() { x += 1 },function() { return x },{from: x, to: x + 1});
+   *     assert.change(function() { x += 1 },function() { return x },{to: x + 1});
+   *
+   * @name change
+   * @param {Function} affect
+   * @param {Function} getValue
+   * @param {Object} options _optional_
+   * @param {String} message
+   * @api public
+   */
+  assert.change = function (fn, changeWatcher, opts, msg) {
+    if(typeof opts === 'string') {
+      msg = opts;
+      opts = null;
+    }
+    new Assertion(fn, msg).to.change(changeWatcher,opts);
+  };
+
+  /**
+   * ### .change(getValue)
+   *
+   * Asserts that the value returned by `getValue`
+   * doesn't change after the `affect` has run:
+   *
+   *     var x = 0;
+   *     assert.noChange(doesNothing,function() { return x });
+   *     function doesNothing() {}
+   *
+   * @name change
+   * @param {Function} affect
+   * @param {Function} getValue
+   * @param {Object} options _optional_
+   * @param {String} message
+   * @api public
+   */
+
+  assert.noChange = function (fn, changeWatcher, opts, msg) {
+    if(typeof opts === 'string') {
+      msg = opts;
+      opts = null;
+    }
+    new Assertion(fn, msg).not.to.change(changeWatcher,opts);
+  };
+
   /*!
    * Undocumented / untested
    */

--- a/test/assert.js
+++ b/test/assert.js
@@ -633,4 +633,53 @@ describe('assert', function () {
     }, 'expected [ 1, 54 ] to have the same members as [ 6, 1, 54 ]');
   });
 
+
+  
+  it('change', function() {
+    var value = "start";
+
+    t(function() { assert.change(changeValue("end"),getValue); });
+    t(function() { assert.change(changeValue("end"),getValue,{from: "start"}); });
+    t(function() { assert.change(changeValue("end"),getValue,{to: "end"}); });
+
+    value = 10;
+    assert.change(changeValue(15),getValue,{by: 5});
+
+    t(function() { assert.noChange(noop,getValue) });
+    t(function() { assert.noChange(noop,getValue,{from: "start"}) });
+
+    t(function() { assert.noChange(noop,getValue,{to: "whevil"}) });
+   
+    // test examples
+    var x = 0;
+    assert.change(function() { x += 1; },function() { return x });
+ 
+    assert.noChange(function() {},function() { return x });
+ 
+    assert.change(function() { x += 1 },function() { return x },{by: 1});
+    assert.change(function() { x += 1 },function() { return x },{from: x});
+    assert.change(function() { x += 1 },function() { return x },{from: x, to: x + 1});
+    assert.change(function() { x += 1 },function() { return x },{to: x + 1});
+
+    var x = 0;
+    assert.noChange(doesNothing,function() { return x });
+    function doesNothing() {}
+   
+
+    function getValue() {
+      return value;
+    }
+    function changeValue(to) {
+      return function() {
+        value = to;
+      }
+    }
+    function t(testFn) {
+      testFn();
+      value = "start";
+    }
+    function noop() {}
+  });
+
+
 });

--- a/test/expect.js
+++ b/test/expect.js
@@ -773,4 +773,108 @@ describe('expect', function () {
     expect([5, 4]).not.members([5, 4, 2]);
   })
 
+  
+  describe('change assertion enforces changes',function() {
+
+    describe("of any kind",function() {
+      it("by throwing when change doesn't occur",function() {
+        err(function() {
+          var value = "start";
+          expect(function() {}).to.change(function() {
+            return value;
+          });
+        },"expected value to have changed from 'start'");
+      });
+      it("doesn't create false negatives",function() {
+        var value = "start";
+        expect(function() {
+          value = "end";
+        }).to.change(function() {
+          return value;
+        });
+      });
+    });
+
+    describe("from a specific value",function() {
+      it("by throwing when value wasn't correct before",function() {
+        err(function() {
+          expect(function() {}).to.change(function() {
+            return "start";
+          },{from: "fnord"});
+        },"change 'from' value wasn't equal to 'start'");
+      });
+      it("doesn't create false negatives",function() {
+        var value = "start";
+        expect(function() {
+          value = "end";
+        }).to.change(function() {
+          return value;
+        },{from: "start"});
+      });
+    });
+    describe("to a specific value",function() {
+      it("by throwing when value doesn't change to a specific value",function() {
+        err(function() {
+          var value = "start";
+          expect(function() {
+            value = "something else";
+          }).to.change(function() {
+            return value;
+          },{to: "end"});
+        },"expected 'start' to change to 'end', instead changed to 'something else'");
+      });
+      it("doesn't create false negatives",function() {
+        var value = "start";
+        expect(function() {
+          value = "end";
+        }).to.change(function() {
+          return value;
+        },{to: "end"});
+      });
+    });
+    describe("by a specific amount",function() {
+      it("by throwing",function() {
+        err(function() {
+          var value = 10;
+          expect(function() {
+            value = 15;
+          }).to.change(function() {
+            return value;
+          },{by: 10});
+        },"expected 10 to change to 20, instead changed to 15");
+      });
+      it("doesn't create false negatives",function() {
+        var value = 10;
+        expect(function() {
+          value = 20;
+        }).to.change(function() {
+          return value;
+        },{by: 10});
+
+      });
+      it("validates a numeric change",function() {
+        err(function() {
+          expect(noop).to.change(noop,{by: "fnord"});
+        },'change "by" assertions only work with numbers specified in "by" and or "from" options');
+        err(function() {
+          expect(noop).to.change(noop,{by: 5,from:"fnord"});
+        },'change "by" assertions only work with numbers specified in "by" and or "from" options');
+        function noop() {}
+      });
+
+    });
+    it("has working examples",function() {
+      var x = 0;
+      expect(function() { x += 1; }).to.change(function() { return x });
+     
+      expect(function() {}).not.to.change(function() { return x });
+     
+      expect(function() { x += 1 }).to.change(function() { return x },{by: 1});
+      expect(function() { x += 1 }).to.change(function() { return x },{from: x});
+      expect(function() { x += 1 }).to.change(function() { return x },{from: x, to: x + 1});
+      expect(function() { x += 1 }).to.change(function() { return x },{to: x + 1});
+    });
+
+  });
+
 });


### PR DESCRIPTION
Hi - initial pull request to see what people think of a change assertion. It's useful to avoid false positives where a test that previously caused an effect doesn't any longer, but this failure is masked by something else having caused it.

```
addUser();
assert.equal(users.length,1);
```

This is prone to false positives: if we break `addUser()` and merge it into a branch where `users` started with a default user, we'd not get a failing test. With a change assertion we can be more specific about the change we want to see:

```
assert.change(function() { return users.length},addUser,{by: 1});
```

Would avoid this issue. 
