### PR TITLE
Assertions to test if objects are extensible.

### DIFF
--- a/lib/chai/core/assertions.js
+++ b/lib/chai/core/assertions.js
@@ -1674,4 +1674,29 @@ module.exports = function (chai, _) {
     );
   });
 
+  /**
+   * ### .frozen
+   *
+   * Asserts that the target is frozen (cannot have new properties added to it
+   * and its existing properties cannot be modified).
+   *
+   *     var frozenObject = Object.freeze({});
+   *
+   *     expect(frozenObject).to.be.frozen;
+   *     expect({}).to.not.be.frozen;
+   *
+   * @name frozen
+   * @api public
+   */
+
+  Assertion.addProperty('frozen', function() {
+    var obj = flag(this, 'object');
+
+    this.assert(
+      Object.isSealed(obj)
+      , 'expected #{this} to be frozen'
+      , 'expected #{this} to not be frozen'
+    );
+  });
+
 };

--- a/lib/chai/core/assertions.js
+++ b/lib/chai/core/assertions.js
@@ -1618,4 +1618,33 @@ module.exports = function (chai, _) {
   Assertion.addChainableMethod('decrease', assertDecreases);
   Assertion.addChainableMethod('decreases', assertDecreases);
 
+  /**
+   * ### .extensible
+   *
+   * Asserts that the target is extensible (can have new properties added to 
+   * it).
+   *
+   *     var nonExtensibleObject = Object.preventExtensions({});
+   *     var sealedObject = Object.seal({});
+   *     var frozenObject = Object.freeze({});
+   *
+   *     expect({}).to.be.extensible;
+   *     expect(nonExtensibleObject).to.not.be.extensible;
+   *     expect(sealedObject).to.not.be.extensible;
+   *     expect(frozenObject).to.not.be.extensible;
+   *
+   * @name extensible
+   * @api public
+   */
+
+  Assertion.addProperty('extensible', function() {
+    var obj = flag(this, 'object');
+
+    this.assert(
+      Object.isExtensible(obj)
+      , 'expected #{this} to be extensible'
+      , 'expected #{this} to not be extensible'
+    );
+  });
+
 };

--- a/lib/chai/core/assertions.js
+++ b/lib/chai/core/assertions.js
@@ -1647,4 +1647,31 @@ module.exports = function (chai, _) {
     );
   });
 
+  /**
+   * ### .sealed
+   *
+   * Asserts that the target is sealed (cannot have new properties added to it
+   * and its existing properties cannot be removed).
+   *
+   *     var sealedObject = Object.seal({});
+   *     var frozenObject = Object.freeze({});
+   *
+   *     expect(sealedObject).to.be.sealed;
+   *     expect(frozenObject).to.be.sealed;
+   *     expect({}).to.not.be.sealed;
+   *
+   * @name sealed
+   * @api public
+   */
+
+  Assertion.addProperty('sealed', function() {
+    var obj = flag(this, 'object');
+
+    this.assert(
+      Object.isSealed(obj)
+      , 'expected #{this} to be sealed'
+      , 'expected #{this} to not be sealed'
+    );
+  });
+
 };

--- a/lib/chai/interface/assert.js
+++ b/lib/chai/interface/assert.js
@@ -1303,6 +1303,45 @@ module.exports = function (chai, util) {
     new Assertion(obj, msg).to.not.be.extensible;
   };
 
+  /**
+   * ### .sealed(object)
+   *
+   * Asserts that `object` is sealed (cannot have new properties added to it
+   * and its existing properties cannot be removed).
+   *
+   *     var sealedObject = Object.seal({});
+   *     var frozenObject = Object.seal({});
+   *
+   *     assert.sealed(sealedObject);
+   *     assert.sealed(frozenObject);
+   *
+   * @name sealed
+   * @param {Object} object
+   * @param {String} message _optional_
+   * @api public
+   */
+
+  assert.sealed = function (obj, msg) {
+    new Assertion(obj, msg).to.be.sealed;
+  };
+
+  /**
+   * ### .notSealed(object)
+   *
+   * Asserts that `object` is _not_ sealed.
+   *
+   *     assert.notSealed({});
+   *
+   * @name notSealed
+   * @param {Object} object
+   * @param {String} message _optional_
+   * @api public
+   */
+
+  assert.notSealed = function (obj, msg) {
+    new Assertion(obj, msg).to.not.be.sealed;
+  };
+
   /*!
    * Aliases.
    */

--- a/lib/chai/interface/assert.js
+++ b/lib/chai/interface/assert.js
@@ -1342,6 +1342,42 @@ module.exports = function (chai, util) {
     new Assertion(obj, msg).to.not.be.sealed;
   };
 
