### PR TITLE
Avoid error instantiation if possible on assertThrows (aka assert.throws). Closes #220

### DIFF
--- a/lib/chai/core/assertions.js
+++ b/lib/chai/core/assertions.js
@@ -618,7 +618,7 @@ module.exports = function (chai, _) {
    *
    * Can also be used in conjunction with `length` to
    * assert a length range. The benefit being a
-   * more informative error message than if the lengtht
+   * more informative error message than if the length
    * was supplied directly.
    *
    *     expect('foo').to.have.length.within(2,4);


### PR DESCRIPTION
Given a constructor as function, try to get the error name from its prototype or itself before relying on the old behaviour. Closes #220
