### PR TITLE
Getter for Should syntax now uses valueOf for primitives

### DIFF
--- a/lib/chai/interface/should.js
+++ b/lib/chai/interface/should.js
@@ -10,10 +10,8 @@ module.exports = function (chai, util) {
   function loadShould () {
     // explicitly define this method as function as to have it's name to include as `ssfi`
     function shouldGetter() {
-      if (this instanceof String || this instanceof Number) {
-        return new Assertion(this.constructor(this), null, shouldGetter);
-      } else if (this instanceof Boolean) {
-        return new Assertion(this == true, null, shouldGetter);
+      if (this instanceof String || this instanceof Number || this instanceof Boolean ) {
+        return new Assertion(this.valueOf(), null, shouldGetter);
       }
       return new Assertion(this, null, shouldGetter);
     }


### PR DESCRIPTION
While this PR doesn't fix a bug when Chai is used by itself, it does make it more compatible with babel and its core-js dependency (and possibly other ES6 transpilation tools).

The issue that led to this PR occurred when using the latest version of babel (and subsequently core-js). Our assertions involving Numbers would fail:

```js
var test = 1;
test.should.equal( 1 );
```

This would throw an error `AssertionError: expected {} to equal 1` when used with babel.

After the update to babel and this error, we checked `shouldjs` and it did not exhibit this error. The reason for this, is that `shouldjs` uses `valueOf` for primitives instead of calling back into their constructors:

* https://github.com/shouldjs/should.js/blob/master/lib/should.js#L85
* https://github.com/shouldjs/should.js/blob/master/lib/util.js#L15-L17

`core-js` is overwriting the Number prototype and constructor to support octal and binary (https://github.com/zloirock/core-js/commits/master/src/es6.number.constructor.js)

I would be more than willing to attempt unit tests around how the existing implementation could break, but it is such an edge case and using `valueOf` is a common way to unwrap primitives. All tests (via `npm test`) in this repo passed with the change in place.

We just spent the weekend and last few days switching our projects over from `shouldjs` to Chai because of how awesome it is. We love this project and I am happy to change this request as needed or to provide more information.