### PR TITLE
Enable should interface attaching to arbitrary root object

### DIFF
--- a/lib/chai/interface/should.js
+++ b/lib/chai/interface/should.js
@@ -7,7 +7,7 @@
 module.exports = function (chai, util) {
   var Assertion = chai.Assertion;
 
-  function loadShould () {
+  function loadShould (where) {
     // explicitly define this method as function as to have it's name to include as `ssfi`
     function shouldGetter() {
       if (this instanceof String || this instanceof Number) {
@@ -32,7 +32,7 @@ module.exports = function (chai, util) {
       });
     }
     // modify Object.prototype to have `should`
-    Object.defineProperty(Object.prototype, 'should', {
+    Object.defineProperty((where || Object).prototype, 'should', {
       set: shouldSetter
       , get: shouldGetter
       , configurable: true


### PR DESCRIPTION
I'm having problems using the `should` interface with [selenium-webdriver](http://code.google.com/p/selenium/wiki/WebDriverJs). I think the problem is that the whole library for some reason runs in its own vm context. Sort of speak it has a parallel object hierarchy, so the `Object` that should attaches to is not the one that all selenium objects (namely promises) inherit.

With this patch should can be attached to an arbitrary object, by calling `chai.should(obj)`. In the selenium use-case the object that did the trick was to do `chai.should(webdriver.promise.Promise)`, because all promises inherit from this one. I'm also using [chai-as-promised](https://github.com/domenic/chai-as-promised), but that is unrelated.

To check the selenium code go to the `_base.js` file inside the selenium-webdriver node package (I couldn't find a replica of that in a repository posted online, the official [webdriver repo](https://code.google.com/p/selenium/source/browse/) has nothing to do with the published tree...).