### PR TITLE
Empty fail undefined

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ chai.js: node_modules lib/*
 #
 
 define release
-	./node_modules/.bin/bump -y --$(1) *.json lib/chai.js
+	./node_modules/.bin/bump -y --$(1) package.json lib/chai.js
 	make chai.js
 	git add --force chai.js lib/chai.js package.json bower.json
 	npm ls --depth=-1 --long . --loglevel silent | head -1 | git commit -F-

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,5 @@
 {
   "name": "chai",
-  "version": "3.0.0",
   "description": "BDD/TDD assertion library for node.js and the browser. Test framework agnostic.",
   "license": "MIT",
   "keywords": [

--- a/lib/chai/core/assertions.js
+++ b/lib/chai/core/assertions.js
@@ -373,8 +373,8 @@ module.exports = function (chai, _) {
    */
 
   Assertion.addProperty('empty', function () {
-    var obj = flag(this, 'object'),
-      expected = obj;
+    var obj = flag(this, 'object')
+      , expected = obj;
 
     if (obj == null) {
       expected = flag(this, 'negate');

--- a/lib/chai/core/assertions.js
+++ b/lib/chai/core/assertions.js
@@ -373,17 +373,19 @@ module.exports = function (chai, _) {
    */
 
   Assertion.addProperty('empty', function () {
-    var obj = flag(this, 'object')
-      , expected = obj;
+    var obj = flag(this, 'object'),
+      expected = obj;
 
-    if (Array.isArray(obj) || 'string' === typeof object) {
-      expected = obj.length;
-    } else if (typeof obj === 'object') {
-      expected = Object.keys(obj).length;
+    if (obj == null) {
+      expected = flag(this, 'negate');
+    } else if (Array.isArray(obj) || 'string' === typeof obj) {
+      expected = obj.length === 0;
+    } else if ('object' === typeof obj) {
+      expected = Object.keys(obj).length === 0;
     }
 
     this.assert(
-        !expected
+        expected
       , 'expected #{this} to be empty'
       , 'expected #{this} not to be empty'
     );

--- a/test/expect.js
+++ b/test/expect.js
@@ -396,7 +396,35 @@ describe('expect', function () {
 
     err(function(){
       expect({foo: 'bar'}).to.be.empty;
-    }, "expected { foo: \'bar\' } to be empty");
+    }, "expected { foo: \'bar\' } to be empty");    
+ 
+    err(function(){
+      expect(0).to.be.empty;
+    }, "expected 0 to be empty");
+
+    err(function(){
+      expect(null).to.be.empty;
+    }, "expected null to be empty");
+
+    err(function(){
+      expect(undefined).to.be.empty;
+    }, "expected undefined to be empty");
+
+    err(function(){
+      expect().to.be.empty;
+    }, "expected undefined to be empty");
+
+    err(function(){
+      expect(null).to.not.be.empty;
+    }, "expected null not to be empty");
+
+    err(function(){
+      expect(undefined).to.not.be.empty;
+    }, "expected undefined not to be empty");
+
+    err(function(){
+      expect().to.not.be.empty;
+    }, "expected undefined not to be empty");
   });
 
   it('property(name)', function(){


### PR DESCRIPTION
- Added handling of undefined and null to fail if passed in

@keithamus Is chai 4.x.x going to be focused towards ES6? If so I can use Object.keys() to coerce primitives.

Also there is the option to do this:
```
else if (obj.hasOwnProperty('length')) {
  expected = obj.length === 0;
 }
```
Which would cover any new objects with length, but it would add support for checking if a function takes parameters or not (not sure that's what you would want from an empty check..).

Just an idea. I will wait for your feedback.