### PR TITLE
corrected var name to 'obj' instead of 'object' - linked to issue472

### DIFF
--- a/lib/chai/core/assertions.js
+++ b/lib/chai/core/assertions.js
@@ -376,7 +376,7 @@ module.exports = function (chai, _) {
     var obj = flag(this, 'object')
       , expected = obj;
 
-    if (Array.isArray(obj) || 'string' === typeof object) {
+    if (Array.isArray(obj) || 'string' === typeof obj) {
       expected = obj.length;
     } else if (typeof obj === 'object') {
       expected = Object.keys(obj).length;


### PR DESCRIPTION
- Corrected condition so that empty string is getting checked as intended
- Raised in issue #472 