### PR TITLE
Added handling for undefined and null on expect empty (fails on negate flag too)

### DIFF
--- a/lib/chai/core/assertions.js
+++ b/lib/chai/core/assertions.js
@@ -376,14 +376,16 @@ module.exports = function (chai, _) {
     var obj = flag(this, 'object')
       , expected = obj;
 
-    if (Array.isArray(obj) || 'string' === typeof object) {
-      expected = obj.length;
-    } else if (typeof obj === 'object') {
-      expected = Object.keys(obj).length;
+    if (obj == null) {
+      expected = flag(this, 'negate');
+    } else if (Array.isArray(obj) || 'string' === typeof obj) {
+      expected = obj.length === 0;
+    } else if ('object' === typeof obj) {
+      expected = Object.keys(obj).length === 0;
     }
 
     this.assert(
-        !expected
+      expected
       , 'expected #{this} to be empty'
       , 'expected #{this} not to be empty'
     );

--- a/lib/chai/core/assertions.js
+++ b/lib/chai/core/assertions.js
@@ -373,19 +373,10 @@ module.exports = function (chai, _) {
    */
 
   Assertion.addProperty('empty', function () {
-    var obj = flag(this, 'object')
-      , expected = obj;
-
-    if (obj == null) {
-      expected = flag(this, 'negate');
-    } else if (Array.isArray(obj) || 'string' === typeof obj) {
-      expected = obj.length === 0;
-    } else if ('object' === typeof obj) {
-      expected = Object.keys(obj).length === 0;
-    }
-
+    var obj = flag(this, 'object');
+    new Assertion(obj).to.exist;
     this.assert(
-      expected
+        Object.keys(Object(obj)).length === 0
       , 'expected #{this} to be empty'
       , 'expected #{this} not to be empty'
     );

--- a/test/expect.js
+++ b/test/expect.js
@@ -397,6 +397,35 @@ describe('expect', function () {
     err(function(){
       expect({foo: 'bar'}).to.be.empty;
     }, "expected { foo: \'bar\' } to be empty");
+
+    err(function(){
+      expect(0).to.be.empty;
+    }, "expected 0 to be empty");
+
+    err(function(){
+      expect(null).to.be.empty;
+    }, "expected null to be empty");
+
+    err(function(){
+      expect(undefined).to.be.empty;
+    }, "expected undefined to be empty");
+
+    err(function(){
+      expect().to.be.empty;
+    }, "expected undefined to be empty");
+
+    err(function(){
+      expect(null).to.not.be.empty;
+    }, "expected null not to be empty");
+
+    err(function(){
+      expect(undefined).to.not.be.empty;
+    }, "expected undefined not to be empty");
+
+    err(function(){
+      expect().to.not.be.empty;
+    }, "expected undefined not to be empty");
+    
   });
 
   it('property(name)', function(){

--- a/test/expect.js
+++ b/test/expect.js
@@ -399,32 +399,28 @@ describe('expect', function () {
     }, "expected { foo: \'bar\' } to be empty");
 
     err(function(){
-      expect(0).to.be.empty;
-    }, "expected 0 to be empty");
-
-    err(function(){
       expect(null).to.be.empty;
-    }, "expected null to be empty");
+    }, "expected null to exist");
 
     err(function(){
       expect(undefined).to.be.empty;
-    }, "expected undefined to be empty");
+    }, "expected undefined to exist");
 
     err(function(){
       expect().to.be.empty;
-    }, "expected undefined to be empty");
+    }, "expected undefined to exist");
 
     err(function(){
       expect(null).to.not.be.empty;
-    }, "expected null not to be empty");
+    }, "expected null to exist");
 
     err(function(){
       expect(undefined).to.not.be.empty;
-    }, "expected undefined not to be empty");
+    }, "expected undefined to exist");
 
     err(function(){
       expect().to.not.be.empty;
-    }, "expected undefined not to be empty");
+    }, "expected undefined to exist");
     
   });
 


### PR DESCRIPTION
- Added handling for undefined and null on expect empty 

@keithamus Is chai 4.x.x going to be focused towards ES6? If so I can use Object.keys() to coerce primitives.

Also there is the option to do this:
```
else if (obj.hasOwnProperty('length')) {
  expected = obj.length === 0;
 }
```

Which would cover any new objects with length, but it would add support for checking if a function takes parameters or not (not sure that's what you would want from an empty check..).

Just an idea. I will wait for your feedback.
