### PR TITLE
Adds assertions .to.be.defined

### DIFF
--- a/lib/chai/core/assertions.js
+++ b/lib/chai/core/assertions.js
@@ -326,6 +326,29 @@ module.exports = function (chai, _) {
   });
 
   /**
+   * ### .defined
+   *
+   * Asserts that the target is not `undefined`.
+   *
+   *     expect(undefined).to.be.defined;
+   *     expect(null).to.not.be.defined;
+   *
+   * Needed because it is intuitive to invert .undefined,
+   * which would always pass if .defined is nonexistent.
+   *
+   * @name undefined
+   * @api public
+   */
+
+  Assertion.addProperty('defined', function () {
+    this.assert(
+        undefined !== flag(this, 'object')
+      , 'expected #{this} to be defined'
+      , 'expected #{this} not to be defined'
+    );
+  });
+
+  /**
    * ### .exist
    *
    * Asserts that the target is neither `null` nor `undefined`.

--- a/test/expect.js
+++ b/test/expect.js
@@ -78,7 +78,7 @@ describe('expect', function () {
 
     err(function(){
       expect(undefined).to.be.defined;
-    }, "expected 'undefined' to be defined");
+    }, "expected undefined to be defined");
   });
 
   it('exist', function(){

--- a/test/expect.js
+++ b/test/expect.js
@@ -70,6 +70,17 @@ describe('expect', function () {
     }, "expected '' to be undefined")
   });
 
+  it("defined", function() {
+    expect({}).to.be.defined;
+    expect(function() {}).to.be.defined;
+    expect(false).to.be.defined;
+    expect(undefined).to.not.be.defined;
+
+    err(function(){
+      expect(undefined).to.be.defined;
+    }, "expected 'undefined' to be defined");
+  });
+
   it('exist', function(){
     var foo = 'bar'
       , bar;


### PR DESCRIPTION
There is of course `.to.exist` and `.to.be.ok` but since #371 we can no longer recommend that developers end every expectation with () which means we do get no-op expectations now and then. Test-first is a solution of course, but there's also test maintenance.

I didn't understand the rationale for the revert in #306 but I suppose there is good reasons. I think the use of .defined nearby .undefined is the most common mistake when asserting without ().