### PR TITLE
Added fail() method to Should and Expect interfaces

### DIFF
--- a/lib/chai/core/assertions.js
+++ b/lib/chai/core/assertions.js
@@ -215,16 +215,6 @@ module.exports = function (chai, _) {
   Assertion.addChainableMethod('contains', include, includeChainingBehavior);
   Assertion.addChainableMethod('includes', include, includeChainingBehavior);
 
-  // TODO: Add jsdoc
-
-  function assertFail (msg) {
-    if (msg) flag(this, 'message', msg);
-    var obj = flag(this, 'object');
-    throw new chai.AssertionError(msg, {}, obj);
-  }
-
-  Assertion.addMethod('fail', assertFail);
-
   /**
    * ### .ok
    *

--- a/lib/chai/core/assertions.js
+++ b/lib/chai/core/assertions.js
@@ -215,6 +215,16 @@ module.exports = function (chai, _) {
   Assertion.addChainableMethod('contains', include, includeChainingBehavior);
   Assertion.addChainableMethod('includes', include, includeChainingBehavior);
 
+  // TODO: Add jsdoc
+
+  function assertFail (msg) {
+    if (msg) flag(this, 'message', msg);
+    var obj = flag(this, 'object');
+    throw new chai.AssertionError(msg, {}, obj);
+  }
+
+  Assertion.addMethod('fail', assertFail);
+
   /**
    * ### .ok
    *

--- a/lib/chai/interface/expect.js
+++ b/lib/chai/interface/expect.js
@@ -9,6 +9,19 @@ module.exports = function (chai, util) {
     return new chai.Assertion(val, message);
   };
 
+  /**
+   * ### .fail(actual, expected, [message], [operator])
+   *
+   * Throw a failure.
+   *
+   * @name fail
+   * @param {Mixed} actual
+   * @param {Mixed} expected
+   * @param {String} message
+   * @param {String} operator
+   * @api public
+   */
+
   chai.expect.fail = function (actual, expected, message, operator) {
     message = message || 'expect.fail()';
     throw new chai.AssertionError(message, {

--- a/lib/chai/interface/expect.js
+++ b/lib/chai/interface/expect.js
@@ -8,5 +8,13 @@ module.exports = function (chai, util) {
   chai.expect = function (val, message) {
     return new chai.Assertion(val, message);
   };
-};
 
+  chai.expect.fail = function (actual, expected, message, operator) {
+    message = message || 'expect.fail()';
+    throw new chai.AssertionError(message, {
+        actual: actual
+      , expected: expected
+      , operator: operator
+    }, chai.expect.fail);
+  };
+};

--- a/lib/chai/interface/should.js
+++ b/lib/chai/interface/should.js
@@ -41,7 +41,7 @@ module.exports = function (chai, util) {
     var should = {};
 
     should.fail = function (actual, expected, message, operator) {
-      message = message || 'assert.fail()';
+      message = message || 'should.fail()';
       throw new chai.AssertionError(message, {
           actual: actual
         , expected: expected

--- a/lib/chai/interface/should.js
+++ b/lib/chai/interface/should.js
@@ -40,6 +40,19 @@ module.exports = function (chai, util) {
 
     var should = {};
 
+    /**
+     * ### .fail(actual, expected, [message], [operator])
+     *
+     * Throw a failure.
+     *
+     * @name fail
+     * @param {Mixed} actual
+     * @param {Mixed} expected
+     * @param {String} message
+     * @param {String} operator
+     * @api public
+     */
+
     should.fail = function (actual, expected, message, operator) {
       message = message || 'should.fail()';
       throw new chai.AssertionError(message, {

--- a/lib/chai/interface/should.js
+++ b/lib/chai/interface/should.js
@@ -40,6 +40,15 @@ module.exports = function (chai, util) {
 
     var should = {};
 
+    should.fail = function (actual, expected, message, operator) {
+      message = message || 'assert.fail()';
+      throw new chai.AssertionError(message, {
+          actual: actual
+        , expected: expected
+        , operator: operator
+      }, should.fail);
+    };
+
     should.equal = function (val1, val2, msg) {
       new Assertion(val1, msg).to.equal(val2);
     };

--- a/test/expect.js
+++ b/test/expect.js
@@ -12,7 +12,7 @@ describe('expect', function () {
 
   it('fail', function () {
     err(function() {
-      expect().fail('this has failed');
+      expect.fail(0, 1, 'this has failed');
     }, /this has failed/);
   });
 

--- a/test/expect.js
+++ b/test/expect.js
@@ -10,6 +10,12 @@ describe('expect', function () {
     expect('foo').to.equal('foo');
   });
 
+  it('fail', function () {
+    err(function() {
+      expect().fail('this has failed');
+    }, /this has failed/);
+  });
+
   it('true', function(){
     expect(true).to.be.true;
     expect(false).to.not.be.true;

--- a/test/should.js
+++ b/test/should.js
@@ -8,9 +8,9 @@ describe('should', function() {
   });
 
   it('fail', function () {
-    chai.expect(function () {
+    err(function() {
       should.fail(0, 1, 'this has failed');
-    }).to.throw(chai.AssertionError, /this has failed/);
+    }, 'this has failed');
   });
 
   it('root exist', function () {

--- a/test/should.js
+++ b/test/should.js
@@ -7,6 +7,12 @@ describe('should', function() {
     should.not.equal('foo', 'bar');
   });
 
+  it('fail', function () {
+    chai.expect(function () {
+      should.fail(0, 1, 'this has failed');
+    }).to.throw(chai.AssertionError, /this has failed/);
+  });
+
   it('root exist', function () {
     var foo = 'foo'
       , bar = undefined;


### PR DESCRIPTION
Should and Expect now have `fail()` methods like Assert does.
```js
should.fail(0, 1, 'failure message');
expect().fail('failure message');
```
Please pay special attention to the Expect implementation as I wasn't totally certain how all of it worked. It may not be fully chainable, though it's not really intended to be.