### PR TITLE
Fix misleading .has.property assertions tests

### DIFF
--- a/lib/chai/core/assertions.js
+++ b/lib/chai/core/assertions.js
@@ -835,7 +835,7 @@ module.exports = function (chai, _) {
         ? pathInfo.value
         : obj[name];
 
-    if (negate && undefined !== val) {
+    if (negate && arguments.length > 1) {
       if (undefined === value) {
         msg = (msg != null) ? msg + ': ' : '';
         throw new Error(msg + _.inspect(obj) + ' has no ' + descriptor + _.inspect(name));
@@ -847,7 +847,7 @@ module.exports = function (chai, _) {
         , 'expected #{this} to not have ' + descriptor + _.inspect(name));
     }
 
-    if (undefined !== val) {
+    if (arguments.length > 1) {
       this.assert(
           val === value
         , 'expected #{this} to have a ' + descriptor + _.inspect(name) + ' of #{exp}, but got #{act}'

--- a/test/assert.js
+++ b/test/assert.js
@@ -445,7 +445,10 @@ describe('assert', function () {
   it('property', function () {
     var obj = { foo: { bar: 'baz' } };
     var simpleObj = { foo: 'bar' };
+    var undefinedKeyObj = { foo: undefined };
     assert.property(obj, 'foo');
+    assert.property(undefinedKeyObj, 'foo');
+    assert.propertyVal(undefinedKeyObj, 'foo', undefined);
     assert.deepProperty(obj, 'foo.bar');
     assert.notProperty(obj, 'baz');
     assert.notProperty(obj, 'foo.bar');
@@ -472,6 +475,10 @@ describe('assert', function () {
     err(function () {
       assert.propertyVal(simpleObj, 'foo', 'ball');
     }, "expected { foo: 'bar' } to have a property 'foo' of 'ball', but got 'bar'");
+
+    err(function () {
+      assert.propertyVal(simpleObj, 'foo', undefined);
+    }, "expected { foo: 'bar' } to have a property 'foo' of undefined, but got 'bar'");
 
     err(function () {
       assert.deepPropertyVal(obj, 'foo.bar', 'ball');
@@ -558,7 +565,7 @@ describe('assert', function () {
   it('operator', function() {
     // For testing undefined and null with == and ===
     var w;
-    
+
     assert.operator(1, '<', 2);
     assert.operator(2, '>', 1);
     assert.operator(1, '==', 1);
@@ -586,7 +593,7 @@ describe('assert', function () {
     err(function () {
       assert.operator(1, '==', 2);
      }, "expected 1 to be == 2");
-     
+
     err(function () {
       assert.operator(1, '===', '1');
      }, "expected 1 to be === \'1\'");
@@ -602,16 +609,16 @@ describe('assert', function () {
     err(function () {
       assert.operator(1, '!=', 1);
      }, "expected 1 to be != 1");
-     
+
     err(function () {
       assert.operator(1, '!==', 1);
      }, "expected 1 to be !== 1");
-    
+
     err(function () {
       assert.operator(w, '===', null);
      }, "expected undefined to be === null");
-     
-     
+
+
   });
 
   it('closeTo', function(){
@@ -690,13 +697,13 @@ describe('assert', function () {
     err(function() {
       assert.isBelow(1, 1);
     }, 'expected 1 to be below 1');
-  
+
   });
-    
+
   it('memberDeepEquals', function() {
     assert.sameDeepMembers([ {b: 3}, {a: 2}, {c: 5} ], [ {c: 5}, {b: 3}, {a: 2} ], 'same deep members');
     assert.sameDeepMembers([ {b: 3}, {a: 2}, 5, "hello" ], [ "hello", 5, {b: 3}, {a: 2} ], 'same deep members');
-    
+
     err(function() {
       assert.sameDeepMembers([ {b: 3} ], [ {c: 3} ])
     }, 'expected [ { b: 3 } ] to have the same members as [ { c: 3 } ]');


### PR DESCRIPTION
This is the fix from pull request #453 with the addition of tests.
Relates to issue #452 

They fail on TravisCI when run off the fork with a `fatal : Cannot read property 'sha' of undefined` error.
I am opening this in case this failure is environment related/non issue as it looks like the actual chai tests themselves are passing. If this is the case, this pull request can be merged in place of #453.