### PR TITLE
Add missing docstring for showDiff argument of assert

### DIFF
--- a/lib/chai/assertion.js
+++ b/lib/chai/assertion.js
@@ -88,10 +88,11 @@ module.exports = function (_chai, util) {
    *
    * @name assert
    * @param {Philosophical} expression to be tested
-   * @param {String or Function} message or function that returns message to display if fails
+   * @param {String or Function} message or function that returns message to display if expression fails
    * @param {String or Function} negatedMessage or function that returns negatedMessage to display if negated expression fails
    * @param {Mixed} expected value (remember to check for negation)
    * @param {Mixed} actual (optional) will default to `this.obj`
+   * @param {Boolean} showDiff (optional) when set to `true`, assert will display a diff in addition to the message if expression fails
    * @api private
    */
 


### PR DESCRIPTION
Considering this `assert` method is extensively used when you build your own helper, I think it should be added to the [*Plugin Utilities* API page](http://chaijs.com/api/plugins/).

What do you think?