### PR TITLE
Remove stray character in `assert.notInclude` docs

### DIFF
--- a/lib/chai/interface/assert.js
+++ b/lib/chai/interface/assert.js
@@ -700,7 +700,7 @@ module.exports = function (chai, util) {
    *
    * Asserts that `haystack` does not include `needle`. Works
    * for strings and arrays.
-   *i
+   *
    *     assert.notInclude('foobar', 'baz', 'string not include substring');
    *     assert.notInclude([ 1, 2, 3 ], 4, 'array not include contain value');
    *


### PR DESCRIPTION
This small error was causing a display issue on the site; namely, the examples for `assert.notInclude` did not render properly:

![chai docs](https://cloud.githubusercontent.com/assets/189606/7920688/7c6a7a5a-0855-11e5-9042-828a4b362e54.png)
