### PR TITLE
Cause deep.have.same.members() to print a diff.

### DIFF
--- a/lib/chai/core/assertions.js
+++ b/lib/chai/core/assertions.js
@@ -1513,6 +1513,7 @@ module.exports = function (chai, _) {
         , 'expected #{this} to not be a superset of #{act}'
         , obj
         , subset
+        , true
       );
     }
 
@@ -1522,6 +1523,7 @@ module.exports = function (chai, _) {
         , 'expected #{this} to not have the same members as #{act}'
         , obj
         , subset
+        , true
     );
   });
 


### PR DESCRIPTION
As it is, when the above assertion fails, one gets the rather unhelpful error message "expected [ Array(n) ] to have the same members as [ Array(m) ]". If the arrays are the same size, but some value in them is different, this isn't very helpful. It usually ends with me printing out the two arrays to the console and attempting to do a diff myself anyway.

By simply passing ``showDiff = true`` to assert() , it indicates that the arrays should be diffed when the error is printed. This functionality is tested in mocha 2.2.5 for both cases where either array is missing a value in the other and where the value differs between the arrays.