### PR TITLE
Added approximately alias to close to

### DIFF
--- a/lib/chai/core/assertions.js
+++ b/lib/chai/core/assertions.js
@@ -1445,19 +1445,20 @@ module.exports = function (chai, _) {
    *     expect(1.5).to.be.closeTo(1, 0.5);
    *
    * @name closeTo
+   * @alias approximately
    * @param {Number} expected
    * @param {Number} delta
    * @param {String} message _optional_
    * @api public
    */
 
-  Assertion.addMethod('closeTo', function (expected, delta, msg) {
+  function closeTo(expected, delta, msg) {
     if (msg) flag(this, 'message', msg);
     var obj = flag(this, 'object');
 
     new Assertion(obj, msg).is.a('number');
     if (_.type(expected) !== 'number' || _.type(delta) !== 'number') {
-      throw new Error('the arguments to closeTo must be numbers');
+      throw new Error('the arguments to closeTo or approximately must be numbers');
     }
 
     this.assert(
@@ -1465,7 +1466,10 @@ module.exports = function (chai, _) {
       , 'expected #{this} to be close to ' + expected + ' +/- ' + delta
       , 'expected #{this} not to be close to ' + expected + ' +/- ' + delta
     );
-  });
+  }
+
+  Assertion.addMethod('closeTo', closeTo);
+  Assertion.addMethod('approximately', closeTo);
 
   function isSubsetOf(subset, superset, cmp) {
     return subset.every(function(elem) {

--- a/lib/chai/interface/assert.js
+++ b/lib/chai/interface/assert.js
@@ -1165,6 +1165,25 @@ module.exports = function (chai, util) {
   assert.closeTo = function (act, exp, delta, msg) {
     new Assertion(act, msg).to.be.closeTo(exp, delta);
   };
+  
+  /**
+   * ### .approximately(actual, expected, delta, [message])
+   *
+   * Asserts that the target is equal `expected`, to within a +/- `delta` range.
+   *
+   *     assert.approximately(1.5, 1, 0.5, 'numbers are close');
+   *
+   * @name approximately
+   * @param {Number} actual
+   * @param {Number} expected
+   * @param {Number} delta
+   * @param {String} message
+   * @api public
+   */
+
+  assert.approximately = function (act, exp, delta, msg) {
+    new Assertion(act, msg).to.be.approximately(exp, delta);
+  };
 
   /**
    * ### .sameMembers(set1, set2, [message])

--- a/test/assert.js
+++ b/test/assert.js
@@ -707,11 +707,37 @@ describe('assert', function () {
 
     err(function() {
       assert.closeTo(1.5, "1.0", 0.5);
-    }, "the arguments to closeTo must be numbers");
+    }, "the arguments to closeTo or approximately must be numbers");
 
     err(function() {
       assert.closeTo(1.5, 1.0, true);
-    }, "the arguments to closeTo must be numbers");
+    }, "the arguments to closeTo or approximately must be numbers");
+  });
+  
+  it('approximately', function(){
+    assert.approximately(1.5, 1.0, 0.5);
+    assert.approximately(10, 20, 20);
+    assert.approximately(-10, 20, 30);
+
+    err(function(){
+      assert.approximately(2, 1.0, 0.5);
+    }, "expected 2 to be close to 1 +/- 0.5");
+
+    err(function(){
+      assert.approximately(-10, 20, 29);
+    }, "expected -10 to be close to 20 +/- 29");
+
+    err(function() {
+      assert.approximately([1.5], 1.0, 0.5);
+    }, "expected [ 1.5 ] to be a number");
+
+    err(function() {
+      assert.approximately(1.5, "1.0", 0.5);
+    }, "the arguments to closeTo or approximately must be numbers");
+
+    err(function() {
+      assert.approximately(1.5, 1.0, true);
+    }, "the arguments to closeTo or approximately must be numbers");
   });
 
   it('members', function() {

--- a/test/expect.js
+++ b/test/expect.js
@@ -1046,11 +1046,37 @@ describe('expect', function () {
 
     err(function() {
       expect(1.5).to.be.closeTo("1.0", 0.5);
-    }, "the arguments to closeTo must be numbers");
+    }, "the arguments to closeTo or approximately must be numbers");
 
     err(function() {
       expect(1.5).to.be.closeTo(1.0, true);
-    }, "the arguments to closeTo must be numbers");
+    }, "the arguments to closeTo or approximately must be numbers");
+  });
+  
+  it('approximately', function(){
+    expect(1.5).to.be.approximately(1.0, 0.5);
+    expect(10).to.be.approximately(20, 20);
+    expect(-10).to.be.approximately(20, 30);
+
+    err(function(){
+      expect(2).to.be.approximately(1.0, 0.5, 'blah');
+    }, "blah: expected 2 to be close to 1 +/- 0.5");
+
+    err(function(){
+      expect(-10).to.be.approximately(20, 29, 'blah');
+    }, "blah: expected -10 to be close to 20 +/- 29");
+
+    err(function() {
+      expect([1.5]).to.be.approximately(1.0, 0.5);
+    }, "expected [ 1.5 ] to be a number");
+
+    err(function() {
+      expect(1.5).to.be.approximately("1.0", 0.5);
+    }, "the arguments to closeTo or approximately must be numbers");
+
+    err(function() {
+      expect(1.5).to.be.approximately(1.0, true);
+    }, "the arguments to closeTo or approximately must be numbers");
   });
 
   it('include.members', function() {

--- a/test/should.js
+++ b/test/should.js
@@ -875,11 +875,31 @@ describe('should', function() {
 
     err(function() {
       (1.5).should.be.closeTo("1.0", 0.5);
-    }, "the arguments to closeTo must be numbers");
+    }, "the arguments to closeTo or approximately must be numbers");
 
     err(function() {
       (1.5).should.be.closeTo(1.0, true);
-    }, "the arguments to closeTo must be numbers");
+    }, "the arguments to closeTo or approximately must be numbers");
+  });
+  
+  it('approximately', function(){
+    (1.5).should.be.approximately(1.0, 0.5);
+
+    err(function(){
+      (2).should.be.approximately(1.0, 0.5, 'blah');
+    }, "blah: expected 2 to be close to 1 +/- 0.5");
+
+    err(function() {
+      [1.5].should.be.approximately(1.0, 0.5);
+    }, "expected [ 1.5 ] to be a number");
+
+    err(function() {
+      (1.5).should.be.approximately("1.0", 0.5);
+    }, "the arguments to closeTo or approximately must be numbers");
+
+    err(function() {
+      (1.5).should.be.approximately(1.0, true);
+    }, "the arguments to closeTo or approximately must be numbers");
   });
 
   it('include.members', function() {


### PR DESCRIPTION
Solves #525 , barring some questions.

1. Should approximately be added to the assert interface as well? This PR does, but this can be removed if you feel it bloats the interface.

2. The aliasing syntax doesn't allow for custom error messaging. This is fine for things like satisfy vs satisfies, but it gets a bit weird when it's something like closeTo and approximately. I edited the internal error messages to be more explicit ('the arguments to closeTo or approximately must be numbers'), but left the assertion messaging the same as to not break anything that might rely on that specific messaging. I don't really like this, because the closeTo function now knows how it's being used... but not having it can be really confusing for people trying to use `approximately` in a wrong way. What do you think of this? We could also just leave all messaging the same and treat approximately as a true alias.