### PR TITLE
No longer using eval on assert operator #386

### DIFF
--- a/lib/chai/interface/assert.js
+++ b/lib/chai/interface/assert.js
@@ -1004,10 +1004,36 @@ module.exports = function (chai, util) {
    */
 
   assert.operator = function (val, operator, val2, msg) {
-    if (!~['==', '===', '>', '>=', '<', '<=', '!=', '!=='].indexOf(operator)) {
-      throw new Error('Invalid operator "' + operator + '"');
+    var ok;
+    switch(operator) {
+      case '==':
+        ok = val == val2;
+        break;
+      case '===':
+        ok = val === val2;
+        break;
+      case '>':
+        ok = val > val2;
+        break;
+      case '>=':
+        ok = val >= val2;
+        break;
+      case '<':
+        ok = val < val2;
+        break;
+      case '<=':
+        ok = val <= val2;
+        break;
+      case '!=':
+        ok = val != val2;
+        break;
+      case '!==':
+        ok = val !== val2;
+        break;
+      default:
+        throw new Error('Invalid operator "' + operator + '"');
     }
-    var test = new Assertion(eval(val + operator + val2), msg);
+    var test = new Assertion(ok, msg);
     test.assert(
         true === flag(test, 'object')
       , 'expected ' + util.inspect(val) + ' to be ' + operator + ' ' + util.inspect(val2)

--- a/test/assert.js
+++ b/test/assert.js
@@ -556,6 +556,9 @@ describe('assert', function () {
   });
 
   it('operator', function() {
+    // For testing undefined and null with == and ===
+    var w;
+    
     assert.operator(1, '<', 2);
     assert.operator(2, '>', 1);
     assert.operator(1, '==', 1);
@@ -563,6 +566,10 @@ describe('assert', function () {
     assert.operator(1, '>=', 1);
     assert.operator(1, '!=', 2);
     assert.operator(1, '!==', 2);
+    assert.operator(1, '!==', '1');
+    assert.operator(w, '==', undefined);
+    assert.operator(w, '===', undefined);
+    assert.operator(w, '==', null);
 
     err(function () {
       assert.operator(1, '=', 2);
@@ -579,6 +586,10 @@ describe('assert', function () {
     err(function () {
       assert.operator(1, '==', 2);
      }, "expected 1 to be == 2");
+     
+    err(function () {
+      assert.operator(1, '===', '1');
+     }, "expected 1 to be === \'1\'");
 
     err(function () {
       assert.operator(2, '<=', 1);
@@ -591,10 +602,16 @@ describe('assert', function () {
     err(function () {
       assert.operator(1, '!=', 1);
      }, "expected 1 to be != 1");
-
+     
     err(function () {
-      assert.operator(1, '!==', '1');
-     }, "expected 1 to be !== \'1\'");
+      assert.operator(1, '!==', 1);
+     }, "expected 1 to be !== 1");
+    
+    err(function () {
+      assert.operator(w, '===', null);
+     }, "expected undefined to be === null");
+     
+     
   });
 
   it('closeTo', function(){


### PR DESCRIPTION
This pull request fixes issue #386 . The use of eval has gone away, and has been replaced with a switch operator on all possible boolean operators. I moved the error to the default case of the switch statement, as this avoids the unnecessary check in the beginning (and so that if more operators were added in the future, you wouldn't have to remember to add it in both places).