### PR TITLE
Various work on aliases

### DIFF
--- a/lib/chai/interface/assert.js
+++ b/lib/chai/interface/assert.js
@@ -72,6 +72,7 @@ module.exports = function (chai, util) {
    *     assert.ok(false, 'this will fail');
    *
    * @name ok
+   * @alias isOk
    * @param {Mixed} object to test
    * @param {String} message
    * @api public
@@ -90,6 +91,7 @@ module.exports = function (chai, util) {
    *     assert.notOk(false, 'this will pass');
    *
    * @name notOk
+   * @alias isNotOk
    * @param {Mixed} object to test
    * @param {String} message
    * @api public
@@ -1423,6 +1425,8 @@ module.exports = function (chai, util) {
     assert[as] = assert[name];
     return alias;
   })
+  ('ok', 'isOk')
+  ('notOk', 'isNotOk')
   ('Throw', 'throw')
   ('Throw', 'throws')
   ('extensible', 'isExtensible')

--- a/lib/chai/interface/assert.js
+++ b/lib/chai/interface/assert.js
@@ -1277,7 +1277,7 @@ module.exports = function (chai, util) {
    * ### .ifError(object)
    *
    * Asserts if value is not a false value, and throws if it is a true value.
-   * This is added to allow for chai to be a drop-in replacement for Node's 
+   * This is added to allow for chai to be a drop-in replacement for Node's
    * assert class.
    *
    *     var err = new Error('I am a custom error');
@@ -1302,6 +1302,7 @@ module.exports = function (chai, util) {
    *     assert.extensible({});
    *
    * @name extensible
+   * @alias isExtensible
    * @param {Object} object
    * @param {String} message _optional_
    * @api public
@@ -1325,6 +1326,7 @@ module.exports = function (chai, util) {
    *     assert.notExtensible(frozenObject);
    *
    * @name notExtensible
+   * @alias isNotExtensible
    * @param {Object} object
    * @param {String} message _optional_
    * @api public
@@ -1347,6 +1349,7 @@ module.exports = function (chai, util) {
    *     assert.sealed(frozenObject);
    *
    * @name sealed
+   * @alias isSealed
    * @param {Object} object
    * @param {String} message _optional_
    * @api public
@@ -1364,6 +1367,7 @@ module.exports = function (chai, util) {
    *     assert.notSealed({});
    *
    * @name notSealed
+   * @alias isNotSealed
    * @param {Object} object
    * @param {String} message _optional_
    * @api public
@@ -1383,6 +1387,7 @@ module.exports = function (chai, util) {
    *     assert.frozen(frozenObject);
    *
    * @name frozen
+   * @alias isFrozen
    * @param {Object} object
    * @param {String} message _optional_
    * @api public
@@ -1400,6 +1405,7 @@ module.exports = function (chai, util) {
    *     assert.notFrozen({});
    *
    * @name notFrozen
+   * @alias isNotFrozen
    * @param {Object} object
    * @param {String} message _optional_
    * @api public
@@ -1418,5 +1424,11 @@ module.exports = function (chai, util) {
     return alias;
   })
   ('Throw', 'throw')
-  ('Throw', 'throws');
+  ('Throw', 'throws')
+  ('extensible', 'isExtensible')
+  ('notExtensible', 'isNotExtensible')
+  ('sealed', 'isSealed')
+  ('notSealed', 'isNotSealed')
+  ('frozen', 'isFrozen')
+  ('notFrozen', 'isNotFrozen');
 };

--- a/lib/chai/interface/assert.js
+++ b/lib/chai/interface/assert.js
@@ -1399,7 +1399,7 @@ module.exports = function (chai, util) {
    *
    *     assert.notFrozen({});
    *
-   * @name notSealed
+   * @name notFrozen
    * @param {Object} object
    * @param {String} message _optional_
    * @api public

--- a/lib/chai/interface/assert.js
+++ b/lib/chai/interface/assert.js
@@ -64,40 +64,40 @@ module.exports = function (chai, util) {
   };
 
   /**
-   * ### .ok(object, [message])
+   * ### .isOk(object, [message])
    *
    * Asserts that `object` is truthy.
    *
-   *     assert.ok('everything', 'everything is ok');
-   *     assert.ok(false, 'this will fail');
+   *     assert.isOk('everything', 'everything is ok');
+   *     assert.isOk(false, 'this will fail');
    *
-   * @name ok
-   * @alias isOk
+   * @name isOk
+   * @alias ok
    * @param {Mixed} object to test
    * @param {String} message
    * @api public
    */
 
-  assert.ok = function (val, msg) {
+  assert.isOk = function (val, msg) {
     new Assertion(val, msg).is.ok;
   };
 
   /**
-   * ### .notOk(object, [message])
+   * ### .isNotOk(object, [message])
    *
    * Asserts that `object` is falsy.
    *
-   *     assert.notOk('everything', 'this will fail');
-   *     assert.notOk(false, 'this will pass');
+   *     assert.isNotOk('everything', 'this will fail');
+   *     assert.isNotOk(false, 'this will pass');
    *
-   * @name notOk
-   * @alias isNotOk
+   * @name isNotOk
+   * @alias notOk
    * @param {Mixed} object to test
    * @param {String} message
    * @api public
    */
 
-  assert.notOk = function (val, msg) {
+  assert.isNotOk = function (val, msg) {
     new Assertion(val, msg).is.not.ok;
   };
 
@@ -1297,25 +1297,25 @@ module.exports = function (chai, util) {
   };
 
   /**
-   * ### .extensible(object)
+   * ### .isExtensible(object)
    *
    * Asserts that `object` is extensible (can have new properties added to it).
    *
-   *     assert.extensible({});
+   *     assert.isExtensible({});
    *
-   * @name extensible
-   * @alias isExtensible
+   * @name isExtensible
+   * @alias extensible
    * @param {Object} object
    * @param {String} message _optional_
    * @api public
    */
 
-  assert.extensible = function (obj, msg) {
+  assert.isExtensible = function (obj, msg) {
     new Assertion(obj, msg).to.be.extensible;
   };
 
   /**
-   * ### .notExtensible(object)
+   * ### .isNotExtensible(object)
    *
    * Asserts that `object` is _not_ extensible.
    *
@@ -1323,23 +1323,23 @@ module.exports = function (chai, util) {
    *     var sealedObject = Object.seal({});
    *     var frozenObject = Object.freese({});
    *
-   *     assert.notExtensible(nonExtensibleObject);
-   *     assert.notExtensible(sealedObject);
-   *     assert.notExtensible(frozenObject);
+   *     assert.isNotExtensible(nonExtensibleObject);
+   *     assert.isNotExtensible(sealedObject);
+   *     assert.isNotExtensible(frozenObject);
    *
-   * @name notExtensible
-   * @alias isNotExtensible
+   * @name isNotExtensible
+   * @alias notExtensible
    * @param {Object} object
    * @param {String} message _optional_
    * @api public
    */
 
-  assert.notExtensible = function (obj, msg) {
+  assert.isNotExtensible = function (obj, msg) {
     new Assertion(obj, msg).to.not.be.extensible;
   };
 
   /**
-   * ### .sealed(object)
+   * ### .isSealed(object)
    *
    * Asserts that `object` is sealed (cannot have new properties added to it
    * and its existing properties cannot be removed).
@@ -1347,40 +1347,40 @@ module.exports = function (chai, util) {
    *     var sealedObject = Object.seal({});
    *     var frozenObject = Object.seal({});
    *
-   *     assert.sealed(sealedObject);
-   *     assert.sealed(frozenObject);
+   *     assert.isSealed(sealedObject);
+   *     assert.isSealed(frozenObject);
    *
-   * @name sealed
-   * @alias isSealed
+   * @name isSealed
+   * @alias sealed
    * @param {Object} object
    * @param {String} message _optional_
    * @api public
    */
 
-  assert.sealed = function (obj, msg) {
+  assert.isSealed = function (obj, msg) {
     new Assertion(obj, msg).to.be.sealed;
   };
 
   /**
-   * ### .notSealed(object)
+   * ### .isNotSealed(object)
    *
    * Asserts that `object` is _not_ sealed.
    *
-   *     assert.notSealed({});
+   *     assert.isNotSealed({});
    *
-   * @name notSealed
-   * @alias isNotSealed
+   * @name isNotSealed
+   * @alias notSealed
    * @param {Object} object
    * @param {String} message _optional_
    * @api public
    */
 
-  assert.notSealed = function (obj, msg) {
+  assert.isNotSealed = function (obj, msg) {
     new Assertion(obj, msg).to.not.be.sealed;
   };
 
   /**
-   * ### .frozen(object)
+   * ### .isFrozen(object)
    *
    * Asserts that `object` is frozen (cannot have new properties added to it
    * and its existing properties cannot be modified).
@@ -1388,32 +1388,32 @@ module.exports = function (chai, util) {
    *     var frozenObject = Object.freeze({});
    *     assert.frozen(frozenObject);
    *
-   * @name frozen
-   * @alias isFrozen
+   * @name isFrozen
+   * @alias frozen
    * @param {Object} object
    * @param {String} message _optional_
    * @api public
    */
 
-  assert.frozen = function (obj, msg) {
+  assert.isFrozen = function (obj, msg) {
     new Assertion(obj, msg).to.be.frozen;
   };
 
   /**
-   * ### .notFrozen(object)
+   * ### .isNotFrozen(object)
    *
    * Asserts that `object` is _not_ frozen.
    *
-   *     assert.notFrozen({});
+   *     assert.isNotFrozen({});
    *
-   * @name notFrozen
-   * @alias isNotFrozen
+   * @name isNotFrozen
+   * @alias notFrozen
    * @param {Object} object
    * @param {String} message _optional_
    * @api public
    */
 
-  assert.notFrozen = function (obj, msg) {
+  assert.isNotFrozen = function (obj, msg) {
     new Assertion(obj, msg).to.not.be.frozen;
   };
 
@@ -1425,14 +1425,14 @@ module.exports = function (chai, util) {
     assert[as] = assert[name];
     return alias;
   })
-  ('ok', 'isOk')
-  ('notOk', 'isNotOk')
+  ('isOk', 'ok')
+  ('isNotOk', 'notOk')
   ('throws', 'throw')
   ('throws', 'Throw')
-  ('extensible', 'isExtensible')
-  ('notExtensible', 'isNotExtensible')
-  ('sealed', 'isSealed')
-  ('notSealed', 'isNotSealed')
-  ('frozen', 'isFrozen')
-  ('notFrozen', 'isNotFrozen');
+  ('isExtensible', 'extensible')
+  ('isNotExtensible', 'notExtensible')
+  ('isSealed', 'sealed')
+  ('isNotSealed', 'notSealed')
+  ('isFrozen', 'frozen')
+  ('isNotFrozen', 'notFrozen');
 };

--- a/lib/chai/interface/assert.js
+++ b/lib/chai/interface/assert.js
@@ -966,11 +966,11 @@ module.exports = function (chai, util) {
    * `constructor`, or alternately that it will throw an error with message
    * matching `regexp`.
    *
-   *     assert.throw(fn, 'function throws a reference error');
-   *     assert.throw(fn, /function throws a reference error/);
-   *     assert.throw(fn, ReferenceError);
-   *     assert.throw(fn, ReferenceError, 'function throws a reference error');
-   *     assert.throw(fn, ReferenceError, /function throws a reference error/);
+   *     assert.throws(fn, 'function throws a reference error');
+   *     assert.throws(fn, /function throws a reference error/);
+   *     assert.throws(fn, ReferenceError);
+   *     assert.throws(fn, ReferenceError, 'function throws a reference error');
+   *     assert.throws(fn, ReferenceError, /function throws a reference error/);
    *
    * @name throws
    * @alias throw
@@ -983,13 +983,13 @@ module.exports = function (chai, util) {
    * @api public
    */
 
-  assert.Throw = function (fn, errt, errs, msg) {
+  assert.throws = function (fn, errt, errs, msg) {
     if ('string' === typeof errt || errt instanceof RegExp) {
       errs = errt;
       errt = null;
     }
 
-    var assertErr = new Assertion(fn, msg).to.Throw(errt, errs);
+    var assertErr = new Assertion(fn, msg).to.throw(errt, errs);
     return flag(assertErr, 'object');
   };
 
@@ -1427,8 +1427,8 @@ module.exports = function (chai, util) {
   })
   ('ok', 'isOk')
   ('notOk', 'isNotOk')
-  ('Throw', 'throw')
-  ('Throw', 'throws')
+  ('throws', 'throw')
+  ('throws', 'Throw')
   ('extensible', 'isExtensible')
   ('notExtensible', 'isNotExtensible')
   ('sealed', 'isSealed')

--- a/test/assert.js
+++ b/test/assert.js
@@ -513,44 +513,46 @@ describe('assert', function () {
     }, "expected { foo: { bar: 'baz' } } to not have a deep property 'foo.bar' of 'baz'");
   });
 
-  it('throws', function() {
-    assert.throws(function() { throw new Error('foo'); });
-    assert.throws(function() { throw new Error('bar'); }, 'bar');
-    assert.throws(function() { throw new Error('bar'); }, /bar/);
-    assert.throws(function() { throw new Error('bar'); }, Error);
-    assert.throws(function() { throw new Error('bar'); }, Error, 'bar');
+  it('throws / throw / Throw', function() {
+    ['throws', 'throw', 'Throw'].forEach(function (throws) {
+      assert[throws](function() { throw new Error('foo'); });
+      assert[throws](function() { throw new Error('bar'); }, 'bar');
+      assert[throws](function() { throw new Error('bar'); }, /bar/);
+      assert[throws](function() { throw new Error('bar'); }, Error);
+      assert[throws](function() { throw new Error('bar'); }, Error, 'bar');
 
-    var thrownErr = assert.throws(function() { throw new Error('foo'); });
-    assert(thrownErr instanceof Error, 'assert.throws returns error');
-    assert(thrownErr.message === 'foo', 'assert.throws returns error message');
+      var thrownErr = assert[throws](function() { throw new Error('foo'); });
+      assert(thrownErr instanceof Error, 'assert.' + throws + ' returns error');
+      assert(thrownErr.message === 'foo', 'assert.' + throws + ' returns error message');
 
-    err(function () {
-      assert.throws(function() { throw new Error('foo') }, TypeError);
-     }, "expected [Function] to throw 'TypeError' but 'Error: foo' was thrown")
+      err(function () {
+        assert[throws](function() { throw new Error('foo') }, TypeError);
+       }, "expected [Function] to throw 'TypeError' but 'Error: foo' was thrown")
 
-    err(function () {
-      assert.throws(function() { throw new Error('foo') }, 'bar');
-     }, "expected [Function] to throw error including 'bar' but got 'foo'")
+      err(function () {
+        assert[throws](function() { throw new Error('foo') }, 'bar');
+       }, "expected [Function] to throw error including 'bar' but got 'foo'")
 
-    err(function () {
-      assert.throws(function() { throw new Error('foo') }, Error, 'bar');
-     }, "expected [Function] to throw error including 'bar' but got 'foo'")
+      err(function () {
+        assert[throws](function() { throw new Error('foo') }, Error, 'bar');
+       }, "expected [Function] to throw error including 'bar' but got 'foo'")
 
-    err(function () {
-      assert.throws(function() { throw new Error('foo') }, TypeError, 'bar');
-     }, "expected [Function] to throw 'TypeError' but 'Error: foo' was thrown")
+      err(function () {
+        assert[throws](function() { throw new Error('foo') }, TypeError, 'bar');
+       }, "expected [Function] to throw 'TypeError' but 'Error: foo' was thrown")
 
-    err(function () {
-      assert.throws(function() {});
-     }, "expected [Function] to throw an error");
+      err(function () {
+        assert[throws](function() {});
+       }, "expected [Function] to throw an error");
 
-    err(function () {
-        assert.throws(function() { throw new Error('') }, 'bar');
-    }, "expected [Function] to throw error including 'bar' but got ''");
+      err(function () {
+          assert[throws](function() { throw new Error('') }, 'bar');
+      }, "expected [Function] to throw error including 'bar' but got ''");
 
-    err(function () {
-        assert.throws(function() { throw new Error('') }, /bar/);
-    }, "expected [Function] to throw error matching /bar/ but got ''");
+      err(function () {
+          assert[throws](function() { throw new Error('') }, /bar/);
+      }, "expected [Function] to throw error matching /bar/ but got ''");
+    });
   });
 
   it('doesNotThrow', function() {

--- a/test/assert.js
+++ b/test/assert.js
@@ -36,40 +36,44 @@ describe('assert', function () {
     }, "expected 'test' to be true");
   });
 
-  it('ok', function () {
-    assert.ok(true);
-    assert.ok(1);
-    assert.ok('test');
+  it('isOk / ok', function () {
+    ['isOk', 'ok'].forEach(function (isOk) {
+      assert[isOk](true);
+      assert[isOk](1);
+      assert[isOk]('test');
 
-    err(function () {
-      assert.ok(false);
-    }, "expected false to be truthy");
+      err(function () {
+        assert[isOk](false);
+      }, "expected false to be truthy");
 
-    err(function () {
-      assert.ok(0);
-    }, "expected 0 to be truthy");
+      err(function () {
+        assert[isOk](0);
+      }, "expected 0 to be truthy");
 
-    err(function () {
-      assert.ok('');
-    }, "expected '' to be truthy");
+      err(function () {
+        assert[isOk]('');
+      }, "expected '' to be truthy");
+    });
   });
 
-  it('notOk', function () {
-    assert.notOk(false);
-    assert.notOk(0);
-    assert.notOk('');
+  it('isNotOk, notOk', function () {
+    ['isNotOk', 'notOk'].forEach(function (isNotOk) {
+      assert[isNotOk](false);
+      assert[isNotOk](0);
+      assert[isNotOk]('');
 
-    err(function () {
-      assert.notOk(true);
-    }, "expected true to be falsy");
+      err(function () {
+        assert[isNotOk](true);
+      }, "expected true to be falsy");
 
-    err(function () {
-      assert.notOk(1);
-    }, "expected 1 to be falsy");
+      err(function () {
+        assert[isNotOk](1);
+      }, "expected 1 to be falsy");
 
-    err(function () {
-      assert.notOk('test');
-    }, "expected 'test' to be falsy");
+      err(function () {
+        assert[isNotOk]('test');
+      }, "expected 'test' to be falsy");
+    });
   });
 
   it('isFalse', function () {

--- a/test/assert.js
+++ b/test/assert.js
@@ -89,7 +89,7 @@ describe('assert', function () {
     assert.equal(foo, undefined);
   });
 
-  it('typeof / notTypeOf', function () {
+  it('typeof', function () {
     assert.typeOf('test', 'string');
     assert.typeOf(true, 'boolean');
     assert.typeOf(5, 'number');
@@ -754,64 +754,75 @@ describe('assert', function () {
     assert.doesNotIncrease(smFn, obj, 'value');
   });
 
-  it('extensible', function() {
-    var nonExtensibleObject = Object.preventExtensions({});
+  it('isExtensible / extensible', function() {
+    ['isExtensible', 'extensible'].forEach(function (isExtensible) {
+      var nonExtensibleObject = Object.preventExtensions({});
 
-    assert.extensible({});
+      assert[isExtensible]({});
 
-    err(function() {
-      assert.extensible(nonExtensibleObject);
-    }, 'expected {} to be extensible');
+      err(function() {
+        assert[isExtensible](nonExtensibleObject);
+      }, 'expected {} to be extensible');
+    });
   });
 
-  it('notExtensible', function() {
-    var nonExtensibleObject = Object.preventExtensions({});
+  it('isNotExtensible / notExtensible', function() {
+    ['isNotExtensible', 'notExtensible'].forEach(function (isNotExtensible) {
+      var nonExtensibleObject = Object.preventExtensions({});
 
-    assert.notExtensible(nonExtensibleObject);
+      assert[isNotExtensible](nonExtensibleObject);
 
-    err(function() {
-      assert.notExtensible({});
-    }, 'expected {} to not be extensible');
+      err(function() {
+        assert[isNotExtensible]({});
+      }, 'expected {} to not be extensible');
+    });
   });
 
-  it('sealed', function() {
-    var sealedObject = Object.seal({});
+  it('isSealed / sealed', function() {
+    ['isSealed', 'sealed'].forEach(function (isSealed) {
+      var sealedObject = Object.seal({});
 
-    assert.sealed(sealedObject);
+      assert[isSealed](sealedObject);
 
-    err(function() {
-      assert.sealed({});
-    }, 'expected {} to be sealed');
+      err(function() {
+        assert[isSealed]({});
+      }, 'expected {} to be sealed');
+    });
   });
 
-  it('notSealed', function() {
-    var sealedObject = Object.seal({});
+  it('isNotSealed / notSealed', function() {
+    ['isNotSealed', 'notSealed'].forEach(function (isNotSealed) {
+      var sealedObject = Object.seal({});
 
-    assert.notSealed({});
+      assert[isNotSealed]({});
 
-    err(function() {
-      assert.notSealed(sealedObject);
-    }, 'expected {} to not be sealed');
+      err(function() {
+        assert[isNotSealed](sealedObject);
+      }, 'expected {} to not be sealed');
+    });
   });
 
-  it('frozen', function() {
-    var frozenObject = Object.freeze({});
+  it('isFrozen / frozen', function() {
+    ['isFrozen', 'frozen'].forEach(function (isFrozen) {
+      var frozenObject = Object.freeze({});
 
-    assert.frozen(frozenObject);
+      assert[isFrozen](frozenObject);
 
-    err(function() {
-      assert.frozen({});
-    }, 'expected {} to be frozen');
+      err(function() {
+        assert[isFrozen]({});
+      }, 'expected {} to be frozen');
+    });
   });
 
-  it('notFrozen', function() {
-    var frozenObject = Object.freeze({});
+  it('isNotFrozen / notFrozen', function() {
+    ['isNotFrozen', 'notFrozen'].forEach(function (isNotFrozen) {
+      var frozenObject = Object.freeze({});
 
-    assert.notFrozen({});
+      assert[isNotFrozen]({});
 
-    err(function() {
-      assert.notFrozen(frozenObject);
-    }, 'expected {} to not be frozen');
+      err(function() {
+        assert[isNotFrozen](frozenObject);
+      }, 'expected {} to not be frozen');
+    });
   });
-
 });


### PR DESCRIPTION
Here is what this PR does:

- Add `is*` aliases for `extensible`, `notExtensible`, `sealed`, `notSealed`, `frozen`, `notFrozen` and update their respective tests to test the aliases
- Add `is*` aliases for `ok` and `notOk` and update their respective tests to test the aliases
- Make the use of `throws` consistent: before these changes, the name of the assertion in the documentation was `throws`, the examples were using `throw` and the code was using `Throw`. Now it's `throws` everywhere and the rest is aliases
- Add tests for aliases of `throws` (`throw` and `Throw`)
- Since we already had `isTrue`, `isNull`, `isObject`, `isBoolean`, ... (20 in total), I made the `is*` aliases the authoritative source, and kept the original ones as aliases for backward-compatibility. For example, `isOk` should be the "official" version (like `isTrue`), but `ok` still exists. If I am not committing any typo, nothing in the API will be broken, just the way it's presented is more consistent.

This PR doesn't update the main `chai.js` file.