### PR TITLE
Added `change`, `increase` and `decrease` assertions with `by` chain (#330)

### DIFF
--- a/lib/chai/core/assertions.js
+++ b/lib/chai/core/assertions.js
@@ -1451,7 +1451,6 @@ module.exports = function (chai, _) {
    *     var obj = { val: 10 };
    *     var fn = function() { obj.val = 15 };
    *     expect(fn).to.increase(obj, 'val');
-   *     expect(fn).to.increase(obj, 'val').by(5);
    *
    * @name increase
    * @alias increases
@@ -1489,7 +1488,6 @@ module.exports = function (chai, _) {
    *     var obj = { val: 10 };
    *     var fn = function() { obj.val = 5 };
    *     expect(fn).to.decrease(obj, 'val');
-   *     expect(fn).to.decrease(obj, 'val').by(5);
    *
    * @name decrease
    * @alias decreases

--- a/lib/chai/core/assertions.js
+++ b/lib/chai/core/assertions.js
@@ -1403,4 +1403,143 @@ module.exports = function (chai, _) {
         , subset
     );
   });
+
+  /**
+   * ### .change(function)
+   *
+   * Asserts that a function changes an object property
+   *
+   *     var obj = { val: 10 };
+   *     var fn = function() { obj.val = 10 };
+   *     var noChangeFn = function() { return 'foo' + 'bar'; }
+   *     expect(fn).to.change(obj, 'val');
+   *     expect(noChangFn).to.not.change(obj, 'val')
+   *
+   * @name change
+   * @alias changes
+   * @alias Change
+   * @param {String} object
+   * @param {String} property name
+   * @param {String} message _optional_
+   * @api public
+   */
+
+  function assertChanges (object, prop, msg) {
+    if (msg) flag(this, 'message', msg);
+    var fn = flag(this, 'object');
+    new Assertion(object, msg).to.have.property(prop);
+
+    var initial = object[prop];
+    fn();
+    var delta = object[prop] - initial;
+    flag(this, 'delta', delta);
+    flag(this, 'property', prop);
+
+    this.assert(
+      delta != 0
+      , 'expected .' + prop + ' to change'
+      , 'expected .' + prop + ' to not change'
+    );
+  }
+
+  Assertion.addChainableMethod('change', assertChanges);
+  Assertion.addChainableMethod('changes', assertChanges);
+  Assertion.addChainableMethod('Change', assertChanges);
+
+  /**
+   * ### .increase(function)
+   *
+   * Asserts that a function increases an object property
+   *
+   *     var obj = { val: 10 };
+   *     var fn = function() { obj.val = 15 };
+   *     expect(fn).to.increase(obj, 'val');
+   *     expect(fn).to.increase(obj, 'val').by(5);
+   *
+   * @name increase
+   * @alias increases
+   * @alias Increase
+   * @param {String} object
+   * @param {String} property name
+   * @param {String} message _optional_
+   * @api public
+   */
+
+  function assertIncreases (object, prop, msg) {
+    if (msg) flag(this, 'message', msg);
+    var fn = flag(this, 'object');
+    new Assertion(object, msg).to.have.property(prop);
+
+    var initial = object[prop];
+    fn();
+    var delta = object[prop] - initial;
+    flag(this, 'delta', delta);
+    flag(this, 'property', prop);
+
+    this.assert(
+      delta > 0
+      , 'expected .' + prop + ' to increase'
+      , 'expected .' + prop + ' to not increase'
+    );
+  }
+
+  Assertion.addChainableMethod('increase', assertIncreases);
+  Assertion.addChainableMethod('increases', assertIncreases);
+  Assertion.addChainableMethod('Increase', assertIncreases);
+
+  /**
+   * ### .decrease(function)
+   *
+   * Asserts that a function decreases an object property
+   *
+   *     var obj = { val: 10 };
+   *     var fn = function() { obj.val = 5 };
+   *     expect(fn).to.decrease(obj, 'val');
+   *     expect(fn).to.decrease(obj, 'val').by(5);
+   *
+   * @name decrease
+   * @alias decreases
+   * @alias Decrease
+   * @param {String} object
+   * @param {String} property name
+   * @param {String} message _optional_
+   * @api public
+   */
+
+  function assertDecreases (object, prop, msg) {
+    if (msg) flag(this, 'message', msg);
+    var fn = flag(this, 'object');
+    new Assertion(object, msg).to.have.property(prop);
+
+    var initial = object[prop];
+    fn();
+    var delta = object[prop] - initial;
+    flag(this, 'delta', -delta);
+    flag(this, 'property', prop);
+
+    this.assert(
+      delta < 0
+      , 'expected .' + prop + ' to decrease'
+      , 'expected .' + prop + ' to not decrease'
+    );
+  }
+
+  Assertion.addChainableMethod('decrease', assertDecreases);
+  Assertion.addChainableMethod('decreases', assertDecreases);
+  Assertion.addChainableMethod('Decrease', assertDecreases);
+
+  function assertChangesBy (expected, msg) {
+    if (msg) flag(this, 'message', msg);
+    var obj   = flag(this, 'object'),
+        prop  = flag(this, 'property'),
+        delta = flag(this, 'delta');
+
+    this.assert(
+      delta === expected
+      , 'expected .' + prop + ' to change by ' + expected
+      , 'expected .' + prop + ' to not change by ' + expected
+    );
+  }
+
+  Assertion.addMethod('by', assertChangesBy);
 };

