### PR TITLE
Avoid error instantiation if possible on assert.throws

### DIFF
--- a/lib/chai/core/assertions.js
+++ b/lib/chai/core/assertions.js
@@ -1026,7 +1026,10 @@ module.exports = function (chai, _) {
       constructor = null;
       errMsg = null;
     } else if (typeof constructor === 'function') {
-      name = (new constructor()).name;
+      name = constructor.prototype.name || constructor.name;
+      if (name === 'Error' && constructor !== Error) {
+        name = (new constructor()).name;
+      }
     } else {
       constructor = null;
     }


### PR DESCRIPTION
Given an error constructor as function, try to get the error name from its prototype or itself before relying on the old behaviour.

Closes #220

Replaces [the old pull](https://github.com/chaijs/chai/pull/221) to avoid useless commits.
