### PR TITLE
Tweak documentation on `.deep` flag.

### DIFF
--- a/lib/chai/core/assertions.js
+++ b/lib/chai/core/assertions.js
@@ -75,9 +75,11 @@ module.exports = function (chai, _) {
    *     expect({ foo: { bar: { baz: 'quux' } } })
    *       .to.have.deep.property('foo.bar.baz', 'quux');
    *
-   * In the `property` assertion, setting `deep` flag may require
-   * to escape dot and brackets, while that is a rare case.
-   * See also the documentation of `.deep.property`.
+   * `.deep.property` special characters can be escaped
+   * by adding two slashes before the `.` or `[]`.
+   *
+   *     var deepCss = { '.link': { '[target]': 42 }};
+   *     expect(deepCss).to.have.deep.property('\\.link.\\[target\\]', 42);
    *
    * @name deep
    * @api public
@@ -765,7 +767,7 @@ module.exports = function (chai, _) {
    *         green: { tea: 'matcha' }
    *       , teas: [ 'chai', 'matcha', { tea: 'konacha' } ]
    *     };
-
+   * 
    *     expect(deepObj).to.have.deep.property('green.tea', 'matcha');
    *     expect(deepObj).to.have.deep.property('teas[1]', 'matcha');
    *     expect(deepObj).to.have.deep.property('teas[2].tea', 'konacha');


### PR DESCRIPTION
Hopefully @umireon won't mind but I've slightly tweaked the documentation on the `.deep` flag regarding escapes (#402). 

This adds an example of escaping, just like `.deep.property` does - to save people jumping around the docs.