### PR TITLE
Added tests and expectations for NaN. Ex: `expect(4).not.to.be.NaN;`

### DIFF
--- a/lib/chai/core/assertions.js
+++ b/lib/chai/core/assertions.js
@@ -332,6 +332,25 @@ module.exports = function (chai, _) {
   });
 
   /**
+   * ### .NaN
+   * Asserts that the target is `NaN`.
+   *
+   *     expect('foo').to.be.NaN;
+   *     expect(4).not.to.be.NaN;
+   *
+   * @name NaN
+   * @api public
+   */
+
+  Assertion.addProperty('NaN', function () {
+    this.assert(
+        isNaN(flag(this, 'object'))
+        , 'expected #{this} to be NaN'
+        , 'expected #{this} not to be NaN'
+    );
+  });
+
+  /**
    * ### .exist
    *
    * Asserts that the target is neither `null` nor `undefined`.

--- a/lib/chai/interface/assert.js
+++ b/lib/chai/interface/assert.js
@@ -331,6 +331,37 @@ module.exports = function (chai, util) {
   };
 
   /**
+   * ### .isNaN
+   * Asserts that value is NaN
+   *
+   *    assert.isNaN('foo', 'foo is NaN');
+   *
+   * @name isNaN
+   * @param {Mixed} value
+   * @param {String} message
+   * @api public
+   */
+
+  assert.isNaN = function (val, msg) {
+    new Assertion(val, msg).to.be.NaN;
+  };
+
+  /**
+   * ### .isNotNaN
+   * Asserts that value is not NaN
+   *
+   *    assert.isNotNaN(4, '4 is not NaN');
+   *
+   * @name isNotNaN
+   * @param {Mixed} value
+   * @param {String} message
+   * @api public
+   */
+  assert.isNotNaN = function (val, msg) {
+    new Assertion(val, msg).not.to.be.NaN;
+  };
+
+  /**
    * ### .isUndefined(value, [message])
    *
    * Asserts that `value` is `undefined`.

--- a/test/assert.js
+++ b/test/assert.js
@@ -281,6 +281,22 @@ describe('assert', function () {
     }, "expected null to not equal null");
   });
 
+  it('isNaN', function() {
+    assert.isNaN('hello');
+
+    err(function (){
+      assert.isNaN(4);
+    }, "expected 4 to be NaN");
+  });
+
+  it('isNotNaN', function() {
+    assert.isNotNaN(4);
+
+    err(function (){
+      assert.isNotNaN('hello');
+    }, "expected 'hello' not to be NaN");
+  });
+
   it('isUndefined', function() {
     assert.isUndefined(undefined);
 

--- a/test/expect.js
+++ b/test/expect.js
@@ -399,6 +399,26 @@ describe('expect', function () {
     }, "expected { foo: \'bar\' } to be empty");
   });
 
+  it('NaN', function() {
+    expect(NaN).to.be.NaN;
+    expect('foo').to.be.NaN;
+    expect({}).to.be.NaN;
+    expect(4).not.to.be.NaN;
+    expect([]).not.to.be.NaN;
+
+    err(function(){
+      expect(4).to.be.NaN;
+    }, "expected 4 to be NaN");
+
+    err(function(){
+      expect([]).to.be.NaN;
+    }, "expected [] to be NaN");
+
+    err(function(){
+      expect('foo').not.to.be.NaN;
+    }, "expected 'foo' not to be NaN");
+  });
+
   it('property(name)', function(){
     expect('test').to.have.property('length');
     expect(4).to.not.have.property('length');

--- a/test/should.js
+++ b/test/should.js
@@ -101,6 +101,15 @@ describe('should', function() {
     }, "expected '' to be null")
   });
 
+  it('NaN', function(){
+    'foo'.should.be.NaN;
+    (4).should.not.be.NaN;
+
+    err(function(){
+      (4).should.be.NaN;
+    }, "expected 4 to be NaN")
+  });
+
   it('undefined', function(){
     (0).should.not.be.undefined;
 


### PR DESCRIPTION
Added support for NaN as per @keithamus comment on issue #477

I agree. I think the `to.be.NaN;` structure is what makes the most sense for this issue.