### PR TITLE
Fix error message string substitutions

### DIFF
--- a/lib/chai/utils/getMessage.js
+++ b/lib/chai/utils/getMessage.js
@@ -43,9 +43,9 @@ module.exports = function (obj, args) {
   if(typeof msg === "function") msg = msg();
   msg = msg || '';
   msg = msg
-    .replace(/#{this}/g, objDisplay(val))
-    .replace(/#{act}/g, objDisplay(actual))
-    .replace(/#{exp}/g, objDisplay(expected));
+    .replace(/#{this}/g, function () { return objDisplay(val); })
+    .replace(/#{act}/g, function () { return objDisplay(actual); })
+    .replace(/#{exp}/g, function () { return objDisplay(expected); });
 
   return flagMsg ? flagMsg + ': ' + msg : msg;
 };

--- a/test/utilities.js
+++ b/test/utilities.js
@@ -342,7 +342,11 @@ describe('utilities', function () {
       var obj = {};
       _.flag(obj, 'message', 'foo');
       expect(_.getMessage(obj, [])).to.contain('foo');
+    });
+  });
 
+  it('getMessage passed message as function', function () {
+    chai.use(function (_chai, _) {
       var obj = {};
       var msg = function() { return "expected a to eql b"; }
       var negateMsg = function() { return "expected a not to eql b"; }

--- a/test/utilities.js
+++ b/test/utilities.js
@@ -356,6 +356,67 @@ describe('utilities', function () {
     });
   });
 
+  it('getMessage template tag substitution', function () {
+    chai.use(function (_chai, _) {
+      var objName = 'trojan horse';
+      var actualValue = 'an actual value';
+      var expectedValue = 'an expected value';
+      [
+          // known template tags
+          {
+              template: 'one #{this} two',
+              expected: 'one \'' + objName + '\' two'
+          },
+          {
+              template: 'one #{act} two',
+              expected: 'one \'' + actualValue + '\' two'
+          },
+          {
+              template: 'one #{exp} two',
+              expected: 'one \'' + expectedValue + '\' two'
+          },
+          // unknown template tag
+          {
+              template: 'one #{unknown} two',
+              expected: 'one #{unknown} two'
+          },
+          // repeated template tag
+          {
+              template: '#{this}#{this}',
+              expected: '\'' + objName + '\'\'' + objName + '\''
+          },
+          // multiple template tags in different order
+          {
+              template: '#{this}#{act}#{exp}#{act}#{this}',
+              expected: '\'' + objName + '\'\'' + actualValue + '\'\'' + expectedValue + '\'\'' + actualValue + '\'\'' + objName + '\''
+          },
+          // immune to string.prototype.replace() `$` substitution
+          {
+              objName: '-$$-',
+              template: '#{this}',
+              expected: '\'-$$-\''
+          },
+          {
+              actualValue: '-$$-',
+              template: '#{act}',
+              expected: '\'-$$-\''
+          },
+          {
+              expectedValue: '-$$-',
+              template: '#{exp}',
+              expected: '\'-$$-\''
+          }
+      ].forEach(function (config) {
+          config.objName = config.objName || objName;
+          config.actualValue = config.actualValue || actualValue;
+          config.expectedValue = config.expectedValue || expectedValue;
+          var obj = {_obj: config.actualValue};
+          _.flag(obj, 'object', config.objName);
+          expect(_.getMessage(obj, [null, config.template, null, config.expectedValue])).to.equal(config.expected);
+      });
+    });
+  });
+
   it('inspect with custom object-returning inspect()s', function () {
     chai.use(function (_chai, _) {
       var obj = {


### PR DESCRIPTION
This is a fix for issue #560.

Tests included.

I notices the `getMessage` tests currently seem to be missing several `getMessage()` implementation features (e.g. how different objects get serialized to strings), but I did not go into implementing those here.