### PR TITLE
Allow messages to be functions

### DIFF
--- a/lib/chai/assertion.js
+++ b/lib/chai/assertion.js
@@ -88,8 +88,8 @@ module.exports = function (_chai, util) {
    *
    * @name assert
    * @param {Philosophical} expression to be tested
-   * @param {String} message to display if fails
-   * @param {String} negatedMessage to display if negated expression fails
+   * @param {String or Function} message or function that returns message to display if fails
+   * @param {String or Function} negatedMessage or function that returns negatedMessage to display if negated expression fails
    * @param {Mixed} expected value (remember to check for negation)
    * @param {Mixed} actual (optional) will default to `this.obj`
    * @api private

--- a/lib/chai/utils/getMessage.js
+++ b/lib/chai/utils/getMessage.js
@@ -39,6 +39,7 @@ module.exports = function (obj, args) {
     , msg = negate ? args[2] : args[1]
     , flagMsg = flag(obj, 'message');
 
+  if(typeof msg === "function") msg = msg();
   msg = msg || '';
   msg = msg
     .replace(/#{this}/g, objDisplay(val))

--- a/test/assert.js
+++ b/test/assert.js
@@ -8,6 +8,10 @@ describe('assert', function () {
     err(function () {
       assert(foo == 'baz', "expected foo to equal `bar`");
     }, "expected foo to equal `bar`");
+
+    err(function () {
+      assert(foo == 'baz', function() { return "expected foo to equal `bar`"; });
+    }, "expected foo to equal `bar`");
   });
 
   it('fail', function () {

--- a/test/utilities.js
+++ b/test/utilities.js
@@ -215,6 +215,13 @@ describe('utilities', function () {
       var obj = {};
       _.flag(obj, 'message', 'foo');
       expect(_.getMessage(obj, [])).to.contain('foo');
+
+      var obj = {};
+      msg = function() { return "expected a to eql b"; }
+      negateMsg = function() { return "expected a not to eql b"; }
+      expect(_.getMessage(obj, [null, msg, negateMsg])).to.equal("expected a to eql b");
+      _.flag(obj, 'negate', true);
+      expect(_.getMessage(obj, [null, msg, negateMsg])).to.equal("expected a not to eql b");
     });
   });
 


### PR DESCRIPTION
Useful for sinon-chai where the messages passed into assertions messages enumerate calls / arguments to the spy and shouldn't have to unless the assertion actually fails. 
See domenic/sinon-chai#30 and domenic/sinon-chai#38
