### PR TITLE
Issue #305 fixed, added assert.isAbove and assert.isBelow

### DIFF
--- a/lib/chai/interface/assert.js
+++ b/lib/chai/interface/assert.js
@@ -237,6 +237,42 @@ module.exports = function (chai, util) {
    * @api public
    */
 
+  assert.isAbove = function (val, abv, msg) {
+    new Assertion(val, msg).to.be.above(abv);
+  };
+
+   /**
+   * ### .isAbove(valueToCheck, valueToBeAbove, [message])
+   *
+   * Asserts `valueToCheck` is strictly greater than (>) `valueToBeAbove`
+   *
+   *     assert.isAbove(5, 2, '5 is strictly greater than 2');
+   *
+   * @name isAbove
+   * @param {Mixed} valueToCheck
+   * @param {Mixed} valueToBeAbove
+   * @param {String} message
+   * @api public
+   */
+
+  assert.isBelow = function (val, blw, msg) {
+    new Assertion(val, msg).to.be.below(blw);
+  };
+
+   /**
+   * ### .isBelow(valueToCheck, valueToBeBelow, [message])
+   *
+   * Asserts `valueToCheck` is strictly less than (<) `valueToBeBelow`
+   *
+   *     assert.isBelow(3, 6, '3 is strictly less than 6');
+   *
+   * @name isBelow
+   * @param {Mixed} valueToCheck
+   * @param {Mixed} valueToBeBelow
+   * @param {String} message
+   * @api public
+   */
+
   assert.isTrue = function (val, msg) {
     new Assertion(val, msg).is['true'];
   };

--- a/test/assert.js
+++ b/test/assert.js
@@ -651,4 +651,28 @@ describe('assert', function () {
     }, 'expected [ 1, 54 ] to have the same members as [ 6, 1, 54 ]');
   });
 
+  it('above', function() {
+    assert.isAbove(5, 2, '5 should be above 2');
+
+    err(function() {
+      assert.isAbove(1, 3);
+    }, 'expected 1 to be above 3');
+
+    err(function() {
+      assert.isAbove(1, 1);
+    }, 'expected 1 to be above 1');
+  });
+
+  it('below', function() {
+    assert.isBelow(2, 5, '2 should be below 5');
+
+    err(function() {
+      assert.isBelow(3, 1);
+    }, 'expected 3 to be below 1');
+
+    err(function() {
+      assert.isBelow(1, 1);
+    }, 'expected 1 to be below 1');
+  });
+
 });


### PR DESCRIPTION
I believe this fixes #305 , and adds the `isAbove` and `isBelow` functions on assert. All the tests ran fine for me on my machine, let me know if I messed anything (like public api comments) up or if something doesn't look right.

Thanks!
