### PR TITLE
`expect(inList).to.be.oneOf` assertion

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -121,19 +121,30 @@ git checkout -b <topic-branch-name>
 
 4. Commit your changes in logical chunks. Use Git's [interactive rebase](https://help.github.com/articles/interactive-rebase) feature to tidy up your commits before making them public.
 
-5. Locally merge (or rebase) the upstream development branch into your topic branch:
+5. Run you code to make sure it works.
+
+```bash
+npm i
+rm chai.js
+make chai.js
+npm test
+# when finished running tests...
+git checkout chai.js
+```
+
+6. Locally merge (or rebase) the upstream development branch into your topic branch:
 
 ```bash
 git pull [--rebase] upstream <dev-branch>
 ```
 
-6. Push your topic branch up to your fork:
+7. Push your topic branch up to your fork:
 
 ```bash
 git push origin <topic-branch-name>
 ```
 
-7. [Open a Pull Request](https://help.github.com/articles/using-pull-requests/) with a clear title and description.
+8. [Open a Pull Request](https://help.github.com/articles/using-pull-requests/) with a clear title and description.
 
 **IMPORTANT**: By submitting a patch, you agree to allow the project owner to license your work under the same license as that used by the project.
 

--- a/lib/chai/core/assertions.js
+++ b/lib/chai/core/assertions.js
@@ -1534,10 +1534,17 @@ module.exports = function (chai, _) {
   /**
    * ### .oneOf(list)
    *
-   * Assert that a non-array, non-object value appears somewhere in the flat array `list`.
+   * Assert that a value appears somewhere in the top level of array `list`.
    *
    *     expect('a').to.be.oneOf(['a', 'b', 'c']);
    *     expect(9).to.not.be.oneOf(['z']);
+   *     expect([3]).to.not.be.oneOf([1, 2, [3]]);
+   *
+   *     var three = [3];
+   *     // for object-types, contents are not compared
+   *     expect(three).to.not.be.oneOf([1, 2, [3]]);
+   *     // comparing references works
+   *     expect(three).to.be.oneOf([1, 2, three]);
    *
    * @name oneOf
    * @param {Array<*>} list
@@ -1549,13 +1556,11 @@ module.exports = function (chai, _) {
     if (msg) flag(this, 'message', msg);
     var expected = flag(this, 'object');
     new Assertion(list).to.be.an('array');
-    new Assertion(expected).to.not.be.an('array');
-    new Assertion(expected).to.not.be.an('object');
 
     this.assert(
         list.indexOf(expected) > -1
-      , 'expected #{this} to be in #{exp}'
-      , 'expected #{this} to not be in #{exp}'
+      , 'expected #{this} to be one of #{exp}'
+      , 'expected #{this} to not be one of #{exp}'
       , list
       , expected
     );

--- a/lib/chai/core/assertions.js
+++ b/lib/chai/core/assertions.js
@@ -1532,6 +1532,39 @@ module.exports = function (chai, _) {
   });
 
   /**
+   * ### .oneOf(list)
+   *
+   * Assert that a non-array, non-object value appears somewhere in the flat array `list`.
+   *
+   *     expect('a').to.be.oneOf(['a', 'b', 'c']);
+   *     expect(9).to.not.be.oneOf(['z']);
+   *
+   * @name oneOf
+   * @param {Array<*>} list
+   * @param {String} message _optional_
+   * @api public
+   */
+
+  function oneOf (list, msg) {
+    if (msg) flag(this, 'message', msg);
+    var expected = flag(this, 'object');
+    new Assertion(list).to.be.an('array');
+    new Assertion(expected).to.not.be.an('array');
+    new Assertion(expected).to.not.be.an('object');
+
+    this.assert(
+        list.indexOf(expected) > -1
+      , 'expected #{this} to be in #{exp}'
+      , 'expected #{this} to not be in #{exp}'
+      , list
+      , expected
+    );
+  }
+
+  Assertion.addMethod('oneOf', oneOf);
+
+
+  /**
    * ### .change(function)
    *
    * Asserts that a function changes an object property

--- a/lib/chai/interface/assert.js
+++ b/lib/chai/interface/assert.js
@@ -1165,7 +1165,7 @@ module.exports = function (chai, util) {
   assert.closeTo = function (act, exp, delta, msg) {
     new Assertion(act, msg).to.be.closeTo(exp, delta);
   };
-  
+
   /**
    * ### .approximately(actual, expected, delta, [message])
    *
@@ -1240,6 +1240,24 @@ module.exports = function (chai, util) {
 
   assert.includeMembers = function (superset, subset, msg) {
     new Assertion(superset, msg).to.include.members(subset);
+  }
+
+  /**
+   * ### .oneOf(inList, list, [message])
+   *
+   * Asserts that non-object, non-array value `inList` appears in the flat array `list`.
+   *
+   *     assert.oneOf(1, [ 2, 1 ], 'Not found in list');
+   *
+   * @name oneOf
+   * @param {*} inList
+   * @param {Array<*>} list
+   * @param {String} message
+   * @api public
+   */
+
+  assert.oneOf = function (inList, list, msg) {
+    new Assertion(inList, msg).to.be.oneOf(list);
   }
 
    /**

--- a/test/assert.js
+++ b/test/assert.js
@@ -771,25 +771,31 @@ describe('assert', function () {
   it('oneOf', function() {
     assert.oneOf(1, [1, 2, 3]);
 
-    err(function() {
-      assert.oneOf([1], []);
-    }, 'expected [ 1 ] not to be an array');
+    var three = [3];
+    assert.oneOf(three, [1, 2, three]);
 
-    err(function() {
-      assert.oneOf({a: 1}, []);
-    }, 'expected { a: 1 } not to be an object');
+    var four = { four: 4 };
+    assert.oneOf(four, [1, 2, four]);
 
     err(function() {
       assert.oneOf(1, 1);
     }, 'expected 1 to be an array');
 
     err(function() {
-      assert.oneOf(1, {a: 1});
+      assert.oneOf(1, { a: 1 });
     }, 'expected { a: 1 } to be an array');
 
     err(function() {
       assert.oneOf(9, [1, 2, 3], 'Message');
-    }, 'Message: expected 9 to be in [ 1, 2, 3 ]');
+    }, 'Message: expected 9 to be one of [ 1, 2, 3 ]');
+
+    err(function() {
+      assert.oneOf([3], [1, 2, [3]]);
+    }, 'expected [ 3 ] to be one of [ 1, 2, [ 3 ] ]');
+
+    err(function() {
+      assert.oneOf({ four: 4 }, [1, 2, { four: 4 }]);
+    }, 'expected { four: 4 } to be one of [ 1, 2, { four: 4 } ]');
 
   });
 

--- a/test/assert.js
+++ b/test/assert.js
@@ -713,7 +713,7 @@ describe('assert', function () {
       assert.closeTo(1.5, 1.0, true);
     }, "the arguments to closeTo or approximately must be numbers");
   });
-  
+
   it('approximately', function(){
     assert.approximately(1.5, 1.0, 0.5);
     assert.approximately(10, 20, 20);
@@ -766,6 +766,31 @@ describe('assert', function () {
     err(function() {
       assert.sameMembers([1, 54], [6, 1, 54]);
     }, 'expected [ 1, 54 ] to have the same members as [ 6, 1, 54 ]');
+  });
+
+  it('oneOf', function() {
+    assert.oneOf(1, [1, 2, 3]);
+
+    err(function() {
+      assert.oneOf([1], []);
+    }, 'expected [ 1 ] not to be an array');
+
+    err(function() {
+      assert.oneOf({a: 1}, []);
+    }, 'expected { a: 1 } not to be an object');
+
+    err(function() {
+      assert.oneOf(1, 1);
+    }, 'expected 1 to be an array');
+
+    err(function() {
+      assert.oneOf(1, {a: 1});
+    }, 'expected { a: 1 } to be an array');
+
+    err(function() {
+      assert.oneOf(9, [1, 2, 3], 'Message');
+    }, 'Message: expected 9 to be in [ 1, 2, 3 ]');
+
   });
 
   it('above', function() {

--- a/test/expect.js
+++ b/test/expect.js
@@ -1052,7 +1052,7 @@ describe('expect', function () {
       expect(1.5).to.be.closeTo(1.0, true);
     }, "the arguments to closeTo or approximately must be numbers");
   });
-  
+
   it('approximately', function(){
     expect(1.5).to.be.approximately(1.0, 0.5);
     expect(10).to.be.approximately(20, 20);
@@ -1077,6 +1077,11 @@ describe('expect', function () {
     err(function() {
       expect(1.5).to.be.approximately(1.0, true);
     }, "the arguments to closeTo or approximately must be numbers");
+  });
+
+  it('oneOf', function() {
+    expect(1).to.be.oneOf([1, 2, 3]);
+    expect('1').to.not.be.oneOf([1, 2, 3]);
   });
 
   it('include.members', function() {

--- a/test/expect.js
+++ b/test/expect.js
@@ -1082,6 +1082,9 @@ describe('expect', function () {
   it('oneOf', function() {
     expect(1).to.be.oneOf([1, 2, 3]);
     expect('1').to.not.be.oneOf([1, 2, 3]);
+    expect([3, [4]]).to.not.be.oneOf([1, 2, [3, 4]]);
+    var threeFour = [3, [4]];
+    expect(threeFour).to.be.oneOf([1, 2, threeFour]);
   });
 
   it('include.members', function() {

--- a/test/should.js
+++ b/test/should.js
@@ -457,6 +457,13 @@ describe('should', function() {
     }, "blah: expected 'foobar' to not contain 'bar'");
   });
 
+  it('oneOf()', function(){
+    'foo'.should.be.oneOf(['foo', 'bar']);
+    'bar'.should.be.oneOf(['foo', 'bar']);
+    'baz'.should.not.be.oneOf(['foo', 'bar']);
+    'baz'.should.not.be.oneOf([]);
+  });
+
   it('include()', function(){
     ['foo', 'bar'].should.include('foo');
     ['foo', 'bar'].should.contain('foo');
@@ -881,7 +888,7 @@ describe('should', function() {
       (1.5).should.be.closeTo(1.0, true);
     }, "the arguments to closeTo or approximately must be numbers");
   });
-  
+
   it('approximately', function(){
     (1.5).should.be.approximately(1.0, 0.5);
 


### PR DESCRIPTION
I see now why you wanted to name it `oneOf`, as opposed to `in`. The rules for matching against arbitrarily deep objects using `_.isEqual()` were not very clear. This PR looks to add just enough functionality to support most typical use cases.

This will ~~reject anything in the `expect` part of the test that is an array or an object. It will only match vai `list.indexOf(inList) > -1`~~ allow for strict reference comparisons for all objects that are passed in. For deeply nested objects, only first level members are considered for matches.