+  /**
+   * ### .frozen(object)
+   *
+   * Asserts that `object` is frozen (cannot have new properties added to it
+   * and its existing properties cannot be modified).
+   *
+   *     var frozenObject = Object.freeze({});
+   *     assert.frozen(frozenObject);
+   *
+   * @name frozen
+   * @param {Object} object
+   * @param {String} message _optional_
+   * @api public
+   */
+
+  assert.frozen = function (obj, msg) {
+    new Assertion(obj, msg).to.be.frozen;
+  };
+
+  /**
+   * ### .notFrozen(object)
+   *
+   * Asserts that `object` is _not_ frozen.
+   *
+   *     assert.notFrozen({});
+   *
+   * @name notSealed
+   * @param {Object} object
+   * @param {String} message _optional_
+   * @api public
+   */
+
+  assert.notFrozen = function (obj, msg) {
+    new Assertion(obj, msg).to.not.be.frozen;
+  };
+
   /*!
    * Aliases.
    */

--- a/lib/chai/interface/assert.js
+++ b/lib/chai/interface/assert.js
@@ -1263,6 +1263,46 @@ module.exports = function (chai, util) {
     }
   };
 
+  /**
+   * ### .extensible(object)
+   *
+   * Asserts that `object` is extensible (can have new properties added to it).
+   *
+   *     assert.extensible({});
+   *
+   * @name extensible
+   * @param {Object} object
+   * @param {String} message _optional_
+   * @api public
+   */
+
+  assert.extensible = function (obj, msg) {
+    new Assertion(obj, msg).to.be.extensible;
+  };
+
+  /**
+   * ### .notExtensible(object)
+   *
+   * Asserts that `object` is _not_ extensible.
+   *
+   *     var nonExtensibleObject = Object.preventExtensions({});
+   *     var sealedObject = Object.seal({});
+   *     var frozenObject = Object.freese({});
+   *
+   *     assert.notExtensible(nonExtensibleObject);
+   *     assert.notExtensible(sealedObject);
+   *     assert.notExtensible(frozenObject);
+   *
+   * @name notExtensible
+   * @param {Object} object
+   * @param {String} message _optional_
+   * @api public
+   */
+
+  assert.notExtensible = function (obj, msg) {
+    new Assertion(obj, msg).to.not.be.extensible;
+  };
+
   /*!
    * Aliases.
    */

--- a/test/assert.js
+++ b/test/assert.js
@@ -738,4 +738,24 @@ describe('assert', function () {
     assert.doesNotIncrease(smFn, obj, 'value');
   });
 
+  it('extensible', function() {
+    var nonExtensibleObject = Object.preventExtensions({});
+
+    assert.extensible({});
+
+    err(function() {
+      assert.extensible(nonExtensibleObject);
+    }, 'expected {} to be extensible');
+  });
+
+  it('notExtensible', function() {
+    var nonExtensibleObject = Object.preventExtensions({});
+
+    assert.notExtensible(nonExtensibleObject);
+
+    err(function() {
+      assert.notExtensible({});
+    }, 'expected {} to not be extensible');
+  });
+
 });

--- a/test/assert.js
+++ b/test/assert.js
@@ -758,4 +758,24 @@ describe('assert', function () {
     }, 'expected {} to not be extensible');
   });
 
+  it('sealed', function() {
+    var sealedObject = Object.seal({});
+
+    assert.sealed(sealedObject);
+
+    err(function() {
+      assert.sealed({});
+    }, 'expected {} to be sealed');
+  });
+
+  it('notSealed', function() {
+    var sealedObject = Object.seal({});
+
+    assert.notSealed({});
+
+    err(function() {
+      assert.notSealed(sealedObject);
+    }, 'expected {} to not be sealed');
+  });
+
 });

--- a/test/assert.js
+++ b/test/assert.js
@@ -778,4 +778,24 @@ describe('assert', function () {
     }, 'expected {} to not be sealed');
   });
 
+  it('frozen', function() {
+    var frozenObject = Object.freeze({});
+
+    assert.frozen(frozenObject);
+
+    err(function() {
+      assert.frozen({});
+    }, 'expected {} to be frozen');
+  });
+
+  it('notFrozen', function() {
+    var frozenObject = Object.freeze({});
+
+    assert.notFrozen({});
+
+    err(function() {
+      assert.notFrozen(frozenObject);
+    }, 'expected {} to not be frozen');
+  });
+
 });

--- a/test/expect.js
+++ b/test/expect.js
@@ -1090,4 +1090,19 @@ describe('expect', function () {
     }, 'expected {} to not be sealed');
   });
 
+  it('frozen', function() {
+    var frozenObject = Object.freeze({});
+
+    expect(frozenObject).to.be.frozen;
+    expect({}).to.not.be.frozen;
+
+    err(function() {
+        expect({}).to.be.frozen;
+    }, 'expected {} to be frozen');
+
+    err(function() {
+        expect(frozenObject).to.not.be.frozen;
+    }, 'expected {} to not be frozen');
+  });
+
 });

