### PR TITLE
Fix docs for overwriteChainableMethod parameters

### DIFF
--- a/lib/chai/utils/overwriteChainableMethod.js
+++ b/lib/chai/utils/overwriteChainableMethod.js
@@ -5,7 +5,7 @@
  */
 
 /**
- * ### overwriteChainableMethod (ctx, name, fn)
+ * ### overwriteChainableMethod (ctx, name, method, chainingBehavior)
  *
  * Overwites an already existing chainable method
  * and provides access to the previous function or


### PR DESCRIPTION
Fixes #320 - method signature docs for overwriteChainableMethod (brought up in https://github.com/chaijs/chai/issues/320).
