### PR TITLE
Expose the util package through the chai object

### DIFF
--- a/lib/chai.js
+++ b/lib/chai.js
@@ -45,6 +45,12 @@ exports.use = function (fn) {
 };
 
 /*!
+ * Utility Functions
+ */
+
+exports.util = util;
+
+/*!
  * Configuration
  */
 


### PR DESCRIPTION
The util object has a lot of helpful functions in it that would be nice to use outside the context of assertions.

For instance, if you want to check deep equality without breaking when false.

```js
if (chai.util.eql(obj1, obj2)) {
  // do more things
} else {
  // do other things instead of having a failing assertion
}
```