--- a/test/expect.js
+++ b/test/expect.js
@@ -1060,5 +1060,19 @@ describe('expect', function () {
     expect(decFn).to.decrease(obj, 'value');
   });
 
+  it('extensible', function() {
+    var nonExtensibleObject = Object.preventExtensions({});
+
+    expect({}).to.be.extensible;
+    expect(nonExtensibleObject).to.not.be.extensible;
+
+    err(function() {
+        expect(nonExtensibleObject).to.be.extensible;
+    }, 'expected {} to be extensible');
+
+    err(function() {
+        expect({}).to.not.be.extensible;
+    }, 'expected {} to not be extensible');
+  });
 
 });

--- a/test/expect.js
+++ b/test/expect.js
@@ -1075,4 +1075,19 @@ describe('expect', function () {
     }, 'expected {} to not be extensible');
   });
 
+  it('sealed', function() {
+    var sealedObject = Object.seal({});
+
+    expect(sealedObject).to.be.sealed;
+    expect({}).to.not.be.sealed;
+
+    err(function() {
+        expect({}).to.be.sealed;
+    }, 'expected {} to be sealed');
+
+    err(function() {
+        expect(sealedObject).to.not.be.sealed;
+    }, 'expected {} to not be sealed');
+  });
+
 });

--- a/test/should.js
+++ b/test/should.js
@@ -939,4 +939,19 @@ describe('should', function() {
      }, 'expected {} to not be extensible');
   });
 
+  it('sealed', function() {
+    var sealedObject = Object.seal({});
+
+    sealedObject.should.be.sealed;
+    ({}).should.not.be.sealed;
+
+    err(function() {
+      ({}).should.be.sealed;
+    }, 'expected {} to be sealed');
+
+    err(function() {
+      sealedObject.should.not.be.sealed;
+    }, 'expected {} to not be sealed');
+  });
+
 });

--- a/test/should.js
+++ b/test/should.js
@@ -923,4 +923,20 @@ describe('should', function() {
     incFn.should.not.decrease(obj, 'value');
     decFn.should.decrease(obj, 'value');
   });
+
+  it('extensible', function() {
+     var nonExtensibleObject = Object.preventExtensions({});
+
+     ({}).should.be.extensible;
+     nonExtensibleObject.should.not.be.extensible;
+
+     err(function() {
+       nonExtensibleObject.should.be.extensible;
+     }, 'expected {} to be extensible');
+
+     err(function() {
+       ({}).should.not.be.extensible;
+     }, 'expected {} to not be extensible');
+  });
+
 });

--- a/test/should.js
+++ b/test/should.js
@@ -954,4 +954,18 @@ describe('should', function() {
     }, 'expected {} to not be sealed');
   });
 
+  it('frozen', function() {
+    var frozenObject = Object.freeze({});
+
+    frozenObject.should.be.frozen;
+    ({}).should.not.be.frozen;
+
+    err(function() {
+        ({}).should.be.frozen;
+    }, 'expected {} to be frozen');
+
+    err(function() {
+        frozenObject.should.not.be.frozen;
+    }, 'expected {} to not be frozen');
+  });
 });


### PR DESCRIPTION
Thin assertions to test if objects are extensible, sealed, or frozen with [`Object.isExtensible()`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/isExtensible), [`Object.isSealed()`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/isSealed), and [`Object.isFrozen()`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/isFrozen). Closes #478.

```javascript
var nonExtensibleObject = Object.preventExtensions({});
var sealedObject = Object.seal({});
var frozenObject = Object.freeze({});

/**
 * Extensible
 */

assert.extensible({});
assert.notExtensible(nonExtensibleObject);
assert.notExtensible(sealedObject);
assert.notExtensible(frozenObject);

expect({}).to.be.extensible;
expect(nonExtensibleObject).to.not.be.extensible;
expect(sealedObject).to.not.be.extensible;
expect(frozenObject).to.not.be.extensible;

({}).should.be.extensible
nonExtensibleObject.should.not.be.extensible;
sealedObject.should.not.be.extensible;
frozenObject.should.not.be.extensible;

/**
 * Sealed
 */

assert.sealed(sealedObject);
assert.sealed(frozenObject);
assert.notSealed({});

expect(sealedObject).to.be.sealed;
expect(frozenObject).to.be.sealed;
expect({}).to.not.be.sealed;

sealedObject.should.be.sealed;
frozenObject.should.be.sealed;
({}).should.not.be.sealed;

/**
 * Frozen
 */

assert.frozen(frozenObject);
assert.notFrozen({});

expect(frozenObject).to.be.frozen;
expect({}).to.not.be.frozen;

frozenObject.should.be.frozen;
({}).should.not.be.frozen;
```

(I did my best to adhere to the already-established code and test style, but if there's something I didn't get quite right or something I could make better, let me know.)