### PR TITLE
Fixes an issues when both `.throws()` and `not.throws()` produce failures.

### DIFF
--- a/lib/chai/core/assertions.js
+++ b/lib/chai/core/assertions.js
@@ -1268,120 +1268,114 @@ module.exports = function (chai, _) {
    */
 
   function assertThrows (constructor, errMsg, msg) {
+
+    function stringify (expected) {
+      if (expected.e) {
+        return expected.e.message ? expected.e.toString() : expected.e.name;
+      }
+      if (expected.type) {
+        var constructor = expected.type;
+        return new constructor().name;
+      }
+    }
+
+    function compatibleConstructor (expected, thrown) {
+      var exception = expected.e;
+      if (exception && exception.constructor === thrown.constructor) {
+        return exception.name === thrown.name;
+      }
+      return !expected.type || thrown instanceof expected.type;
+    }
+
+    function compatibleMessage (expected, thrown) {
+      var isThrownedException = typeof thrown === 'object' && thrown.hasOwnProperty('message');
+      var message = isThrownedException ? thrown.message : '' + String(thrown);
+      if (expected.errMsg instanceof RegExp) {
+        return expected.errMsg.test(message);
+      }
+      if (!expected.errMsg) {
+        return true;
+      }
+      if (expected.action === 'matching') {
+        return message === expected.errMsg;
+      }
+      return message.indexOf(expected.errMsg) !== -1;
+    }
+
+    function parseParams (constructor, errMsg) {
+      var expected = { placeholder: 'an error', action: 'matching' };
+      if (!arguments.length || !constructor) {
+        return expected;
+      }
+      if (constructor instanceof RegExp) {
+        expected.errMsg = constructor;
+        return expected;
+      }
+      if (typeof constructor === 'string') {
+        expected.errMsg = constructor;
+        expected.action = 'including';
+        return expected;
+      }
+      if (constructor instanceof Error) {
+        expected.e = constructor;
+        expected.type = constructor.constructor;
+        expected.errMsg = constructor.message;
+      } else {
+        expected.type = constructor;
+        expected.errMsg = errMsg;
+        if (typeof errMsg === 'string') {
+          expected.action = 'including';
+        }
+      }
+      expected.placeholder = '#{exp}';
+      return expected;
+    }
+
     if (msg) flag(this, 'message', msg);
     var obj = flag(this, 'object');
     new Assertion(obj, msg).is.a('function');
 
-    var thrown = false
-      , desiredError = null
-      , name = null
-      , thrownError = null;
-
-    if (arguments.length === 0) {
-      errMsg = null;
-      constructor = null;
-    } else if (constructor && (constructor instanceof RegExp || 'string' === typeof constructor)) {
-      errMsg = constructor;
-      constructor = null;
-    } else if (constructor && constructor instanceof Error) {
-      desiredError = constructor;
-      constructor = null;
-      errMsg = null;
-    } else if (typeof constructor === 'function') {
-      name = constructor.prototype.name;
-      if (!name || (name === 'Error' && constructor !== Error)) {
-        name = constructor.name || (new constructor()).name;
-      }
-    } else {
-      constructor = null;
-    }
+    var thrown;
+    var expected = parseParams.apply(null, arguments);
 
     try {
       obj();
     } catch (err) {
-      // first, check desired error
-      if (desiredError) {
-        this.assert(
-            err === desiredError
-          , 'expected #{this} to throw #{exp} but #{act} was thrown'
-          , 'expected #{this} to not throw #{exp}'
-          , (desiredError instanceof Error ? desiredError.toString() : desiredError)
-          , (err instanceof Error ? err.toString() : err)
-        );
-
-        flag(this, 'object', err);
-        return this;
-      }
-
-      // next, check constructor
-      if (constructor) {
-        this.assert(
-            err instanceof constructor
-          , 'expected #{this} to throw #{exp} but #{act} was thrown'
-          , 'expected #{this} to not throw #{exp} but #{act} was thrown'
-          , name
-          , (err instanceof Error ? err.toString() : err)
-        );
-
-        if (!errMsg) {
-          flag(this, 'object', err);
-          return this;
-        }
-      }
-
-      // next, check message
-      var message = 'error' === _.type(err) && "message" in err
-        ? err.message
-        : '' + err;
-
-      if ((message != null) && errMsg && errMsg instanceof RegExp) {
-        this.assert(
-            errMsg.exec(message)
-          , 'expected #{this} to throw error matching #{exp} but got #{act}'
-          , 'expected #{this} to throw error not matching #{exp}'
-          , errMsg
-          , message
-        );
-
-        flag(this, 'object', err);
-        return this;
-      } else if ((message != null) && errMsg && 'string' === typeof errMsg) {
-        this.assert(
-            ~message.indexOf(errMsg)
-          , 'expected #{this} to throw error including #{exp} but got #{act}'
-          , 'expected #{this} to throw error not including #{act}'
-          , errMsg
-          , message
-        );
-
-        flag(this, 'object', err);
-        return this;
-      } else {
-        thrown = true;
-        thrownError = err;
-      }
+      thrown = err;
     }
 
-    var actuallyGot = ''
-      , expectedThrown = name !== null
-        ? name
-        : desiredError
-          ? '#{exp}' //_.inspect(desiredError)
-          : 'an error';
-
-    if (thrown) {
-      actuallyGot = ' but #{act} was thrown'
+    if (thrown === undefined) {
+      this.assert(
+          false
+        , 'expected #{this} to throw ' + expected.placeholder
+        , 'expected #{this} to not throw ' + expected.placeholder
+        , stringify(expected)
+      );
+      return this;
     }
 
-    this.assert(
-        thrown === true
-      , 'expected #{this} to throw ' + expectedThrown + actuallyGot
-      , 'expected #{this} to not throw ' + expectedThrown + actuallyGot
-      , (desiredError instanceof Error ? desiredError.toString() : desiredError)
-      , (thrownError instanceof Error ? thrownError.toString() : thrownError)
-    );
+    var compatibleConstructor = compatibleConstructor(expected, thrown);
+    var compatibleMessage = compatibleMessage(expected, thrown);
 
-    flag(this, 'object', thrownError);
+    if (!compatibleConstructor || !expected.errMsg) {
+      this.assert(
+          compatibleConstructor && compatibleMessage
+        , 'expected #{this} to throw ' + expected.placeholder + ' but #{act} was thrown'
+        , 'expected #{this} to not throw ' + expected.placeholder + ' but #{act} was thrown'
+        , stringify(expected)
+        , (thrown instanceof Error ? thrown.toString() : thrown)
+      );
+    } else {
+      this.assert(
+          compatibleConstructor && compatibleMessage
+        , 'expected #{this} to throw error ' + expected.action + ' #{exp} but got #{act}'
+        , 'expected #{this} to not throw error ' + expected.action + ' #{exp}'
+        , expected.errMsg
+        , (thrown instanceof Error ? thrown.message : thrown)
+      );
+    }
+    flag(this, 'object', thrown);
+    return this;
   };
 
   Assertion.addMethod('throw', assertThrows);

--- a/lib/chai/interface/assert.js
+++ b/lib/chai/interface/assert.js
@@ -1112,11 +1112,6 @@ module.exports = function (chai, util) {
    */
 
   assert.throws = function (fn, errt, errs, msg) {
-    if ('string' === typeof errt || errt instanceof RegExp) {
-      errs = errt;
-      errt = null;
-    }
-
     var assertErr = new Assertion(fn, msg).to.throw(errt, errs);
     return flag(assertErr, 'object');
   };

--- a/test/expect.js
+++ b/test/expect.js
@@ -887,6 +887,7 @@ describe('expect', function () {
 
     var goodFn = function () { 1==1; }
       , badFn = function () { throw new Error('testing'); }
+      , stringErrFn = function () { throw 'testing'; }
       , refErrFn = function () { throw new ReferenceError('hello'); }
       , ickyErrFn = function () { throw new PoorlyConstructedError(); }
       , specificErrFn = function () { throw specificError; }
@@ -894,19 +895,33 @@ describe('expect', function () {
 
     expect(goodFn).to.not.throw();
     expect(goodFn).to.not.throw(Error);
+    expect(goodFn).to.not.throw(new Error());
     expect(goodFn).to.not.throw(specificError);
     expect(badFn).to.throw();
     expect(badFn).to.throw(Error);
+    expect(badFn).to.throw(new Error());
+    expect(badFn).to.not.throw(Error, 'hello');
+    expect(badFn).to.not.throw(new Error('hello'));
     expect(badFn).to.not.throw(ReferenceError);
+    expect(badFn).to.not.throw(new ReferenceError());
     expect(badFn).to.not.throw(specificError);
+    expect(stringErrFn).to.throw();
+    expect(stringErrFn).to.not.throw(ReferenceError);
+    expect(stringErrFn).to.not.throw(new ReferenceError());
+    expect(stringErrFn).to.not.throw(specificError);
     expect(refErrFn).to.throw();
     expect(refErrFn).to.throw(ReferenceError);
+    expect(refErrFn).to.throw(new ReferenceError());
     expect(refErrFn).to.throw(Error);
+    expect(refErrFn).to.throw(new Error());
     expect(refErrFn).to.not.throw(TypeError);
+    expect(refErrFn).to.not.throw(new TypeError());
     expect(refErrFn).to.not.throw(specificError);
     expect(ickyErrFn).to.throw();
     expect(ickyErrFn).to.throw(PoorlyConstructedError);
+    expect(ickyErrFn).to.throw(new PoorlyConstructedError());
     expect(ickyErrFn).to.throw(Error);
+    expect(ickyErrFn).to.not.throw(new Error());
     expect(ickyErrFn).to.not.throw(specificError);
     expect(specificErrFn).to.throw(specificError);
 
@@ -914,9 +929,13 @@ describe('expect', function () {
     expect(badFn).to.not.throw(/hello/);
     expect(badFn).to.throw('testing');
     expect(badFn).to.not.throw('hello');
-
     expect(badFn).to.throw(Error, /testing/);
     expect(badFn).to.throw(Error, 'testing');
+
+    expect(stringErrFn).to.throw(/testing/);
+    expect(stringErrFn).to.throw('testing');
+    expect(stringErrFn).to.not.throw(/hello/);
+    expect(stringErrFn).to.not.throw('hello');
 
     err(function(){
       expect(goodFn).to.throw();
@@ -924,7 +943,11 @@ describe('expect', function () {
 
     err(function(){
       expect(goodFn).to.throw(ReferenceError);
-    }, "expected [Function] to throw ReferenceError");
+    }, "expected [Function] to throw 'ReferenceError'");
+
+    err(function(){
+      expect(goodFn).to.throw(new ReferenceError());
+    }, "expected [Function] to throw 'ReferenceError'");
 
     err(function(){
       expect(goodFn).to.throw(specificError);
@@ -939,6 +962,10 @@ describe('expect', function () {
     }, "expected [Function] to throw 'ReferenceError' but 'Error: testing' was thrown");
 
     err(function(){
+      expect(badFn).to.throw(new ReferenceError());
+    }, "expected [Function] to throw 'ReferenceError' but 'Error: testing' was thrown");
+
+    err(function(){
       expect(badFn).to.throw(specificError);
     }, "expected [Function] to throw 'RangeError: boo' but 'Error: testing' was thrown");
 
@@ -947,7 +974,47 @@ describe('expect', function () {
     }, "expected [Function] to not throw 'Error' but 'Error: testing' was thrown");
 
     err(function(){
+      expect(badFn).to.not.throw(new Error());
+    }, "expected [Function] to not throw 'Error' but 'Error: testing' was thrown");
+
+    err(function(){
+      expect(badFn).to.throw(Error, 'hello');
+    }, "expected [Function] to throw error including 'hello' but got 'testing'");
+
+    err(function(){
+      expect(badFn).to.throw(new Error('hello'));
+    }, "expected [Function] to throw error matching 'hello' but got 'testing'");
+
+    err(function(){
+      expect(badFn).to.not.throw(Error, 'test');
+    }, "expected [Function] to not throw error including 'test'");
+
+    err(function(){
+      expect(badFn).to.throw(new Error('test'));
+    }, "expected [Function] to throw error matching 'test' but got 'testing'");
+
+    err(function(){
+      expect(stringErrFn).to.not.throw();
+    }, "expected [Function] to not throw an error but 'testing' was thrown");
+
+    err(function(){
+      expect(stringErrFn).to.throw(ReferenceError);
+    }, "expected [Function] to throw 'ReferenceError' but 'testing' was thrown");
+
+    err(function(){
+      expect(stringErrFn).to.throw(new ReferenceError());
+    }, "expected [Function] to throw 'ReferenceError' but 'testing' was thrown");
+
+    err(function(){
+      expect(stringErrFn).to.throw(specificError);
+    }, "expected [Function] to throw 'RangeError: boo' but 'testing' was thrown");
+
+    err(function(){
       expect(refErrFn).to.not.throw(ReferenceError);
+    }, "expected [Function] to not throw 'ReferenceError' but 'ReferenceError: hello' was thrown");
+
+    err(function(){
+      expect(refErrFn).to.not.throw(new ReferenceError());
     }, "expected [Function] to not throw 'ReferenceError' but 'ReferenceError: hello' was thrown");
 
     err(function(){
@@ -955,11 +1022,23 @@ describe('expect', function () {
     }, "expected [Function] to throw 'PoorlyConstructedError' but 'Error: testing' was thrown");
 
     err(function(){
+      expect(badFn).to.throw(new PoorlyConstructedError());
+    }, "expected [Function] to throw 'PoorlyConstructedError' but 'Error: testing' was thrown");
+
+    err(function(){
       expect(ickyErrFn).to.not.throw(PoorlyConstructedError);
     }, /^(expected \[Function\] to not throw 'PoorlyConstructedError' but)(.*)(PoorlyConstructedError|\{ Object \()(.*)(was thrown)$/);
 
     err(function(){
+      expect(ickyErrFn).to.not.throw(new PoorlyConstructedError());
+    }, /^(expected \[Function\] to not throw 'PoorlyConstructedError' but)(.*)(PoorlyConstructedError|\{ Object \()(.*)(was thrown)$/);
+
+    err(function(){
       expect(ickyErrFn).to.throw(ReferenceError);
+    }, /^(expected \[Function\] to throw 'ReferenceError' but)(.*)(PoorlyConstructedError|\{ Object \()(.*)(was thrown)$/);
+
+    err(function(){
+      expect(ickyErrFn).to.throw(new ReferenceError());
     }, /^(expected \[Function\] to throw 'ReferenceError' but)(.*)(PoorlyConstructedError|\{ Object \()(.*)(was thrown)$/);
 
     err(function(){
@@ -968,11 +1047,11 @@ describe('expect', function () {
 
     err(function(){
       expect(specificErrFn).to.not.throw(specificError);
-    }, "expected [Function] to not throw 'RangeError: boo'");
+    }, "expected [Function] to not throw error matching 'boo'");
 
     err(function (){
       expect(badFn).to.not.throw(/testing/);
-    }, "expected [Function] to throw error not matching /testing/");
+    }, "expected [Function] to not throw error matching /testing/");
 
     err(function () {
       expect(badFn).to.throw(/hello/);

--- a/test/should.js
+++ b/test/should.js
@@ -54,7 +54,7 @@ describe('should', function() {
 
     err(function () {
       should.not.Throw(function () { throw new Error('error!') }, Error, 'error!', 'blah');
-    }, "blah: expected [Function] to not throw 'Error' but 'Error: error!' was thrown");
+    }, "blah: expected [Function] to not throw error including 'error!'");
   });
 
   it('true', function(){
@@ -701,22 +701,33 @@ describe('should', function() {
 
     (goodFn).should.not.throw();
     (goodFn).should.not.throw(Error);
+    (goodFn).should.not.throw(new Error());
     (goodFn).should.not.throw(specificError);
     (badFn).should.throw();
     (badFn).should.throw(Error);
+    (badFn).should.throw(new Error());
+    (badFn).should.not.throw(Error, 'hello');
+    (badFn).should.not.throw(new Error('hello'));
     (badFn).should.not.throw(ReferenceError);
+    (badFn).should.not.throw(new ReferenceError());
     (badFn).should.not.throw(specificError);
     (stringErrFn).should.throw();
     (stringErrFn).should.not.throw(ReferenceError);
+    (stringErrFn).should.not.throw(new ReferenceError());
     (stringErrFn).should.not.throw(specificError);
     (refErrFn).should.throw();
     (refErrFn).should.throw(ReferenceError);
+    (refErrFn).should.throw(new ReferenceError());
     (refErrFn).should.throw(Error);
+    (refErrFn).should.throw(new Error());
     (refErrFn).should.not.throw(TypeError);
+    (refErrFn).should.not.throw(new TypeError());
     (refErrFn).should.not.throw(specificError);
     (ickyErrFn).should.throw();
     (ickyErrFn).should.throw(PoorlyConstructedError);
+    (ickyErrFn).should.throw(new PoorlyConstructedError());
     (ickyErrFn).should.throw(Error);
+    (ickyErrFn).should.not.throw(new Error());
     (ickyErrFn).should.not.throw(specificError);
     (specificErrFn).should.throw(specificError);
 
@@ -726,6 +737,7 @@ describe('should', function() {
     (badFn).should.not.throw('hello');
     (badFn).should.throw(Error, /testing/);
     (badFn).should.throw(Error, 'testing');
+    (badFn).should.throw(new Error('testing'));
 
     (stringErrFn).should.throw(/testing/);
     (stringErrFn).should.throw('testing');
@@ -734,11 +746,15 @@ describe('should', function() {
 
     should.throw(badFn);
     should.throw(refErrFn, ReferenceError);
+    should.throw(refErrFn, new ReferenceError());
     should.throw(refErrFn, Error);
+    should.throw(refErrFn, new Error());
     should.throw(ickyErrFn, PoorlyConstructedError);
+    should.throw(ickyErrFn, new PoorlyConstructedError());
     should.throw(specificErrFn, specificError);
     should.not.throw(goodFn);
     should.not.throw(badFn, ReferenceError);
+    should.not.throw(badFn, new ReferenceError());
     should.not.throw(badFn, specificError);
 
     should.throw(badFn, Error, /testing/);
@@ -750,7 +766,11 @@ describe('should', function() {
 
     err(function(){
       (goodFn).should.throw(ReferenceError);
-    }, "expected [Function] to throw ReferenceError");
+    }, "expected [Function] to throw 'ReferenceError'");
+
+    err(function(){
+      (goodFn).should.throw(new ReferenceError());
+    }, "expected [Function] to throw 'ReferenceError'");
 
     err(function(){
       (goodFn).should.throw(specificError);
@@ -765,12 +785,36 @@ describe('should', function() {
     }, "expected [Function] to throw 'ReferenceError' but 'Error: testing' was thrown");
 
     err(function(){
+      (badFn).should.throw(new ReferenceError());
+    }, "expected [Function] to throw 'ReferenceError' but 'Error: testing' was thrown");
+
+    err(function(){
       (badFn).should.throw(specificError);
     }, "expected [Function] to throw 'RangeError: boo' but 'Error: testing' was thrown");
 
     err(function(){
       (badFn).should.not.throw(Error);
     }, "expected [Function] to not throw 'Error' but 'Error: testing' was thrown");
+
+    err(function(){
+      (badFn).should.not.throw(new Error());
+    }, "expected [Function] to not throw 'Error' but 'Error: testing' was thrown");
+
+    err(function(){
+      (badFn).should.throw(new Error('test'));
+    }, "expected [Function] to throw error matching 'test' but got 'testing'");
+
+    err(function(){
+      (badFn).should.throw(Error, 'hello');
+    }, "expected [Function] to throw error including 'hello' but got 'testing'");
+
+    err(function(){
+      (badFn).should.throw(new Error('hello'));
+    }, "expected [Function] to throw error matching 'hello' but got 'testing'");
+
+    err(function(){
+      (badFn).should.not.throw(Error, 'test');
+    }, "expected [Function] to not throw error including 'test'");
 
     err(function(){
       (stringErrFn).should.not.throw();
@@ -781,15 +825,19 @@ describe('should', function() {
     }, "expected [Function] to throw 'ReferenceError' but 'testing' was thrown");
 
     err(function(){
+      (stringErrFn).should.throw(new ReferenceError());
+    }, "expected [Function] to throw 'ReferenceError' but 'testing' was thrown");
+
+    err(function(){
       (stringErrFn).should.throw(specificError);
     }, "expected [Function] to throw 'RangeError: boo' but 'testing' was thrown");
 
     err(function(){
-      (stringErrFn).should.not.throw('testing');
-    }, "expected [Function] to throw error not including 'testing'");
+      (refErrFn).should.not.throw(ReferenceError);
+    }, "expected [Function] to not throw 'ReferenceError' but 'ReferenceError: hello' was thrown");
 
     err(function(){
-      (refErrFn).should.not.throw(ReferenceError);
+      (refErrFn).should.not.throw(new ReferenceError());
     }, "expected [Function] to not throw 'ReferenceError' but 'ReferenceError: hello' was thrown");
 
     err(function(){
@@ -797,11 +845,23 @@ describe('should', function() {
     }, "expected [Function] to throw 'PoorlyConstructedError' but 'Error: testing' was thrown")
 
     err(function(){
+      (badFn).should.throw(new PoorlyConstructedError());
+    }, "expected [Function] to throw 'PoorlyConstructedError' but 'Error: testing' was thrown")
+
+    err(function(){
       (ickyErrFn).should.not.throw(PoorlyConstructedError);
     }, /^(expected \[Function\] to not throw 'PoorlyConstructedError' but)(.*)(PoorlyConstructedError|\{ Object \()(.*)(was thrown)$/);
 
     err(function(){
+      (ickyErrFn).should.not.throw(new PoorlyConstructedError());
+    }, /^(expected \[Function\] to not throw 'PoorlyConstructedError' but)(.*)(PoorlyConstructedError|\{ Object \()(.*)(was thrown)$/);
+
+    err(function(){
       (ickyErrFn).should.throw(ReferenceError);
+    }, /^(expected \[Function\] to throw 'ReferenceError' but)(.*)(PoorlyConstructedError|\{ Object \()(.*)(was thrown)$/);
+
+    err(function(){
+      (ickyErrFn).should.throw(new ReferenceError());
     }, /^(expected \[Function\] to throw 'ReferenceError' but)(.*)(PoorlyConstructedError|\{ Object \()(.*)(was thrown)$/);
 
     err(function(){
@@ -810,11 +870,11 @@ describe('should', function() {
 
     err(function(){
       (specificErrFn).should.not.throw(specificError);
-    }, "expected [Function] to not throw 'RangeError: boo'");
+    }, "expected [Function] to not throw error matching 'boo'");
 
     err(function (){
       (badFn).should.not.throw(/testing/);
-    }, "expected [Function] to throw error not matching /testing/");
+    }, "expected [Function] to not throw error matching /testing/");
 
     err(function () {
       (badFn).should.throw(/hello/);


### PR DESCRIPTION
This PR solves an issue when both `.throws()` and `not.throws()` produce failures. Exemple:
```js
expect(function() { throw new Error(); }).to.throw(Error, 'hello'); // fails
expect(function() { throw new Error(); }).to.not.throw(Error, 'hello'); // fails too
```
Imo the `not`spec above should pass.

This PR solves this issue and also modify the initial behavior by perfoming lazy comparison on exceptions to allows this syntax to make it works out of the box:
```js
expect(function() { throw new Error('testing'); }).to.throw(new Error('testing')); 
```
Indeed previoulsy a `===` comparison was made on objects which requires the following syntax:
```js
expect(function() { throw new Error('testing'); }).to.throw(Error, 'testing'); 
```
Now both syntax can be used either way. the only difference is one is assuming the error message to be strictly identical since the second way only requires `testing` to be included in the error message.

Solves https://github.com/chaijs/chai/issues/436, https://github.com/chaijs/chai/issues/430 and probaly https://github.com/chaijs/chai/pull/470