### PR TITLE
fix: closeTo should check value's type before assertion

### DIFF
--- a/lib/chai/core/assertions.js
+++ b/lib/chai/core/assertions.js
@@ -1249,6 +1249,12 @@ module.exports = function (chai, _) {
   Assertion.addMethod('closeTo', function (expected, delta, msg) {
     if (msg) flag(this, 'message', msg);
     var obj = flag(this, 'object');
+
+    new Assertion(obj, msg).is.a('number');
+    if (_.type(expected) !== 'number' || _.type(delta) !== 'number') {
+      throw new Error('the arguments to closeTo must be numbers');
+    }
+
     this.assert(
         Math.abs(obj - expected) <= delta
       , 'expected #{this} to be close to ' + expected + ' +/- ' + delta

--- a/test/assert.js
+++ b/test/assert.js
@@ -605,6 +605,18 @@ describe('assert', function () {
     err(function(){
       assert.closeTo(-10, 20, 29);
     }, "expected -10 to be close to 20 +/- 29");
+
+    err(function() {
+      assert.closeTo([1.5], 1.0, 0.5);
+    }, "expected [ 1.5 ] to be a number");
+
+    err(function() {
+      assert.closeTo(1.5, "1.0", 0.5);
+    }, "the arguments to closeTo must be numbers");
+
+    err(function() {
+      assert.closeTo(1.5, 1.0, true);
+    }, "the arguments to closeTo must be numbers");
   });
 
   it('members', function() {

--- a/test/expect.js
+++ b/test/expect.js
@@ -777,6 +777,18 @@ describe('expect', function () {
     err(function(){
       expect(-10).to.be.closeTo(20, 29, 'blah');
     }, "blah: expected -10 to be close to 20 +/- 29");
+
+    err(function() {
+      expect([1.5]).to.be.closeTo(1.0, 0.5);
+    }, "expected [ 1.5 ] to be a number");
+
+    err(function() {
+      expect(1.5).to.be.closeTo("1.0", 0.5);
+    }, "the arguments to closeTo must be numbers");
+
+    err(function() {
+      expect(1.5).to.be.closeTo(1.0, true);
+    }, "the arguments to closeTo must be numbers");
   });
 
   it('include.members', function() {

--- a/test/should.js
+++ b/test/should.js
@@ -701,6 +701,18 @@ describe('should', function() {
     err(function(){
       (2).should.be.closeTo(1.0, 0.5, 'blah');
     }, "blah: expected 2 to be close to 1 +/- 0.5");
+
+    err(function() {
+      [1.5].should.be.closeTo(1.0, 0.5);
+    }, "expected [ 1.5 ] to be a number");
+
+    err(function() {
+      (1.5).should.be.closeTo("1.0", 0.5);
+    }, "the arguments to closeTo must be numbers");
+
+    err(function() {
+      (1.5).should.be.closeTo(1.0, true);
+    }, "the arguments to closeTo must be numbers");
   });
 
   it('include.members', function() {


### PR DESCRIPTION
`Assertion#closeTo` passes tests that should be failed.

e.g.

``` javascript
expect([1.5]).to.be.closeTo(1.0, 0.5); // PASS???
expect(1.5).to.be.closeTo("1.0", 0.5); // PASS???
```

so, I fixed it.

``` javascript
expect([1.5]).to.be.closeTo(1.0, 0.5); // throw "expected [ 1.5 ] to be a number"
expect(1.5).to.be.closeTo("1.0", 0.5); // throw "expected '1.0' to be a number"
```
