### PR TITLE
Fixing a typo in the `getProperties()` utility

### DIFF
--- a/lib/chai/utils/getProperties.js
+++ b/lib/chai/utils/getProperties.js
@@ -17,7 +17,7 @@
  */
 
 module.exports = function getProperties(object) {
-  var result = Object.getOwnPropertyNames(subject);
+  var result = Object.getOwnPropertyNames(object);
 
   function addProperty(property) {
     if (result.indexOf(property) === -1) {
@@ -25,7 +25,7 @@ module.exports = function getProperties(object) {
     }
   }
 
-  var proto = Object.getPrototypeOf(subject);
+  var proto = Object.getPrototypeOf(object);
   while (proto !== null) {
     Object.getOwnPropertyNames(proto).forEach(addProperty);
     proto = Object.getPrototypeOf(proto);


### PR DESCRIPTION
The `subject` should apparently be `object`.

My apologies for creating a new pull request..the last one disappeared due to me resetting my master branch. Previous PR is here: #483 

As requested, I rebased all my commits and removed the `chai.js` build. I think it would be helpful to add these guidelines to the README file, since I saw quite a few people running into these when opening PRs.