### PR TITLE
resolves #255: upgrade mocha

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     , "karma-mocha": "*"
     , "karma-sauce-launcher": "0.2.x"
     , "karma-phantomjs-launcher": "0.1.1"
-    , "mocha": "1.17.x"
+    , "mocha": "1.21.x"
     , "istanbul": "0.2.x"
   }
 }

--- a/test/bootstrap/karma.js
+++ b/test/bootstrap/karma.js
@@ -2,13 +2,13 @@
  * Attach chai to global
  */
 
-global.chai = require('chai');
+window.chai = require('chai');
 
 /*!
  * Provide check for fail function.
  */
 
-global.err = function (fn, msg) {
+window.err = function (fn, msg) {
   try {
     fn();
     throw new chai.AssertionError('Expected an error');


### PR DESCRIPTION
Because of conflicts with node-webkit, we removed the global `global` object in v1.21.1.

Change to `test/bootstrap/karma.js` makes the tests pass.