--- a/lib/chai/core/assertions.js
+++ b/lib/chai/core/assertions.js
@@ -1428,15 +1428,18 @@ module.exports = function (chai, _) {
     if (msg) flag(this, 'message', msg);
     var fn = flag(this, 'object');
     new Assertion(object, msg).to.have.property(prop);
+    new Assertion(fn).is.a('function');
+    flag(this, 'property', prop);
 
     var initial = object[prop];
     fn();
-    var delta = object[prop] - initial;
-    flag(this, 'delta', delta);
-    flag(this, 'property', prop);
+
+    if ('number' == typeof initial) {
+      flag(this, 'delta', object[prop] - initial);
+    }
 
     this.assert(
-      delta != 0
+      initial !== object[prop]
       , 'expected .' + prop + ' to change'
       , 'expected .' + prop + ' to not change'
     );
@@ -1469,6 +1472,7 @@ module.exports = function (chai, _) {
     if (msg) flag(this, 'message', msg);
     var fn = flag(this, 'object');
     new Assertion(object, msg).to.have.property(prop);
+    new Assertion(fn).is.a('function');
 
     var initial = object[prop];
     fn();
@@ -1510,6 +1514,7 @@ module.exports = function (chai, _) {
     if (msg) flag(this, 'message', msg);
     var fn = flag(this, 'object');
     new Assertion(object, msg).to.have.property(prop);
+    new Assertion(fn).is.a('function');
 
     var initial = object[prop];
     fn();

--- a/lib/chai/core/assertions.js
+++ b/lib/chai/core/assertions.js
@@ -1429,14 +1429,9 @@ module.exports = function (chai, _) {
     var fn = flag(this, 'object');
     new Assertion(object, msg).to.have.property(prop);
     new Assertion(fn).is.a('function');
-    flag(this, 'property', prop);
 
     var initial = object[prop];
     fn();
-
-    if ('number' == typeof initial) {
-      flag(this, 'delta', object[prop] - initial);
-    }
 
     this.assert(
       initial !== object[prop]
@@ -1475,12 +1470,9 @@ module.exports = function (chai, _) {
 
     var initial = object[prop];
     fn();
-    var delta = object[prop] - initial;
-    flag(this, 'delta', delta);
-    flag(this, 'property', prop);
 
     this.assert(
-      delta > 0
+      object[prop] - initial > 0
       , 'expected .' + prop + ' to increase'
       , 'expected .' + prop + ' to not increase'
     );
@@ -1516,12 +1508,9 @@ module.exports = function (chai, _) {
 
     var initial = object[prop];
     fn();
-    var delta = object[prop] - initial;
-    flag(this, 'delta', -delta);
-    flag(this, 'property', prop);
 
     this.assert(
-      delta < 0
+      object[prop] - initial < 0
       , 'expected .' + prop + ' to decrease'
       , 'expected .' + prop + ' to not decrease'
     );
@@ -1530,18 +1519,4 @@ module.exports = function (chai, _) {
   Assertion.addChainableMethod('decrease', assertDecreases);
   Assertion.addChainableMethod('decreases', assertDecreases);
 
-  function assertChangesBy (expected, msg) {
-    if (msg) flag(this, 'message', msg);
-    var obj   = flag(this, 'object'),
-        prop  = flag(this, 'property'),
-        delta = flag(this, 'delta');
-
-    this.assert(
-      delta === expected
-      , 'expected .' + prop + ' to change by ' + expected
-      , 'expected .' + prop + ' to not change by ' + expected
-    );
-  }
-
-  Assertion.addMethod('by', assertChangesBy);
 };

--- a/lib/chai/core/assertions.js
+++ b/lib/chai/core/assertions.js
@@ -1410,7 +1410,7 @@ module.exports = function (chai, _) {
    * Asserts that a function changes an object property
    *
    *     var obj = { val: 10 };
-   *     var fn = function() { obj.val = 10 };
+   *     var fn = function() { obj.val += 3 };
    *     var noChangeFn = function() { return 'foo' + 'bar'; }
    *     expect(fn).to.change(obj, 'val');
    *     expect(noChangFn).to.not.change(obj, 'val')
@@ -1447,7 +1447,6 @@ module.exports = function (chai, _) {
 
   Assertion.addChainableMethod('change', assertChanges);
   Assertion.addChainableMethod('changes', assertChanges);
-  Assertion.addChainableMethod('Change', assertChanges);
 
   /**
    * ### .increase(function)
@@ -1489,7 +1488,6 @@ module.exports = function (chai, _) {
 
   Assertion.addChainableMethod('increase', assertIncreases);
   Assertion.addChainableMethod('increases', assertIncreases);
-  Assertion.addChainableMethod('Increase', assertIncreases);
 
   /**
    * ### .decrease(function)
@@ -1531,7 +1529,6 @@ module.exports = function (chai, _) {
 
   Assertion.addChainableMethod('decrease', assertDecreases);
   Assertion.addChainableMethod('decreases', assertDecreases);
-  Assertion.addChainableMethod('Decrease', assertDecreases);
 
   function assertChangesBy (expected, msg) {
     if (msg) flag(this, 'message', msg);

--- a/lib/chai/interface/assert.js
+++ b/lib/chai/interface/assert.js
@@ -1175,28 +1175,6 @@ module.exports = function (chai, util) {
   }
 
    /**
-   * ### .increasesBy(function, object, property, amount)
-   *
-   * Asserts that a function increases an object property by `amount`
-   *
-   *     var obj = { val: 10 };
-   *     var fn = function() { obj.val = 13 };
-   *     assert.increasesBy(fn, obj, 'val', 3);
-   *
-   * @name increasesBy
-   * @param {Function} modifier function
-   * @param {Object} object
-   * @param {String} property name
-   * @param {Number} amount to increase by
-   * @param {String} message _optional_
-   * @api public
-   */
-
-  assert.increasesBy = function (fn, obj, prop, amount) {
-    new Assertion(fn).to.increase(obj, prop).by(amount);
-  }
-
-   /**
    * ### .decreases(function, object, property)
    *
    * Asserts that a function decreases an object property
@@ -1236,28 +1214,6 @@ module.exports = function (chai, util) {
 
   assert.doesNotDecrease = function (fn, obj, prop) {
     new Assertion(fn).to.not.decrease(obj, prop);
-  }
-
-   /**
-   * ### .decreasesBy(function, object, property, amount)
-   *
-   * Asserts that a function decreases an object property by `amount`
-   *
-   *     var obj = { val: 10 };
-   *     var fn = function() { obj.val = 5 };
-   *     assert.decreasesBy(fn, obj, 'val', 5);
-   *
-   * @name decreasesBy
-   * @param {Function} modifier function
-   * @param {Object} object
-   * @param {String} property name
-   * @param {Number} amount to decrease by
-   * @param {String} message _optional_
-   * @api public
-   */
-
-  assert.decreasesBy = function (fn, obj, prop, amount) {
-    new Assertion(fn).to.decrease(obj, prop).by(amount);
   }
 
   /*!

--- a/lib/chai/interface/assert.js
+++ b/lib/chai/interface/assert.js
@@ -1090,6 +1090,176 @@ module.exports = function (chai, util) {
     new Assertion(superset, msg).to.include.members(subset);
   }
 
+   /**
+   * ### .changes(function, object, property)
+   *
+   * Asserts that a function changes the value of a property
+   *
+   *     var obj = { val: 10 };
+   *     var fn = function() { obj.val = 22 };
+   *     assert.changes(fn, obj, 'val');
+   *
+   * @name changes
+   * @param {Function} modifier function
+   * @param {Object} object
+   * @param {String} property name
+   * @param {String} message _optional_
+   * @api public
+   */
+
+  assert.changes = function (fn, obj, prop) {
+    new Assertion(fn).to.change(obj, prop);
+  }
+
+   /**
+   * ### .doesNotChange(function, object, property)
+   *
+   * Asserts that a function does not changes the value of a property
+   *
+   *     var obj = { val: 10 };
+   *     var fn = function() { console.log('foo'); };
+   *     assert.doesNotChange(fn, obj, 'val');
+   *
+   * @name doesNotChange
+   * @param {Function} modifier function
+   * @param {Object} object
+   * @param {String} property name
+   * @param {String} message _optional_
+   * @api public
+   */
+
+  assert.doesNotChange = function (fn, obj, prop) {
+    new Assertion(fn).to.not.change(obj, prop);
+  }
+
+   /**
+   * ### .increases(function, object, property)
+   *
+   * Asserts that a function increases an object property
+   *
+   *     var obj = { val: 10 };
+   *     var fn = function() { obj.val = 13 };
+   *     assert.increases(fn, obj, 'val');
+   *
+   * @name increases
+   * @param {Function} modifier function
+   * @param {Object} object
+   * @param {String} property name
+   * @param {String} message _optional_
+   * @api public
+   */
+
+  assert.increases = function (fn, obj, prop) {
+    new Assertion(fn).to.increase(obj, prop);
+  }
+
+   /**
+   * ### .doesNotIncrease(function, object, property)
+   *
+   * Asserts that a function does not increase object property
+   *
+   *     var obj = { val: 10 };
+   *     var fn = function() { obj.val = 8 };
+   *     assert.doesNotIncrease(fn, obj, 'val');
+   *
+   * @name doesNotIncrease
+   * @param {Function} modifier function
+   * @param {Object} object
+   * @param {String} property name
+   * @param {String} message _optional_
+   * @api public
+   */
+
+  assert.doesNotIncrease = function (fn, obj, prop) {
+    new Assertion(fn).to.not.increase(obj, prop);
+  }
+
+   /**
+   * ### .increasesBy(function, object, property, amount)
+   *
+   * Asserts that a function increases an object property by `amount`
+   *
+   *     var obj = { val: 10 };
+   *     var fn = function() { obj.val = 13 };
+   *     assert.increasesBy(fn, obj, 'val', 3);
+   *
+   * @name increasesBy
+   * @param {Function} modifier function
+   * @param {Object} object
+   * @param {String} property name
+   * @param {Number} amount to increase by
+   * @param {String} message _optional_
+   * @api public
+   */
+
+  assert.increasesBy = function (fn, obj, prop, amount) {
+    new Assertion(fn).to.increase(obj, prop).by(amount);
+  }
+
+   /**
+   * ### .decreases(function, object, property)
+   *
+   * Asserts that a function decreases an object property
+   *
+   *     var obj = { val: 10 };
+   *     var fn = function() { obj.val = 5 };
+   *     assert.decreases(fn, obj, 'val');
+   *
+   * @name decreases
+   * @param {Function} modifier function
+   * @param {Object} object
+   * @param {String} property name
+   * @param {String} message _optional_
+   * @api public
+   */
+
+  assert.decreases = function (fn, obj, prop) {
+    new Assertion(fn).to.decrease(obj, prop);
+  }
+
+   /**
+   * ### .doesNotDecrease(function, object, property)
+   *
+   * Asserts that a function does not decreases an object property
+   *
+   *     var obj = { val: 10 };
+   *     var fn = function() { obj.val = 15 };
+   *     assert.doesNotDecrease(fn, obj, 'val');
+   *
+   * @name doesNotDecrease
+   * @param {Function} modifier function
+   * @param {Object} object
+   * @param {String} property name
+   * @param {String} message _optional_
+   * @api public
+   */
+
+  assert.doesNotDecrease = function (fn, obj, prop) {
+    new Assertion(fn).to.not.decrease(obj, prop);
+  }
+
+   /**
+   * ### .decreasesBy(function, object, property, amount)
+   *
+   * Asserts that a function decreases an object property by `amount`
+   *
+   *     var obj = { val: 10 };
+   *     var fn = function() { obj.val = 5 };
+   *     assert.decreasesBy(fn, obj, 'val', 5);
+   *
+   * @name decreasesBy
+   * @param {Function} modifier function
+   * @param {Object} object
+   * @param {String} property name
+   * @param {Number} amount to decrease by
+   * @param {String} message _optional_
+   * @api public
+   */
+
+  assert.decreasesBy = function (fn, obj, prop, amount) {
+    new Assertion(fn).to.decrease(obj, prop).by(amount);
+  }
+
   /*!
    * Undocumented / untested
    */

--- a/test/assert.js
+++ b/test/assert.js
@@ -689,4 +689,28 @@ describe('assert', function () {
     }, 'expected [ { b: 3 } ] to have the same members as [ { b: 5 } ]');
   });
 
+  it('change', function() {
+    var obj = { value: 10 },
+        fn = function() { obj.value += 5 },
+        smFn = function() { 'foo' + 'bar' };
+
+    assert.changes(fn, obj, 'value');
+    assert.doesNotChange(smFn, obj, 'value');
+  });
+
+  it('increase, decrease', function() {
+    var obj = { value: 10 },
+        incFn = function() { obj.value += 2 },
+        decFn = function() { obj.value -= 3 },
+        smFn  = function() { obj.value += 0 };
+
+    assert.decreases(decFn, obj, 'value');
+    assert.decreasesBy(decFn, obj, 'value', 3);
+    assert.doesNotDecrease(smFn, obj, 'value');
+
+    assert.increases(incFn, obj, 'value');
+    assert.increasesBy(incFn, obj, 'value', 2);
+    assert.doesNotIncrease(smFn, obj, 'value');
+  });
+
 });

--- a/test/assert.js
+++ b/test/assert.js
@@ -690,12 +690,14 @@ describe('assert', function () {
   });
 
   it('change', function() {
-    var obj = { value: 10 },
-        fn = function() { obj.value += 5 },
-        smFn = function() { 'foo' + 'bar' };
+    var obj = { value: 10, str: 'foo' },
+        fn     = function() { obj.value += 5 },
+        bangFn = function() { obj.str += '!' },
+        smFn   = function() { 'foo' + 'bar' };
 
     assert.changes(fn, obj, 'value');
     assert.doesNotChange(smFn, obj, 'value');
+    assert.changes(bangFn, obj, 'str');
   });
 
   it('increase, decrease', function() {

--- a/test/assert.js
+++ b/test/assert.js
@@ -707,11 +707,9 @@ describe('assert', function () {
         smFn  = function() { obj.value += 0 };
 
     assert.decreases(decFn, obj, 'value');
-    assert.decreasesBy(decFn, obj, 'value', 3);
     assert.doesNotDecrease(smFn, obj, 'value');
 
     assert.increases(incFn, obj, 'value');
-    assert.increasesBy(incFn, obj, 'value', 2);
     assert.doesNotIncrease(smFn, obj, 'value');
   });
 

--- a/test/expect.js
+++ b/test/expect.js
@@ -901,13 +901,16 @@ describe('expect', function () {
   });
 
   it('change', function() {
-    var obj = { value: 10 },
-        fn = function() { obj.value += 5 },
-        sameFn = function() { 'foo' + 'bar' };
+    var obj = { value: 10, str: 'foo' },
+        fn     = function() { obj.value += 5 },
+        sameFn = function() { 'foo' + 'bar' },
+        bangFn = function() { obj.str += '!' };
 
     expect(fn).to.change(obj, 'value');
     expect(fn).to.change(obj, 'value').by(5);
     expect(sameFn).to.not.change(obj, 'value');
+    expect(sameFn).to.not.change(obj, 'str');
+    expect(bangFn).to.change(obj, 'str');
   });
 
   it('increase, decrease', function() {

--- a/test/expect.js
+++ b/test/expect.js
@@ -900,4 +900,32 @@ describe('expect', function () {
     }, "expected [ { id: 1 } ] to have the same members as [ { id: 2 } ]");
   });
 
+  it('change', function() {
+    var obj = { value: 10 },
+        fn = function() { obj.value += 5 },
+        sameFn = function() { 'foo' + 'bar' };
+
+    expect(fn).to.change(obj, 'value');
+    expect(fn).to.change(obj, 'value').by(5);
+    expect(sameFn).to.not.change(obj, 'value');
+  });
+
+  it('increase, decrease', function() {
+    var obj = { value: 10 },
+        incFn = function() { obj.value += 2 },
+        decFn = function() { obj.value -= 3 },
+        smFn  = function() { obj.value += 0 };
+
+    expect(smFn).to.not.increase(obj, 'value');
+    expect(decFn).to.not.increase(obj, 'value');
+    expect(incFn).to.increase(obj, 'value');
+    expect(incFn).to.increase(obj, 'value').by(2);
+
+    expect(smFn).to.not.decrease(obj, 'value');
+    expect(incFn).to.not.decrease(obj, 'value');
+    expect(decFn).to.decrease(obj, 'value');
+    expect(decFn).to.decrease(obj, 'value').by(3);
+  });
+
+
 });

--- a/test/expect.js
+++ b/test/expect.js
@@ -907,7 +907,6 @@ describe('expect', function () {
         bangFn = function() { obj.str += '!' };
 
     expect(fn).to.change(obj, 'value');
-    expect(fn).to.change(obj, 'value').by(5);
     expect(sameFn).to.not.change(obj, 'value');
     expect(sameFn).to.not.change(obj, 'str');
     expect(bangFn).to.change(obj, 'str');
@@ -922,12 +921,10 @@ describe('expect', function () {
     expect(smFn).to.not.increase(obj, 'value');
     expect(decFn).to.not.increase(obj, 'value');
     expect(incFn).to.increase(obj, 'value');
-    expect(incFn).to.increase(obj, 'value').by(2);
 
     expect(smFn).to.not.decrease(obj, 'value');
     expect(incFn).to.not.decrease(obj, 'value');
     expect(decFn).to.decrease(obj, 'value');
-    expect(decFn).to.decrease(obj, 'value').by(3);
   });
 
 

--- a/test/should.js
+++ b/test/should.js
@@ -787,8 +787,6 @@ describe('should', function() {
         bangFn = function() { obj.str += '!' }; 
 
     fn.should.change(obj, 'value');
-    fn.should.change(obj, 'value').by(5);
-    decFn.should.change(obj, 'value').by(-3);
     sameFn.should.not.change(obj, 'value');
     sameFn.should.not.change(obj, 'str');
     bangFn.should.change(obj, 'str');
@@ -803,11 +801,9 @@ describe('should', function() {
     smFn.should.not.increase(obj, 'value');
     decFn.should.not.increase(obj, 'value');
     incFn.should.increase(obj, 'value');
-    incFn.should.increase(obj, 'value').by(2);
 
     smFn.should.not.decrease(obj, 'value');
     incFn.should.not.decrease(obj, 'value');
     decFn.should.decrease(obj, 'value');
-    decFn.should.decrease(obj, 'value').by(3);
   });
 });

--- a/test/should.js
+++ b/test/should.js
@@ -778,4 +778,33 @@ describe('should', function() {
       [1, 2, 3].should.have.same.members(4);
     }, 'expected 4 to be an array');
   });
+
+  it('change', function() {
+    var obj = { value: 10 },
+        fn     = function() { obj.value += 5 },
+        sameFn = function() { 'foo' + 'bar' },
+        decFn  = function() { obj.value -= 3 };
+
+    fn.should.change(obj, 'value');
+    fn.should.change(obj, 'value').by(5);
+    decFn.should.change(obj, 'value').by(-3);
+    sameFn.should.not.change(obj, 'value');
+  });
+
+  it('increase, decrease', function() {
+    var obj = { value: 10 },
+        incFn = function() { obj.value += 2 },
+        decFn = function() { obj.value -= 3 },
+        smFn  = function() { obj.value += 0 };
+
+    smFn.should.not.increase(obj, 'value');
+    decFn.should.not.increase(obj, 'value');
+    incFn.should.increase(obj, 'value');
+    incFn.should.increase(obj, 'value').by(2);
+
+    smFn.should.not.decrease(obj, 'value');
+    incFn.should.not.decrease(obj, 'value');
+    decFn.should.decrease(obj, 'value');
+    decFn.should.decrease(obj, 'value').by(3);
+  });
 });

--- a/test/should.js
+++ b/test/should.js
@@ -780,15 +780,18 @@ describe('should', function() {
   });
 
   it('change', function() {
-    var obj = { value: 10 },
+    var obj = { value: 10, str: 'foo' },
         fn     = function() { obj.value += 5 },
-        sameFn = function() { 'foo' + 'bar' },
-        decFn  = function() { obj.value -= 3 };
+        sameFn = function() { obj.value += 0 },
+        decFn  = function() { obj.value -= 3 },
+        bangFn = function() { obj.str += '!' }; 
 
     fn.should.change(obj, 'value');
     fn.should.change(obj, 'value').by(5);
     decFn.should.change(obj, 'value').by(-3);
     sameFn.should.not.change(obj, 'value');
+    sameFn.should.not.change(obj, 'str');
+    bangFn.should.change(obj, 'str');
   });
 
   it('increase, decrease', function() {


### PR DESCRIPTION
Added `change`, `increase` and `decrease` assertions with `by` chain:

```javascript
buildUser = function() { ... };
removeUsers = function() { ... };
buildUser.should.change(users, 'length');
buildUser.should.change(users, 'length').by(1);
removeUsers.should.decrease(users, 'length');
...
```

I've used `change` a bunch in other testing setups and it allows for more readable and terse tests *(instead of `before=val ... val.should.eq(before+1)`)*.

