### PR TITLE
adding checkError utility to compare errors against criteria

### DIFF
--- a/lib/chai/core/assertions.js
+++ b/lib/chai/core/assertions.js
@@ -5,6 +5,8 @@
  * MIT Licensed
  */
 
+ var checkError = require('../utils/checkError');
+
 module.exports = function (chai, _) {
   var Assertion = chai.Assertion
     , toString = Object.prototype.toString
@@ -1211,123 +1213,87 @@ module.exports = function (chai, _) {
    * @returns error for chaining (null if no error)
    * @api public
    */
-
   function assertThrows (constructor, errMsg, msg) {
+    var caughtError;
     if (msg) flag(this, 'message', msg);
     var obj = flag(this, 'object');
     new Assertion(obj, msg).is.a('function');
 
-    var thrown = false
-      , desiredError = null
-      , name = null
-      , thrownError = null;
-
-    if (arguments.length === 0) {
-      errMsg = null;
-      constructor = null;
-    } else if (constructor && (constructor instanceof RegExp || 'string' === typeof constructor)) {
-      errMsg = constructor;
-      constructor = null;
-    } else if (constructor && constructor instanceof Error) {
-      desiredError = constructor;
-      constructor = null;
-      errMsg = null;
-    } else if (typeof constructor === 'function') {
-      name = constructor.prototype.name || constructor.name;
-      if (name === 'Error' && constructor !== Error) {
-        name = (new constructor()).name;
-      }
-    } else {
-      constructor = null;
-    }
-
     try {
       obj();
     } catch (err) {
-      // first, check desired error
-      if (desiredError) {
-        this.assert(
-            err === desiredError
-          , 'expected #{this} to throw #{exp} but #{act} was thrown'
-          , 'expected #{this} to not throw #{exp}'
-          , (desiredError instanceof Error ? desiredError.toString() : desiredError)
-          , (err instanceof Error ? err.toString() : err)
-        );
+      caughtError = err;
+    }
 
-        flag(this, 'object', err);
-        return this;
-      }
+    var foundErrors = checkError.call(this, caughtError, {constructor: constructor, errMsg: errMsg});
+    var self = this;
 
-      // next, check constructor
-      if (constructor) {
-        this.assert(
-            err instanceof constructor
-          , 'expected #{this} to throw #{exp} but #{act} was thrown'
-          , 'expected #{this} to not throw #{exp} but #{act} was thrown'
-          , name
-          , (err instanceof Error ? err.toString() : err)
-        );
+    foundErrors.forEach(function(foundError){
+      var expected = foundError.expected;
 
-        if (!errMsg) {
-          flag(this, 'object', err);
-          return this;
+      function getErrorMsg(options) {
+        var extra = ''
+          , typesToErrorMessages
+          , moreInfo = ''
+          , expected;
+
+        if (options.negate) {
+            extra = 'not ';
         }
+
+        if (typeof foundError.actual !== 'undefined') {
+          if (foundError.failType === 'errorMessageDoesNotMatch' ||
+              foundError.failType === 'errorMessageDoesInclude') {
+              moreInfo = ' but got #{act}';
+          }
+
+          if ((foundError.failType === 'differentErrorInstance' ||
+               foundError.failType === 'differentErrorType') &&
+               (foundError.actual !== foundError.expected)) {
+              moreInfo = ' but #{act} was thrown';
+          }
+        }
+
+        if (!!foundError.expected) {
+          expected = '#{exp}';
+        } else {
+          expected = 'an error';
+        }
+
+        if (options.negate) {
+          typesToErrorMessages = {
+              'differentErrorInstance':   'expected #{this} to ' + extra + 'throw '+expected + moreInfo
+            , 'differentErrorType':       'expected #{this} to ' + extra + 'throw '+expected + moreInfo
+            , 'errorMessageDoesNotMatch': 'expected #{this} to throw error ' + extra + 'matching #{exp}'
+            , 'errorMessageDoesInclude':  'expected #{this} to throw error ' + extra + 'including #{exp}'
+            , 'noErrorThrown':            'expected #{this} to throw ' + expected + moreInfo
+          };
+        } else {
+            typesToErrorMessages = {
+              'differentErrorInstance':   'expected #{this} to ' + extra + 'throw '+expected + moreInfo
+            , 'differentErrorType':       'expected #{this} to ' + extra + 'throw '+expected + moreInfo
+            , 'errorMessageDoesNotMatch': 'expected #{this} to throw error ' + extra + 'matching #{exp}' + moreInfo
+            , 'errorMessageDoesInclude':  'expected #{this} to throw error ' + extra + 'including #{exp}' + moreInfo
+            , 'noErrorThrown':            'expected #{this} to throw ' + expected
+          };
+
+        }
+
+        return typesToErrorMessages[foundError.failType];
       }
 
-      // next, check message
-      var message = 'error' === _.type(err) && "message" in err
-        ? err.message
-        : '' + err;
+      self.assert.call(self,
+          foundError.result
+        , getErrorMsg({negate:false})
+        , getErrorMsg({negate:true})
+        , (foundError.expected instanceof Error ? foundError.expected.toString() : foundError.expected)
+        , (foundError.actual instanceof Error ? foundError.actual.toString() : foundError.actual));
 
-      if ((message != null) && errMsg && errMsg instanceof RegExp) {
-        this.assert(
-            errMsg.exec(message)
-          , 'expected #{this} to throw error matching #{exp} but got #{act}'
-          , 'expected #{this} to throw error not matching #{exp}'
-          , errMsg
-          , message
-        );
-
-        flag(this, 'object', err);
-        return this;
-      } else if ((message != null) && errMsg && 'string' === typeof errMsg) {
-        this.assert(
-            ~message.indexOf(errMsg)
-          , 'expected #{this} to throw error including #{exp} but got #{act}'
-          , 'expected #{this} to throw error not including #{act}'
-          , errMsg
-          , message
-        );
-
-        flag(this, 'object', err);
-        return this;
-      } else {
-        thrown = true;
-        thrownError = err;
+      if (foundError.nextObject) {
+        flag(self, 'object', foundError.nextObject);
       }
-    }
-
-    var actuallyGot = ''
-      , expectedThrown = name !== null
-        ? name
-        : desiredError
-          ? '#{exp}' //_.inspect(desiredError)
-          : 'an error';
-
-    if (thrown) {
-      actuallyGot = ' but #{act} was thrown'
-    }
-
-    this.assert(
-        thrown === true
-      , 'expected #{this} to throw ' + expectedThrown + actuallyGot
-      , 'expected #{this} to not throw ' + expectedThrown + actuallyGot
-      , (desiredError instanceof Error ? desiredError.toString() : desiredError)
-      , (thrownError instanceof Error ? thrownError.toString() : thrownError)
-    );
-
-    flag(this, 'object', thrownError);
-  };
+    });
+  }
 
   Assertion.addMethod('throw', assertThrows);
   Assertion.addMethod('throws', assertThrows);

--- a/lib/chai/utils/checkError.js
+++ b/lib/chai/utils/checkError.js
@@ -1,0 +1,165 @@
+/*!
+ * Chai - checkError utility
+ * Copyright(c) 2012-2014 Jake Luer <jake@alogicalparadox.com>
+ * MIT Licensed
+ */
+
+/**
+ * ### checkError (err, assertionargs)
+ *
+ * Checks that an error conforms to a given set of criteria.
+ * Returns whether the error matches, as well as details of a failed matches.
+ * Result is an array of objects containing :
+ *   - result : did it match
+ *   - failType : why it didn't match : one of the following :
+ *      differentErrorInstance : error isn't the same instance as was requested
+ *      differentErrorType : error is of a different type to the one requested
+ *      errorMessageDoesNotMatch : error message does not match of the given regex
+ *      errorMessageDoesInclude : error message does not include
+ *                                (i.e. is not a substring) of the given string
+ *      noErrorThrown : no error was provided
+ *   - expected : expected error
+ *   - actual : actual error
+ *   - nextObject: next object to be flagged
+ *
+ *
+ * @param {Error} error value to be checked
+ * @param {Object} properties to check on the error:
+ * has properties :
+ *   - constructor : either the error instance or the constructor of the desired error
+ *   - errMsg : either a substring or a regex that the error message should match
+ * @name checkError
+ * @api public
+ */
+
+ var flag = require('./flag');
+ var type = require('type-detect');
+ var Assertion = require('../assertion');
+
+module.exports = function checkError (err, assertionargs) {
+    var foundErrors = [],
+        constructor = assertionargs && assertionargs.constructor,
+        errMsg = assertionargs && assertionargs.errMsg;
+
+    var thrown = false
+      , desiredError = null
+      , name = null
+      , thrownError = null;
+
+    if (arguments.length === 0) {
+      errMsg = null;
+      constructor = null;
+    } else if (constructor && (constructor instanceof RegExp || 'string' === typeof constructor)) {
+      errMsg = constructor;
+      constructor = null;
+    } else if (constructor && constructor instanceof Error) {
+      desiredError = constructor;
+      constructor = null;
+      errMsg = null;
+    } else if (typeof constructor === 'function') {
+      name = constructor.prototype.name || constructor.name;
+      if (name === 'Error' && constructor !== Error) {
+        name = (new constructor()).name;
+      }
+    } else {
+      constructor = null;
+    }
+
+    if (err) {
+      // first, check desired error
+      if (desiredError) {
+        foundErrors.push({
+            result: err === desiredError
+          , failType: 'differentErrorInstance'
+          , expected: desiredError
+          , actual: err
+          , nextObject: err
+        });
+
+        return foundErrors;
+      }
+
+      // next, check constructor
+      if (constructor) {
+        var nextError = {
+            result: err instanceof constructor
+          , failType: 'differentErrorType'
+          , expected: name
+          , actual: err
+        };
+
+        if (!errMsg) {
+          nextError.nextObject = err;
+          foundErrors.push(nextError);
+          return foundErrors;
+        } else {
+          foundErrors.push(nextError);
+        }
+      }
+
+      // next, check message
+      var message = 'error' === type(err) && "message" in err
+        ? err.message
+        : '' + err;
+
+      if ((message != null) && errMsg && errMsg instanceof RegExp) {
+        foundErrors.push({
+            result: errMsg.exec(message) != null
+          , failType: 'errorMessageDoesNotMatch'
+          , expected: errMsg
+          , actual: message
+          , nextObject: err
+        });
+
+        return foundErrors;
+      } else if ((message != null) && errMsg && 'string' === typeof errMsg) {
+
+        foundErrors.push({
+            result: !!(~message.indexOf(errMsg))
+          , failType: 'errorMessageDoesInclude'
+          , expected: errMsg
+          , actual: message
+          , nextObject: err
+        });
+
+        return foundErrors;
+      } else {
+        thrown = true;
+        thrownError = err;
+      }
+    }
+
+    var myError = {
+        result: thrown === true
+      , expected: desiredError
+      , actual: err
+      , nextObject: thrownError
+    };
+
+    if (thrown) {
+      myError.failType =  'differentErrorInstance'
+    } else {
+      myError.failType = 'noErrorThrown';
+    }
+
+    if (!desiredError) {
+      if (!!constructor) {
+        myError.expected = constructor;
+      } else if (!!errMsg) {
+        myError.expected = errMsg;
+        if ('string' === typeof errMsg) {
+          myError.failType =  'errorMessageDoesInclude';
+        } else if (errMsg instanceof RegExp) {
+          myError.failType = 'errorMessageDoesNotMatch';
+        }
+      }
+    }
+
+    if (name !== null) {
+      myError.expected = name;
+    }
+
+    foundErrors.push(myError);
+
+    return foundErrors;
+};

--- a/lib/chai/utils/index.js
+++ b/lib/chai/utils/index.js
@@ -124,3 +124,5 @@ exports.addChainableMethod = require('./addChainableMethod');
 
 exports.overwriteChainableMethod = require('./overwriteChainableMethod');
 
+exports.checkError = require('./checkError');
+

--- a/test/expect.js
+++ b/test/expect.js
@@ -872,7 +872,7 @@ describe('expect', function () {
 
     err(function(){
       expect(goodFn).to.throw(ReferenceError);
-    }, "expected [Function] to throw ReferenceError");
+    }, "expected [Function] to throw 'ReferenceError'");
 
     err(function(){
       expect(goodFn).to.throw(specificError);

--- a/test/should.js
+++ b/test/should.js
@@ -718,7 +718,7 @@ describe('should', function() {
 
     err(function(){
       (goodFn).should.throw(ReferenceError);
-    }, "expected [Function] to throw ReferenceError");
+    }, "expected [Function] to throw 'ReferenceError'");
 
     err(function(){
       (goodFn).should.throw(specificError);

--- a/test/utilities.js
+++ b/test/utilities.js
@@ -448,4 +448,158 @@ describe('utilities', function () {
     });
   });
 
+  describe('checkError', function() {
+    var checkError;
+    beforeEach(function() {
+      chai.use(function (_chai, utils) {
+          checkError = utils.checkError;
+      });
+    });
+
+    describe('differentErrorInstance', function() {
+      it('has error', function() {
+        var actual = new Error('matcha');
+        var expected = new Error('green tea');
+
+        var output = checkError(actual, {
+          constructor: expected
+        });
+
+        expect(output.length).to.equal(1);
+        expect(output[0].failType).to.equal('differentErrorInstance');
+        expect(output[0].expected).to.equal(expected);
+        expect(output[0].actual).to.equal(actual);
+        expect(output[0].result).to.be.false;
+      });
+
+      it('does not have error', function() {
+        var actual = new Error('matcha');
+        var expected = actual;
+
+        var output = checkError(actual, {
+          constructor: expected
+        });
+
+        expect(output.length).to.equal(1);
+        expect(output[0].failType).to.equal('differentErrorInstance');
+        expect(output[0].expected).to.equal(expected);
+        expect(output[0].actual).to.equal(actual);
+        expect(output[0].result).to.be.true;
+      });
+    });
+
+    describe('differentErrorType', function() {
+      it('has error', function() {
+        var actual = new Error('matcha');
+        var expected = SyntaxError;
+
+        var output = checkError(actual, {
+          constructor: expected
+        });
+
+        expect(output.length).to.equal(1);
+        expect(output[0].failType).to.equal('differentErrorType');
+        expect(output[0].expected).to.equal(expected.prototype.name);
+        expect(output[0].actual).to.equal(actual);
+        expect(output[0].result).to.be.false;
+      });
+
+      it('does not have error', function() {
+        var actual = new Error('matcha');
+        var expected = Error;
+
+        var output = checkError(actual, {
+          constructor: expected
+        });
+
+        expect(output.length).to.equal(1);
+        expect(output[0].failType).to.equal('differentErrorType');
+        expect(output[0].expected).to.equal(expected.prototype.name);
+        expect(output[0].actual).to.equal(actual);
+        expect(output[0].result).to.be.true;
+      });
+    });
+
+    describe('errorMessageDoesNotMatch', function() {
+      it('has error', function() {
+        var actual = new Error('matcha');
+        var expected = /green tea/;
+
+        var output = checkError(actual, {
+          constructor: expected
+        });
+
+        expect(output.length).to.equal(1);
+        expect(output[0].failType).to.equal('errorMessageDoesNotMatch');
+        expect(output[0].expected).to.equal(expected);
+        expect(output[0].actual).to.equal(actual.message);
+        expect(output[0].result).to.be.false;
+      });
+
+      it('does not have error', function() {
+        var actual = new Error('matcha');
+        var expected = /matcha/;
+
+        var output = checkError(actual, {
+          constructor: expected
+        });
+
+        expect(output.length).to.equal(1);
+        expect(output[0].failType).to.equal('errorMessageDoesNotMatch');
+        expect(output[0].expected).to.equal(expected);
+        expect(output[0].actual).to.equal(actual.message);
+        expect(output[0].result).to.be.true;
+      });
+    });
+
+    describe('errorMessageDoesInclude', function() {
+      it('has error', function() {
+        var actual = new Error('matcha');
+        var expected = 'green tea';
+
+        var output = checkError(actual, {
+          constructor: expected
+        });
+
+        expect(output.length).to.equal(1);
+        expect(output[0].failType).to.equal('errorMessageDoesInclude');
+        expect(output[0].expected).to.equal(expected);
+        expect(output[0].actual).to.equal(actual.message);
+        expect(output[0].result).to.be.false;
+      });
+
+      it('does not have error', function() {
+        var actual = new Error('green tea');
+        var expected = 'een';
+
+        var output = checkError(actual, {
+          constructor: expected
+        });
+
+        expect(output.length).to.equal(1);
+        expect(output[0].failType).to.equal('errorMessageDoesInclude');
+        expect(output[0].expected).to.equal(expected);
+        expect(output[0].actual).to.equal(actual.message);
+        expect(output[0].result).to.be.true;
+      });
+    });
+
+    describe('noErrorThrown', function() {
+      it('has error', function() {
+        var actual = undefined;
+        var expected = new Error('matcha');
+
+        var output = checkError(actual, {
+          constructor: expected
+        });
+
+        expect(output.length).to.equal(1);
+        expect(output[0].failType).to.equal('noErrorThrown');
+        expect(output[0].expected).to.equal(expected);
+        expect(output[0].actual).to.equal(actual);
+        expect(output[0].result).to.be.false;
+      });
+    });
+
+  });
 });


### PR DESCRIPTION
Refactoring as per domenic/chai-as-promised#47 to add a checkError utility. The purpose of this is to make it easier for plug ins to use the same logic as chai when verifying errors.

A couple of things I wasn't sure about : 
- I've kept the API the same as the variable names in the original contents of assertThrows (i.e. the params passed into checkError on assertionArgs) but it might be clearer if they were renamed.
- checkError currently returns an array because in some cases the original code asserted more than once. This makes it a bit more complex but also more flexible.
- The only pre-existing test(s) I had to change were the ones who check for a message with ReferenceError without quotes (e.g. https://github.com/chaijs/chai/blob/5c5cbd1c36355a1261b3652da927ded36803174b/test/expect.js#l875). A lot of other tests specified Errors in quotes, when specified as constructors, instances or matches, in quotes, and I *think* its more consistent now, but I might just have misunderstood the logic.

Anyway happy to fix up stuff if this is helpful. Thanks!
