### PR TITLE
Add missing parameter showDiff and make docstring "documentationable"

### DIFF
--- a/chai.js
+++ b/chai.js
@@ -845,8 +845,8 @@ module.exports = function (_chai, util) {
     util.overwriteChainableMethod(this.prototype, name, fn, chainingBehavior);
   };
 
-  /*!
-   * ### .assert(expression, message, negateMessage, expected, actual)
+  /**
+   * ### .assert(expression, message, negateMessage, expected, actual, showDiff)
    *
    * Executes an expression and check expectations. Throws AssertionError for reporting if test doesn't pass.
    *

--- a/lib/chai/assertion.js
+++ b/lib/chai/assertion.js
@@ -81,8 +81,8 @@ module.exports = function (_chai, util) {
     util.overwriteChainableMethod(this.prototype, name, fn, chainingBehavior);
   };
 
-  /*!
-   * ### .assert(expression, message, negateMessage, expected, actual)
+  /**
+   * ### .assert(expression, message, negateMessage, expected, actual, showDiff)
    *
    * Executes an expression and check expectations. Throws AssertionError for reporting if test doesn't pass.
    *


### PR DESCRIPTION
I discussed some time ago about this on #382 with @keithamus.

I couldn't find a documentation on how to make a docstring appear on the doc site, so I made the assumption that docstrings starting with `/*!` were ignored and those starting with `/**` were added to the web pages. Please make fun of me if I am completely mistaken.

This goes along with chaijs/chai-docs#80.