### PR TITLE
return error on throw method to chain on error properties

### DIFF
--- a/lib/chai/core/assertions.js
+++ b/lib/chai/core/assertions.js
@@ -1002,6 +1002,7 @@ module.exports = function (chai, _) {
    * @param {String|RegExp} expected error message
    * @param {String} message _optional_
    * @see https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Error#Error_types
+   * @returns error for chaining (null if no error)
    * @api public
    */
 
@@ -1043,6 +1044,7 @@ module.exports = function (chai, _) {
           , (desiredError instanceof Error ? desiredError.toString() : desiredError)
           , (err instanceof Error ? err.toString() : err)
         );
+        flag(this, 'object', err);
 
         return this;
       }
@@ -1056,7 +1058,10 @@ module.exports = function (chai, _) {
           , (err instanceof Error ? err.toString() : err)
         );
 
-        if (!errMsg) return this;
+        if (!errMsg) {
+          flag(this, 'object', err);
+          return this;
+        }
       }
       // next, check message
       var message = 'object' === _.type(err) && "message" in err
@@ -1071,6 +1076,7 @@ module.exports = function (chai, _) {
           , errMsg
           , message
         );
+        flag(this, 'object', err);
 
         return this;
       } else if ((message != null) && errMsg && 'string' === typeof errMsg) {
@@ -1081,6 +1087,7 @@ module.exports = function (chai, _) {
           , errMsg
           , message
         );
+        flag(this, 'object', err);
 
         return this;
       } else {
@@ -1107,6 +1114,7 @@ module.exports = function (chai, _) {
       , (desiredError instanceof Error ? desiredError.toString() : desiredError)
       , (thrownError instanceof Error ? thrownError.toString() : thrownError)
     );
+    flag(this, 'object', null);
   };
 
   Assertion.addMethod('throw', assertThrows);

--- a/test/expect.js
+++ b/test/expect.js
@@ -575,6 +575,10 @@ describe('expect', function () {
     }, "expected [ 'milk', 'sugar', 'smile' ] to have a length of 4 but got 3");
 
     expect(tea).to.be.a('object').and.have.property('name', 'chai');
+
+    var badFn = function () { throw new Error('testing'); };
+
+    expect(badFn).to.throw(Error).with.property('message', 'testing');
   });
 
   it('throw', function () {


### PR DESCRIPTION
Allow to create that type of assertions:

``` js
expect(fn).to.throw(BadArgumentError).that.have.property('code', 500);
```

by chaining on the error instance, not on the function that throw an error
