### PR TITLE
Fix wrong order of expected and actual values for members matcher

### DIFF
--- a/lib/chai/core/assertions.js
+++ b/lib/chai/core/assertions.js
@@ -1585,19 +1585,19 @@ module.exports = function (chai, _) {
     if (flag(this, 'contains')) {
       return this.assert(
           isSubsetOf(subset, obj, cmp)
-        , 'expected #{this} to be a superset of #{act}'
-        , 'expected #{this} to not be a superset of #{act}'
-        , obj
+        , 'expected #{this} to be a superset of #{exp}'
+        , 'expected #{this} to not be a superset of #{exp}'
         , subset
+        , obj
       );
     }
 
     this.assert(
         isSubsetOf(obj, subset, cmp) && isSubsetOf(subset, obj, cmp)
-        , 'expected #{this} to have the same members as #{act}'
-        , 'expected #{this} to not have the same members as #{act}'
-        , obj
+        , 'expected #{this} to have the same members as #{exp}'
+        , 'expected #{this} to not have the same members as #{exp}'
         , subset
+        , obj
     );
   });
 


### PR DESCRIPTION
This caused i.e. WebStorm's diff view to show actual value as expected and vice versa.