### PR TITLE
Show diff for keys assertion

### DIFF
--- a/lib/chai/core/assertions.js
+++ b/lib/chai/core/assertions.js
@@ -950,6 +950,7 @@ module.exports = function (chai, _) {
     if (!keys.length) throw new Error('keys required');
 
     var actual = Object.keys(obj)
+      , expected = keys
       , len = keys.length;
 
     // Inclusion
@@ -984,6 +985,9 @@ module.exports = function (chai, _) {
         ok
       , 'expected #{this} to ' + str
       , 'expected #{this} to not ' + str
+      , expected.sort()
+      , actual.sort()
+      , true
     );
   }
 


### PR DESCRIPTION
Use the show diff feature when the `keys` assertion fails.

Currently, when a `keys` assertion fails, the output looks like 

```
AssertionError: expected { Object (id, name, ...) } to have keys 'name', and 'id'
```

That statement makes it impossible to see which keys the source object should or should not have.  In this case, Object has more keys than expected, but I don't know what they are.

With this pull request, the output of that same assertion looks like this:

```
  AssertionError: expected { Object (id, name, ...) } to have keys 'name', and 'id'
  + expected - actual

   [
     "id",
  +  "name"
  -  "name",
  -  "parent_id",
  -  "type_id"
   ]
```

Now I can see that the `parent_id` and `type_id` keys are in the source but shouldn't be.

On lines 988 and 989, the reason for the .sort() call is to make the diff look nicer.  Without it, the keys could be in any order and the diff would just show all the keys for both expected and actual.

All mocha tests pass.
