### PR TITLE
Make sure TypeErrors thrown by frozen are caught

### DIFF
--- a/lib/chai/core/assertions.js
+++ b/lib/chai/core/assertions.js
@@ -1719,11 +1719,24 @@ module.exports = function (chai, _) {
   Assertion.addProperty('frozen', function() {
     var obj = flag(this, 'object');
 
+    // In ES5, if the argument to this method is not an object (a primitive), then it will cause a TypeError.
+    // In ES6, a non-object argument will be treated as if it was a frozen ordinary object, simply return true.
+    // See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/isFrozen
+    // The following provides ES6 behavior when a TypeError is thrown under ES5.
+
+    var isFrozen;
+
+    try {
+      isFrozen = Object.isFrozen(obj);
+    } catch (err) {
+      if (err instanceof TypeError) isFrozen = true;
+      else throw err;
+    }
+
     this.assert(
-      Object.isFrozen(obj)
+      isFrozen
       , 'expected #{this} to be frozen'
       , 'expected #{this} to not be frozen'
     );
   });
-
 };

--- a/lib/chai/core/assertions.js
+++ b/lib/chai/core/assertions.js
@@ -1694,8 +1694,22 @@ module.exports = function (chai, _) {
   Assertion.addProperty('sealed', function() {
     var obj = flag(this, 'object');
 
+    // In ES5, if the argument to this method is not an object (a primitive), then it will cause a TypeError.
+    // In ES6, a non-object argument will be treated as if it was a sealed ordinary object, simply return true.
+    // See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/isSealed
+    // The following provides ES6 behavior when a TypeError is thrown under ES5.
+
+    var isSealed;
+
+    try {
+      isSealed = Object.isSealed(obj);
+    } catch (err) {
+      if (err instanceof TypeError) isSealed = true;
+      else throw err;
+    }
+
     this.assert(
-      Object.isSealed(obj)
+      isSealed
       , 'expected #{this} to be sealed'
       , 'expected #{this} to not be sealed'
     );

--- a/lib/chai/core/assertions.js
+++ b/lib/chai/core/assertions.js
@@ -1667,8 +1667,22 @@ module.exports = function (chai, _) {
   Assertion.addProperty('extensible', function() {
     var obj = flag(this, 'object');
 
+    // In ES5, if the argument to this method is not an object (a primitive), then it will cause a TypeError.
+    // In ES6, a non-object argument will be treated as if it was a non-extensible ordinary object, simply return false.
+    // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/isExtensible
+    // The following provides ES6 behavior when a TypeError is thrown under ES5.
+
+    var isExtensible;
+
+    try {
+      isExtensible = Object.isExtensible(obj);
+    } catch (err) {
+      if (err instanceof TypeError) isExtensible = false;
+      else throw err;
+    }
+
     this.assert(
-      Object.isExtensible(obj)
+      isExtensible
       , 'expected #{this} to be extensible'
       , 'expected #{this} to not be extensible'
     );

--- a/lib/chai/core/assertions.js
+++ b/lib/chai/core/assertions.js
@@ -1438,7 +1438,7 @@ module.exports = function (chai, _) {
       , result
     );
   }
-  
+
   Assertion.addMethod('satisfy', satisfy);
   Assertion.addMethod('satisfies', satisfy);
 
@@ -1648,7 +1648,7 @@ module.exports = function (chai, _) {
   /**
    * ### .extensible
    *
-   * Asserts that the target is extensible (can have new properties added to 
+   * Asserts that the target is extensible (can have new properties added to
    * it).
    *
    *     var nonExtensibleObject = Object.preventExtensions({});

--- a/test/assert.js
+++ b/test/assert.js
@@ -833,6 +833,14 @@ describe('assert', function () {
       err(function() {
         assert[isFrozen]({});
       }, 'expected {} to be frozen');
+
+      // Making sure ES6-like Object.isFrozen response is respected for all primitive types
+
+      assert[isFrozen](42);
+      assert[isFrozen](null);
+      assert[isFrozen]('foo');
+      assert[isFrozen](false);
+      assert[isFrozen](undefined);
     });
   });
 
@@ -845,6 +853,28 @@ describe('assert', function () {
       err(function() {
         assert[isNotFrozen](frozenObject);
       }, 'expected {} to not be frozen');
+
+      // Making sure ES6-like Object.isFrozen response is respected for all primitive types
+
+      err(function() {
+        assert[isNotFrozen](42);
+      }, 'expected 42 to not be frozen');
+
+      err(function() {
+        assert[isNotFrozen](null);
+      }, 'expected null to not be frozen');
+
+      err(function() {
+        assert[isNotFrozen]('foo');
+      }, 'expected \'foo\' to not be frozen');
+
+      err(function() {
+        assert[isNotFrozen](false);
+      }, 'expected false to not be frozen');
+
+      err(function() {
+        assert[isNotFrozen](undefined);
+      }, 'expected undefined to not be frozen');
     });
   });
 });

--- a/test/assert.js
+++ b/test/assert.js
@@ -785,6 +785,28 @@ describe('assert', function () {
       err(function() {
         assert[isExtensible](nonExtensibleObject);
       }, 'expected {} to be extensible');
+
+      // Making sure ES6-like Object.isExtensible response is respected for all primitive types
+
+      err(function() {
+        assert[isExtensible](42);
+      }, 'expected 42 to be extensible');
+
+      err(function() {
+        assert[isExtensible](null);
+      }, 'expected null to be extensible');
+
+      err(function() {
+        assert[isExtensible]('foo');
+      }, 'expected \'foo\' to be extensible');
+
+      err(function() {
+        assert[isExtensible](false);
+      }, 'expected false to be extensible');
+
+      err(function() {
+        assert[isExtensible](undefined);
+      }, 'expected undefined to be extensible');
     });
   });
 
@@ -797,6 +819,14 @@ describe('assert', function () {
       err(function() {
         assert[isNotExtensible]({});
       }, 'expected {} to not be extensible');
+
+      // Making sure ES6-like Object.isExtensible response is respected for all primitive types
+
+      assert[isNotExtensible](42);
+      assert[isNotExtensible](null);
+      assert[isNotExtensible]('foo');
+      assert[isNotExtensible](false);
+      assert[isNotExtensible](undefined);
     });
   });
 

--- a/test/assert.js
+++ b/test/assert.js
@@ -809,6 +809,14 @@ describe('assert', function () {
       err(function() {
         assert[isSealed]({});
       }, 'expected {} to be sealed');
+
+      // Making sure ES6-like Object.isSealed response is respected for all primitive types
+
+      assert[isSealed](42);
+      assert[isSealed](null);
+      assert[isSealed]('foo');
+      assert[isSealed](false);
+      assert[isSealed](undefined);
     });
   });
 
@@ -821,6 +829,28 @@ describe('assert', function () {
       err(function() {
         assert[isNotSealed](sealedObject);
       }, 'expected {} to not be sealed');
+
+      // Making sure ES6-like Object.isSealed response is respected for all primitive types
+
+      err(function() {
+        assert[isNotSealed](42);
+      }, 'expected 42 to not be sealed');
+
+      err(function() {
+        assert[isNotSealed](null);
+      }, 'expected null to not be sealed');
+
+      err(function() {
+        assert[isNotSealed]('foo');
+      }, 'expected \'foo\' to not be sealed');
+
+      err(function() {
+        assert[isNotSealed](false);
+      }, 'expected false to not be sealed');
+
+      err(function() {
+        assert[isNotSealed](undefined);
+      }, 'expected undefined to not be sealed');
     });
   });
 

--- a/test/expect.js
+++ b/test/expect.js
@@ -1093,6 +1093,34 @@ describe('expect', function () {
     err(function() {
         expect({}).to.not.be.extensible;
     }, 'expected {} to not be extensible');
+
+    // Making sure ES6-like Object.isExtensible response is respected for all primitive types
+
+    expect(42).to.not.be.extensible;
+    expect(null).to.not.be.extensible;
+    expect('foo').to.not.be.extensible;
+    expect(false).to.not.be.extensible;
+    expect(undefined).to.not.be.extensible;
+
+    err(function() {
+      expect(42).to.be.extensible;
+    }, 'expected 42 to be extensible');
+
+    err(function() {
+      expect(null).to.be.extensible;
+    }, 'expected null to be extensible');
+
+    err(function() {
+      expect('foo').to.be.extensible;
+    }, 'expected \'foo\' to be extensible');
+
+    err(function() {
+      expect(false).to.be.extensible;
+    }, 'expected false to be extensible');
+
+    err(function() {
+      expect(undefined).to.be.extensible;
+    }, 'expected undefined to be extensible');
   });
 
   it('sealed', function() {

--- a/test/expect.js
+++ b/test/expect.js
@@ -1123,6 +1123,33 @@ describe('expect', function () {
     err(function() {
         expect(frozenObject).to.not.be.frozen;
     }, 'expected {} to not be frozen');
-  });
 
+    // Making sure ES6-like Object.isFrozen response is respected for all primitive types
+
+    expect(42).to.be.frozen;
+    expect(null).to.be.frozen;
+    expect('foo').to.be.frozen;
+    expect(false).to.be.frozen;
+    expect(undefined).to.be.frozen;
+
+    err(function() {
+      expect(42).to.not.be.frozen;
+    }, 'expected 42 to not be frozen');
+
+    err(function() {
+      expect(null).to.not.be.frozen;
+    }, 'expected null to not be frozen');
+
+    err(function() {
+      expect('foo').to.not.be.frozen;
+    }, 'expected \'foo\' to not be frozen');
+
+    err(function() {
+      expect(false).to.not.be.frozen;
+    }, 'expected false to not be frozen');
+
+    err(function() {
+      expect(undefined).to.not.be.frozen;
+    }, 'expected undefined to not be frozen');
+  });
 });

--- a/test/expect.js
+++ b/test/expect.js
@@ -1108,6 +1108,34 @@ describe('expect', function () {
     err(function() {
         expect(sealedObject).to.not.be.sealed;
     }, 'expected {} to not be sealed');
+
+    // Making sure ES6-like Object.isSealed response is respected for all primitive types
+
+    expect(42).to.be.sealed;
+    expect(null).to.be.sealed;
+    expect('foo').to.be.sealed;
+    expect(false).to.be.sealed;
+    expect(undefined).to.be.sealed;
+
+    err(function() {
+      expect(42).to.not.be.sealed;
+    }, 'expected 42 to not be sealed');
+
+    err(function() {
+      expect(null).to.not.be.sealed;
+    }, 'expected null to not be sealed');
+
+    err(function() {
+      expect('foo').to.not.be.sealed;
+    }, 'expected \'foo\' to not be sealed');
+
+    err(function() {
+      expect(false).to.not.be.sealed;
+    }, 'expected false to not be sealed');
+
+    err(function() {
+      expect(undefined).to.not.be.sealed;
+    }, 'expected undefined to not be sealed');
   });
 
   it('frozen', function() {

--- a/test/should.js
+++ b/test/should.js
@@ -910,7 +910,7 @@ describe('should', function() {
         fn     = function() { obj.value += 5 },
         sameFn = function() { obj.value += 0 },
         decFn  = function() { obj.value -= 3 },
-        bangFn = function() { obj.str += '!' }; 
+        bangFn = function() { obj.str += '!' };
 
     fn.should.change(obj, 'value');
     sameFn.should.not.change(obj, 'value');

--- a/test/should.js
+++ b/test/should.js
@@ -961,6 +961,24 @@ describe('should', function() {
     err(function() {
       sealedObject.should.not.be.sealed;
     }, 'expected {} to not be sealed');
+
+    // Making sure ES6-like Object.isSealed response is respected for all primitive types
+
+    (42).should.be.sealed;
+    'foo'.should.be.sealed;
+    false.should.be.sealed;
+
+    err(function() {
+      (42).should.not.be.sealed;
+    }, 'expected 42 to not be sealed');
+
+    err(function() {
+      'foo'.should.not.be.sealed;
+    }, 'expected \'foo\' to not be sealed');
+
+    err(function() {
+      false.should.not.be.sealed;
+    }, 'expected false to not be sealed');
   });
 
   it('frozen', function() {

--- a/test/should.js
+++ b/test/should.js
@@ -946,6 +946,24 @@ describe('should', function() {
      err(function() {
        ({}).should.not.be.extensible;
      }, 'expected {} to not be extensible');
+
+     // Making sure ES6-like Object.isExtensible response is respected for all primitive types
+
+     (42).should.not.be.extensible;
+     'foo'.should.not.be.extensible;
+     false.should.not.be.extensible;
+
+     err(function() {
+       (42).should.be.extensible;
+     }, 'expected 42 to be extensible');
+
+     err(function() {
+       'foo'.should.be.extensible;
+     }, 'expected \'foo\' to be extensible');
+
+     err(function() {
+       false.should.be.extensible;
+     }, 'expected false to be extensible');
   });
 
   it('sealed', function() {

--- a/test/should.js
+++ b/test/should.js
@@ -976,5 +976,23 @@ describe('should', function() {
     err(function() {
         frozenObject.should.not.be.frozen;
     }, 'expected {} to not be frozen');
+
+    // Making sure ES6-like Object.isFrozen response is respected for all primitive types
+
+    (42).should.be.frozen;
+    'foo'.should.be.frozen;
+    false.should.be.frozen;
+
+    err(function() {
+      (42).should.not.be.frozen;
+    }, 'expected 42 to not be frozen');
+
+    err(function() {
+      'foo'.should.not.be.frozen;
+    }, 'expected \'foo\' to not be frozen');
+
+    err(function() {
+      false.should.not.be.frozen;
+    }, 'expected false to not be frozen');
   });
 });


### PR DESCRIPTION
See #491.

Example of a failure is:

```
  1) expect frozen:
     TypeError: The element must be a non-null object or an array, number given.
      at Assertion.<anonymous> (lib/chai/core/assertions.js:1733:15)
      at Assertion.Object.defineProperty.get (lib/chai/utils/addProperty.js:35:29)
      at Context.<anonymous> (test/expect.js:1129:20)
```

I would have preferred to hide the stack trace but I'm not sure one can easily do it with a `TypeError`, and in this case I think a `TypeError` makes much more sense than an `AssertionError`.

I didn't investigate much, but where is it that you manage to not show the stack trace for `AssertionError`s?