### PR TITLE
Escaping dot should be taken in deep property

### DIFF
--- a/lib/chai/core/assertions.js
+++ b/lib/chai/core/assertions.js
@@ -75,6 +75,10 @@ module.exports = function (chai, _) {
    *     expect({ foo: { bar: { baz: 'quux' } } })
    *       .to.have.deep.property('foo.bar.baz', 'quux');
    *
+   * In the `property` assertion, setting `deep` flag may require
+   * to escape dot and brackets, while that is a rare case.
+   * See also the documentation of `.deep.property`.
+   *
    * @name deep
    * @api public
    */

--- a/lib/chai/core/assertions.js
+++ b/lib/chai/core/assertions.js
@@ -793,6 +793,18 @@ module.exports = function (chai, _) {
    *       .with.deep.property('[2]')
    *         .that.deep.equals({ tea: 'konacha' });
    *
+   * Note that dots and bracket in `name` must be backslash-escaped when
+   * the `deep` flag is set, while they must NOT be escaped when the `deep`
+   * flag is not set.
+   *
+   *     // simple referencing
+   *     var css = { '.link[target]': 42 };
+   *     expect(css).to.have.property('.link[target]', 42);
+   *
+   *     // deep referencing
+   *     var deepCss = { '.link': { '[target]': 42 }};
+   *     expect(deepCss).to.have.deep.property('\\.link.\\[target\\]', 42);
+   *
    * @name property
    * @alias deep.property
    * @param {String} name

--- a/lib/chai/utils/getPathInfo.js
+++ b/lib/chai/utils/getPathInfo.js
@@ -67,7 +67,7 @@ function parsePath (path) {
     var re = /\[(\d+)\]$/
       , mArr = re.exec(value);
     if (mArr) return { i: parseFloat(mArr[1]) };
-    else return { p: value };
+    else return { p: value.replace(/\\\./g, '.') };
   });
 }
 

