### PR TITLE
Arrays passed to `.keys()` assertions are sorted (unexpectedly) by side-effect

### DIFF
--- a/lib/chai/core/assertions.js
+++ b/lib/chai/core/assertions.js
@@ -1067,7 +1067,7 @@ module.exports = function (chai, _) {
         ok
       , 'expected #{this} to ' + str
       , 'expected #{this} to not ' + str
-      , expected.sort()
+      , expected.slice(0).sort()
       , actual.sort()
       , true
     );

--- a/test/expect.js
+++ b/test/expect.js
@@ -668,6 +668,15 @@ describe('expect', function () {
 
   });
 
+  it('keys(array) will not mutate array (#359)', function () {
+      var expected = [ 'b', 'a' ];
+      var original_order = [ 'b', 'a' ];
+      var obj = { "b": 1, "a": 1 };
+      expect(expected).deep.equal(original_order);
+      expect(obj).keys(original_order);
+      expect(expected).deep.equal(original_order);
+  });
+
   it('chaining', function(){
     var tea = { name: 'chai', extras: ['milk', 'sugar', 'smile'] };
     expect(tea).to.have.property('extras').with.lengthOf(3);

--- a/test/should.js
+++ b/test/should.js
@@ -525,6 +525,15 @@ describe('should', function() {
     }, "expected { foo: 1, bar: 2 } to not have keys 'foo', or 'baz'");
   });
 
+  it('keys(array) will not mutate array (#359)', function () {
+      var expected = [ 'b', 'a' ];
+      var original_order = [ 'b', 'a' ];
+      var obj = { "b": 1, "a": 1 };
+      expected.should.deep.equal(original_order);
+      obj.should.keys(original_order);
+      expected.should.deep.equal(original_order);
+  });
+
   it('throw', function () {
     // See GH-45: some poorly-constructed custom errors don't have useful names
     // on either their constructor or their constructor prototype, but instead


### PR DESCRIPTION
## Example
```
var chai = require("chai");

var orig = ["b", "a"];
var mykeys = ["b","a"];
var O = {
  "b": 1,
  "a": 2
};

chai.expect(mykeys).deep.equal(orig);
chai.expect(O).keys(mykeys);
chai.expect(mykeys).deep.equal(orig);
// AssertionError: expected [ 'a', 'b' ] to deeply equal [ 'b', 'a' ]
```

This is caused by the `.sort()` at https://github.com/chaijs/chai/blob/master/lib/chai/core/assertions.js#L1070

## Possible Repairs

1. remove the `sort`()
2. clone / copy the `expected` list earlier in the function.
3. Something else

## Other implications

- unknown, thus my ask :)  I don't know Chai's code base and there may be other `sort` issues.  I didn't see any.

## Action Request 

If this sounds good, I can write up a PR tomorrow with whichever solution makes the most sense.