### PR TITLE
New showDiff behaviour also depending on expected and actual values

### DIFF
--- a/lib/chai/assertion.js
+++ b/lib/chai/assertion.js
@@ -98,7 +98,8 @@ module.exports = function (_chai, util) {
 
   Assertion.prototype.assert = function (expr, msg, negateMsg, expected, _actual, showDiff) {
     var ok = util.test(this, arguments);
-    if (true !== showDiff) showDiff = false;
+    if (false !== showDiff) showDiff = true;
+    if (undefined === expected && undefined === _actual) showDiff = false;
     if (true !== config.showDiff) showDiff = false;
 
     if (!ok) {

--- a/test/assert.js
+++ b/test/assert.js
@@ -865,4 +865,33 @@ describe('assert', function () {
       }, 'expected {} to not be frozen');
     });
   });
+
+  it('showDiff true with actual and expected args', function() {
+    try {
+      new chai.Assertion().assert(
+          'one' === 'two'
+        , 'expected #{this} to equal #{exp}'
+        , 'expected #{this} to not equal #{act}'
+        , 'one'
+        , 'two'
+      );
+    } catch(e) {
+      assert.isTrue(e.showDiff);
+    }
+  });
+
+  it('showDiff false without expected and actual', function() {
+    try {
+      new chai.Assertion().assert(
+          'one' === 'two'
+        , 'expected #{this} to equal #{exp}'
+        , 'expected #{this} to not equal #{act}'
+        , 'one'
+        , 'two'
+        , false
+      );
+    } catch(e) {
+      assert.isFalse(e.showDiff);
+    }
+  });
 });


### PR DESCRIPTION
This is related to the #515 issue.

I've used try/catch blocks on the test because adding a new parameter to the `err()` function seems too ugly.

I'm also directly using chai.Assertion because this way we guarantee this test won't be too tightly coupled with other assertion methods implementation.


PS.: Thank you guys for the awesome work you've been doing on Chai.