--- a/lib/chai/utils/getPathInfo.js
+++ b/lib/chai/utils/getPathInfo.js
@@ -54,6 +54,7 @@ module.exports = function getPathInfo(path, obj) {
  *
  * * Can be as near infinitely deep and nested
  * * Arrays are also valid using the formal `myobject.document[3].property`.
+ * * Literal dots and brackets (not delimiter) must be backslash-escaped.
  *
  * @param {String} path
  * @returns {Object} parsed
@@ -61,14 +62,15 @@ module.exports = function getPathInfo(path, obj) {
  */
 
 function parsePath (path) {
-  var str = path.replace(/\[/g, '.[')
-    , parts = str.match(/(\\\.|[^.]+?)+/g);
-  return parts.map(function (value) {
-    var re = /\[(\d+)\]$/
-      , mArr = re.exec(value);
-    if (mArr) return { i: parseFloat(mArr[1]) };
-    else return { p: value.replace(/\\\./g, '.') };
-  });
+  /* assumed /^(?:(?:\\[.\[\]]|[^.\[\]])+|\[\d+\])(?:\.(?:\\[.\[\]]|[^.\[\]])+|\[\d+\])$/ */
+  var re = /(?:\\[.\[\]]|[^.\[\]])+|\[(\d+)\]/g
+    , parsed = []
+    , value;
+  while ((value = re.exec(path)) !== null) {
+    if (value[1]) parsed.push({ i: parseFloat(value[1]) });
+    else parsed.push({ p: value[0].replace(/\\([.\[\]])/g, '$1') });
+  }
+  return parsed;
 }
 
 

--- a/lib/chai/utils/getPathInfo.js
+++ b/lib/chai/utils/getPathInfo.js
@@ -62,15 +62,14 @@ module.exports = function getPathInfo(path, obj) {
  */
 
 function parsePath (path) {
-  /* assumed /^(?:(?:\\[.\[\]]|[^.\[\]])+|\[\d+\])(?:\.(?:\\[.\[\]]|[^.\[\]])+|\[\d+\])$/ */
-  var re = /(?:\\[.\[\]]|[^.\[\]])+|\[(\d+)\]/g
-    , parsed = []
-    , value;
-  while ((value = re.exec(path)) !== null) {
-    if (value[1]) parsed.push({ i: parseFloat(value[1]) });
-    else parsed.push({ p: value[0].replace(/\\([.\[\]])/g, '$1') });
-  }
-  return parsed;
+  var str = path.replace(/([^\\])\[/g, '$1.[')
+    , parts = str.match(/(\\\.|[^.]+?)+/g);
+  return parts.map(function (value) {
+    var re = /^\[(\d+)\]$/
+      , mArr = re.exec(value);
+    if (mArr) return { i: parseFloat(mArr[1]) };
+    else return { p: value.replace(/\\([.\[\]])/g, '$1') };
+  });
 }
 
 

--- a/test/expect.js
+++ b/test/expect.js
@@ -429,6 +429,9 @@ describe('expect', function () {
     expect({ 'foo': [1, 2, 3] })
       .to.have.deep.property('foo[1]');
 
+    expect({ 'foo.bar': 'baz'})
+      .to.have.deep.property('foo\\.bar');
+
     err(function(){
       expect({ 'foo.bar': 'baz' })
         .to.have.deep.property('foo.bar');

--- a/test/expect.js
+++ b/test/expect.js
@@ -411,6 +411,9 @@ describe('expect', function () {
     expect(obj).to.have.property('foo');
     expect(obj).to.have.property('bar');
 
+    expect({ 'foo.bar[]': 'baz'})
+      .to.have.property('foo.bar[]');
+
     err(function(){
       expect('asd').to.have.property('foo');
     }, "expected 'asd' to have a property 'foo'");
@@ -429,8 +432,8 @@ describe('expect', function () {
     expect({ 'foo': [1, 2, 3] })
       .to.have.deep.property('foo[1]');
 
-    expect({ 'foo.bar': 'baz'})
-      .to.have.deep.property('foo\\.bar');
+    expect({ 'foo.bar[]': 'baz'})
+      .to.have.deep.property('foo\\.bar\\[\\]');
 
     err(function(){
       expect({ 'foo.bar': 'baz' })

--- a/test/utilities.js
+++ b/test/utilities.js
@@ -90,6 +90,9 @@ describe('utilities', function () {
           dimensions: {
             units: 'mm',
             lengths: [[1.2, 3.5], [2.2, 1.5], [5, 7]]
+          },
+          'dimensions.lengths': {
+            '[2]': [1.2, 3.5]
           }
         };
 
@@ -151,6 +154,15 @@ describe('utilities', function () {
       expect(info.value).to.be.undefined;
       info.name.should.equal(5);
       info.exists.should.be.false;
+    });
+
+    it('should handle backslash-escaping for .[]', function() {
+      var info = gpi('dimensions\\.lengths.\\[2\\][1]', obj);
+
+      info.parent.should.equal(obj['dimensions.lengths']['[2]']);
+      info.value.should.equal(obj['dimensions.lengths']['[2]'][1]);
+      info.name.should.equal(1);
+      info.exists.should.be.true;
     });
   });
 


### PR DESCRIPTION
According to [getPathInfo.js] (https://github.com/chaijs/chai/blob/b6e1b573e07d108b4ecd6c9da733f20f010986a8/lib/chai/utils/getPathInfo.js#L65), `deep.property(name)` is assumed to support escaping dot `.` by prepending backslash `\`. However, escaping dot in `deep.property` seems to work in the unexpected way. Here is the example:

```
> expect({"foo.bar": "baz"}).to.have.deep.property("foo.bar", "baz");
AssertionError: expected { 'foo.bar': 'baz' } to have a deep property 'foo.bar'
// fail expectedly

> expect({"foo.bar": "baz"}).to.have.deep.property("foo\\.bar", "baz");
AssertionError: expected { 'foo.bar': 'baz' } to have a deep property 'foo\\.bar'
// fail unexpectedly

> expect({"foo\\.bar": "baz"}).to.have.deep.property("foo\\.bar", "baz");
// success unexpectedly
```

The current implementation of `deep.property`never match `{"foo\\.bar": "baz"}` because backslash `\` is not removed on processing escape. This PR fixes this problem. In addition, it includes the test case to ensure the problem fixed.

Noted that this PR obviously breaks some backward compatibility.