### PR TITLE
Revert .empty assertion change from PR #499

### DIFF
--- a/lib/chai/core/assertions.js
+++ b/lib/chai/core/assertions.js
@@ -396,8 +396,17 @@ module.exports = function (chai, _) {
    */
 
   Assertion.addProperty('empty', function () {
+    var obj = flag(this, 'object')
+      , expected = obj;
+
+    if (Array.isArray(obj) || 'string' === typeof object) {
+      expected = obj.length;
+    } else if (typeof obj === 'object') {
+      expected = Object.keys(obj).length;
+    }
+
     this.assert(
-        Object.keys(Object(flag(this, 'object'))).length === 0
+        !expected
       , 'expected #{this} to be empty'
       , 'expected #{this} not to be empty'
     );


### PR DESCRIPTION
The change introduced in #499 breaks compatibility with Array-like objects (e.g. mongoose arrays).
It should be applied in the next major version.

Fix #537 

cc @keithamus 