### PR TITLE
Fix travis.yml deploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,3 +20,4 @@ deploy:
   on:
     tags: true
     repo: chaijs/chai
+    all_branches: true


### PR DESCRIPTION
@logicalparadox it seems like this fixes the issue around travis being unable to deploy. See related issue on travis: https://github.com/travis-ci/travis-ci/issues/1675#issuecomment-37851765.

It still requires a tag to deploy, so PRs wont be able to trigger deploys (although if core contribs tag a branch it will try to deploy)