### PR TITLE
fixed expect('').to.contain('') so it passes

### DIFF
--- a/lib/chai/core/assertions.js
+++ b/lib/chai/core/assertions.js
@@ -214,7 +214,7 @@ module.exports = function (chai, _) {
       for (var k in val) subset[k] = obj[k];
       expected = _.eql(subset, val);
     } else {
-      expected = obj && ~obj.indexOf(val);
+      expected = (obj != undefined) && ~obj.indexOf(val);
     }
     this.assert(
         expected

--- a/test/assert.js
+++ b/test/assert.js
@@ -430,6 +430,7 @@ describe('assert', function () {
 
   it('include', function() {
     assert.include('foobar', 'bar');
+    assert.include('', '');
     assert.include([ 1, 2, 3], 3);
     assert.include({a:1, b:2}, {b:2});
 


### PR DESCRIPTION
Found a bug when you are trying to assert against a blank string.
Test case and fix included