### PR TITLE
Fix stack trace tracking for property asserts

### DIFF
--- a/lib/chai/utils/addProperty.js
+++ b/lib/chai/utils/addProperty.js
@@ -4,6 +4,9 @@
  * MIT Licensed
  */
 
+var config = require('../config');
+var flag = require('./flag');
+
 /**
  * ### addProperty (ctx, name, getter)
  *
@@ -31,7 +34,11 @@
 
 module.exports = function (ctx, name, getter) {
   Object.defineProperty(ctx, name,
-    { get: function () {
+    { get: function addProperty() {
+        var old_ssfi = flag(this, 'ssfi');
+        if (old_ssfi && config.includeStack === false)
+          flag(this, 'ssfi', addProperty);
+
         var result = getter.call(this);
         return result === undefined ? this : result;
       }

--- a/test/configuration.js
+++ b/test/configuration.js
@@ -21,8 +21,11 @@ describe('configuration', function () {
   function fooThrows () {
     chai.expect('foo').to.be.equal('bar');
   }
+  function fooPropThrows () {
+    chai.expect('foo').to.not.exist;
+  }
 
-  it('includeStack is true', function () {
+  it('includeStack is true for method assertions', function () {
     chai.config.includeStack = true;
 
     try {
@@ -38,7 +41,7 @@ describe('configuration', function () {
 
   });
 
-  it('includeStack is false', function () {
+  it('includeStack is false for method assertions', function () {
     chai.config.includeStack = false;
 
     try {
@@ -51,6 +54,40 @@ describe('configuration', function () {
       if ('undefined' !== typeof err.stack && 'undefined' !== typeof Error.captureStackTrace) {
         assert.notInclude(err.stack, 'assertEqual', 'should not have internal stack trace in error message');
         assert.include(err.stack, 'fooThrows', 'should have user stack trace in error message');
+      }
+    }
+  });
+
+  it('includeStack is true for property assertions', function () {
+    chai.config.includeStack = true;
+
+    try {
+      fooPropThrows();
+      assert.ok(false, 'should not get here because error thrown');
+    } catch (err) {
+      // not all browsers support err.stack
+      // Phantom does not include function names for getter exec
+      if ('undefined' !== typeof err.stack && 'undefined' !== typeof Error.captureStackTrace) {
+        assert.include(err.stack, 'addProperty', 'should have internal stack trace in error message');
+        assert.include(err.stack, 'fooPropThrows', 'should have user stack trace in error message');
+      }
+    }
+
+  });
+
+  it('includeStack is false for property assertions', function () {
+    chai.config.includeStack = false;
+
+    try {
+      fooPropThrows();
+      assert.ok(false, 'should not get here because error thrown');
+    } catch (err) {
+      // IE 10 supports err.stack in Chrome format, but without
+      // `Error.captureStackTrace` support that allows tuning of the error
+      // message.
+      if ('undefined' !== typeof err.stack && 'undefined' !== typeof Error.captureStackTrace) {
+        assert.notInclude(err.stack, 'addProperty', 'should not have internal stack trace in error message');
+        assert.include(err.stack, 'fooPropThrows', 'should have user stack trace in error message');
       }
     }
   });


### PR DESCRIPTION
The ssfi parameter was not being updated for these methods, which ended up causing the trace to be omitted.

Fixes #358