### PR TITLE
Fix a small inconsistency in the .null assertion docs

### DIFF
--- a/lib/chai/core/assertions.js
+++ b/lib/chai/core/assertions.js
@@ -291,7 +291,7 @@ module.exports = function (chai, _) {
    * Asserts that the target is `null`.
    *
    *     expect(null).to.be.null;
-   *     expect(undefined).not.to.be.null;
+   *     expect(undefined).to.not.be.null;
    *
    * @name null
    * @api public


### PR DESCRIPTION
The other assertions for undefined and the like all use '.to.not' in their examples - The slight increase in consistency is nice. :)