### PR TITLE
isAtLeast, isAtMost assertions added to assert interface

### DIFF
--- a/lib/chai/interface/assert.js
+++ b/lib/chai/interface/assert.js
@@ -244,6 +244,25 @@ module.exports = function (chai, util) {
   };
 
    /**
+   * ### .isAtLeast(valueToCheck, valueToBeAtLeast, [message])
+   *
+   * Asserts `valueToCheck` is greater than or equal to (>=) `valueToBeAtLeast`
+   *
+   *     assert.isAtLeast(5, 2, '5 is greater or equal to 2');
+   *     assert.isAtLeast(3, 3, '3 is greater or equal to 3');
+   *
+   * @name isAtLeast
+   * @param {Mixed} valueToCheck
+   * @param {Mixed} valueToBeAtLeast
+   * @param {String} message
+   * @api public
+   */
+
+  assert.isAtLeast = function (val, atlst, msg) {
+    new Assertion(val, msg).to.be.least(atlst);
+  };
+
+   /**
    * ### .isBelow(valueToCheck, valueToBeBelow, [message])
    *
    * Asserts `valueToCheck` is strictly less than (<) `valueToBeBelow`
@@ -259,6 +278,25 @@ module.exports = function (chai, util) {
 
   assert.isBelow = function (val, blw, msg) {
     new Assertion(val, msg).to.be.below(blw);
+  };
+
+   /**
+   * ### .isAtMost(valueToCheck, valueToBeAtMost, [message])
+   *
+   * Asserts `valueToCheck` is less than or equal to (<=) `valueToBeAtMost`
+   *
+   *     assert.isAtMost(3, 6, '3 is less than or equal to 6');
+   *     assert.isAtMost(4, 4, '4 is less than or equal to 4');
+   *
+   * @name isAtMost
+   * @param {Mixed} valueToCheck
+   * @param {Mixed} valueToBeAtMost
+   * @param {String} message
+   * @api public
+   */
+
+  assert.isAtMost = function (val, atmst, msg) {
+    new Assertion(val, msg).to.be.most(atmst);
   };
 
   /**

--- a/test/assert.js
+++ b/test/assert.js
@@ -726,6 +726,15 @@ describe('assert', function () {
     }, 'expected 1 to be above 1');
   });
 
+  it('atLeast', function() {
+    assert.isAtLeast(5, 2, '5 should be above 2');
+    assert.isAtLeast(1, 1, '1 should be equal to 1');
+
+    err(function() {
+      assert.isAtLeast(1, 3);
+    }, 'expected 1 to be at least 3');
+  });
+
   it('below', function() {
     assert.isBelow(2, 5, '2 should be below 5');
 
@@ -737,6 +746,15 @@ describe('assert', function () {
       assert.isBelow(1, 1);
     }, 'expected 1 to be below 1');
 
+  });
+
+  it('atMost', function() {
+    assert.isAtMost(2, 5, '2 should be below 5');
+    assert.isAtMost(1, 1, '1 should be equal to 1');
+
+    err(function() {
+      assert.isAtMost(3, 1);
+    }, 'expected 3 to be at most 1');
   });
 
   it('memberDeepEquals', function() {


### PR DESCRIPTION
I noticed the `assert` interface was missing these methods. One can use the `operator` method but that feels clunky. The `CONTRIBUTING.md` says to not expand the interface without asking due to possible rejection. I'm 100% fine with this being rejected if the expansion of the interface is deemed not useful. I attempted to match style best I could but there is no linter so I'm not 100% positive I've hit every point.

Also, it'd be nice if the `CONTRIBUTING.md` was expanded to discuss whether one should include an updated `chai.js` or not. I assumed not since that appeared to be part of the release process but I wasn't sure.

I went with is* for these to match the rest of the `assert`, I'm happy to rename them to something else that y'all like. I started with `most` and `least` like the `should`/`expect` interfaces but decided matching the interface I was adding them to was more important than matching what the other interfaces call them.

I also opted to not add the aliases `gte` and `lte` as there didn't appear to be any other shorthand aliases in `assert`. Happy to add those as well if those are desired.

Thanks for ChaiJS