### PR TITLE
[WIP] Truncate Typed Arrays (#441)

### DIFF
--- a/lib/chai/utils/inspect.js
+++ b/lib/chai/utils/inspect.js
@@ -4,6 +4,7 @@
 var getName = require('./getName');
 var getProperties = require('./getProperties');
 var getEnumerableProperties = require('./getEnumerableProperties');
+var config = require('../config');
 
 module.exports = inspect;
 
@@ -244,8 +245,9 @@ function formatArray(ctx, value, recurseTimes, visibleKeys, keys) {
 function formatTypedArray(ctx, value, recurseTimes, visibleKeys, keys) {
   var output = [];
 
-  // Truncating TypedArray if it has more than 1000 elements
-  var l = value.length > 1000 ? 5 : value.length;
+  // Truncating TypedArray if it has more elements than the configured threshold
+  var t = config.truncateThreshold;
+  var l = value.length > t ? t : value.length;
 
   for (var i = 0; i < l; ++i) {
     if (Object.prototype.hasOwnProperty.call(value, String(i))) {

--- a/lib/chai/utils/inspect.js
+++ b/lib/chai/utils/inspect.js
@@ -175,6 +175,8 @@ function formatValue(ctx, value, recurseTimes) {
   var output;
   if (array) {
     output = formatArray(ctx, value, recurseTimes, visibleKeys, keys);
+  } else if (typedArray) {
+    output = formatTypedArray(ctx, value, recurseTimes, visibleKeys, keys);
   } else {
     output = keys.map(function(key) {
       return formatProperty(ctx, value, recurseTimes, visibleKeys, key, array);
@@ -238,6 +240,20 @@ function formatArray(ctx, value, recurseTimes, visibleKeys, keys) {
   return output;
 }
 
+function formatTypedArray(ctx, value, recurseTimes, visibleKeys, keys) {
+  var output = [];
+
+  for (var i = 0; i < l; ++i) {
+    if (Object.prototype.hasOwnProperty.call(value, String(i))) {
+      output.push(formatProperty(ctx, value, recurseTimes, visibleKeys,
+          String(i), true));
+    } else {
+      output.push('');
+    }
+  }
+
+  return output;
+}
 
 function formatProperty(ctx, value, recurseTimes, visibleKeys, key, array) {
   var name, str;

--- a/lib/chai/utils/inspect.js
+++ b/lib/chai/utils/inspect.js
@@ -120,7 +120,15 @@ function formatValue(ctx, value, recurseTimes) {
     }
   }
 
-  var base = '', array = false, braces = ['{', '}'];
+  var base = ''
+    , array = false
+    , typedArray = false
+    , braces = ['{', '}'];
+
+  if (isTypedArray(value)) {
+    typedArray = true;
+    braces = ['[', ']'];
+  }
 
   // Make Array say that they are Array
   if (isArray(value)) {
@@ -309,6 +317,22 @@ function reduceToSingleString(output, base, braces) {
   }
 
   return braces[0] + base + ' ' + output.join(', ') + ' ' + braces[1];
+}
+
+function isTypedArray(ar) {
+  // Unfortunately there's no way to check if an object is a TypedArray
+  // We have to check if it's one of these types
+  return (typeof ar === 'object' &&
+          objectToString(ar) === '[object Int8Array]' ||
+          objectToString(ar) === '[object Uint8Array]' ||
+          objectToString(ar) === '[object Uint8ClampedArray]' ||
+          objectToString(ar) === '[object Int16Array]' ||
+          objectToString(ar) === '[object Uint16Array]' ||
+          objectToString(ar) === '[object Int32Array]' ||
+          objectToString(ar) === '[object Uint32Array]' ||
+          objectToString(ar) === '[object Float32Array]' ||
+          objectToString(ar) === '[object Float64Array]'
+        )
 }
 
 function isArray(ar) {

--- a/lib/chai/utils/inspect.js
+++ b/lib/chai/utils/inspect.js
@@ -8,7 +8,7 @@ var getEnumerableProperties = require('./getEnumerableProperties');
 module.exports = inspect;
 
 /**
- * Echos the value of a value. Trys to print the value out
+ * Echos the value of a value. Tries to print the value out
  * in the best way possible given the different types.
  *
  * @param {Object} obj The object to print out.
@@ -231,6 +231,7 @@ function formatArray(ctx, value, recurseTimes, visibleKeys, keys) {
       output.push('');
     }
   }
+
   keys.forEach(function(key) {
     if (!key.match(/^\d+$/)) {
       output.push(formatProperty(ctx, value, recurseTimes, visibleKeys,
@@ -244,10 +245,7 @@ function formatTypedArray(ctx, value, recurseTimes, visibleKeys, keys) {
   var output = [];
 
   // Truncating TypedArray if it has more than 1000 elements
-  var l = value.length;
-  if (l > 1000) {
-    l = 5
-  }
+  var l = value.length > 1000 ? 5 : value.length;
 
   for (var i = 0; i < l; ++i) {
     if (Object.prototype.hasOwnProperty.call(value, String(i))) {
@@ -258,7 +256,7 @@ function formatTypedArray(ctx, value, recurseTimes, visibleKeys, keys) {
     }
   }
 
-  // If TypedArray has been truncated we add '...' to it's end
+  // If TypedArray has been truncated we add '...' to its end
   if (l !== value.length) {
     output.push('...');
   }
@@ -358,8 +356,7 @@ function isTypedArray(ar) {
           objectToString(ar) === '[object Int32Array]' ||
           objectToString(ar) === '[object Uint32Array]' ||
           objectToString(ar) === '[object Float32Array]' ||
-          objectToString(ar) === '[object Float64Array]'
-        )
+          objectToString(ar) === '[object Float64Array]');
 }
 
 function isArray(ar) {

--- a/lib/chai/utils/inspect.js
+++ b/lib/chai/utils/inspect.js
@@ -243,6 +243,12 @@ function formatArray(ctx, value, recurseTimes, visibleKeys, keys) {
 function formatTypedArray(ctx, value, recurseTimes, visibleKeys, keys) {
   var output = [];
 
+  // Truncating TypedArray if it has more than 1000 elements
+  var l = value.length;
+  if (l > 1000) {
+    l = 5
+  }
+
   for (var i = 0; i < l; ++i) {
     if (Object.prototype.hasOwnProperty.call(value, String(i))) {
       output.push(formatProperty(ctx, value, recurseTimes, visibleKeys,
@@ -250,6 +256,11 @@ function formatTypedArray(ctx, value, recurseTimes, visibleKeys, keys) {
     } else {
       output.push('');
     }
+  }
+
+  // If TypedArray has been truncated we add '...' to it's end
+  if (l !== value.length) {
+    output.push('...');
   }
 
   return output;

--- a/lib/chai/utils/inspect.js
+++ b/lib/chai/utils/inspect.js
@@ -177,7 +177,7 @@ function formatValue(ctx, value, recurseTimes) {
   if (array) {
     output = formatArray(ctx, value, recurseTimes, visibleKeys, keys);
   } else if (typedArray) {
-    output = formatTypedArray(ctx, value, recurseTimes, visibleKeys, keys);
+    return formatTypedArray(value);
   } else {
     output = keys.map(function(key) {
       return formatProperty(ctx, value, recurseTimes, visibleKeys, key, array);
@@ -242,28 +242,24 @@ function formatArray(ctx, value, recurseTimes, visibleKeys, keys) {
   return output;
 }
 
-function formatTypedArray(ctx, value, recurseTimes, visibleKeys, keys) {
-  var output = [];
+function formatTypedArray(value) {
+  var str = '[ ';
 
-  // Truncating TypedArray if it has more elements than the configured threshold
-  var t = config.truncateThreshold;
-  var l = value.length > t ? t : value.length;
-
-  for (var i = 0; i < l; ++i) {
-    if (Object.prototype.hasOwnProperty.call(value, String(i))) {
-      output.push(formatProperty(ctx, value, recurseTimes, visibleKeys,
-          String(i), true));
-    } else {
-      output.push('');
+  for (var i = 0; i < value.length; ++i) {
+    if (str.length >= config.truncateThreshold - 7) {
+      str += '...';
+      break;
     }
+    str += value[i] + ', ';
+  }
+  str += ' ]';
+
+  // Removing trailing `, ` if the array was not truncated
+  if (str.indexOf(',  ]') !== -1) {
+    str = str.replace(',  ]', ' ]');
   }
 
-  // If TypedArray has been truncated we add '...' to its end
-  if (l !== value.length) {
-    output.push('...');
-  }
-
-  return output;
+  return str;
 }
 
 function formatProperty(ctx, value, recurseTimes, visibleKeys, key, array) {

--- a/lib/chai/utils/inspect.js
+++ b/lib/chai/utils/inspect.js
@@ -349,16 +349,7 @@ function reduceToSingleString(output, base, braces) {
 function isTypedArray(ar) {
   // Unfortunately there's no way to check if an object is a TypedArray
   // We have to check if it's one of these types
-  return (typeof ar === 'object' &&
-          objectToString(ar) === '[object Int8Array]' ||
-          objectToString(ar) === '[object Uint8Array]' ||
-          objectToString(ar) === '[object Uint8ClampedArray]' ||
-          objectToString(ar) === '[object Int16Array]' ||
-          objectToString(ar) === '[object Uint16Array]' ||
-          objectToString(ar) === '[object Int32Array]' ||
-          objectToString(ar) === '[object Uint32Array]' ||
-          objectToString(ar) === '[object Float32Array]' ||
-          objectToString(ar) === '[object Float64Array]');
+  return (typeof ar === 'object' && /\w+Array]$/.test(objectToString(ar)));
 }
 
 function isArray(ar) {

--- a/test/utilities.js
+++ b/test/utilities.js
@@ -430,12 +430,14 @@ describe('utilities', function () {
   it('truncate long TypedArray', function () {
     chai.use(function (_chai, _) {
 
+      _chai.config.truncateThreshold = 5;
+
       var arr = []
         , exp = '[ 1, 2, 3, 4, 5, ... ]'
         , isNode = true;
 
       // Filling arr with lots of elements
-      for (var i = 1; i <= 1001; i++) {
+      for (var i = 1; i <= 1000; i++) {
         arr.push(i);
       }
 

--- a/test/utilities.js
+++ b/test/utilities.js
@@ -430,10 +430,8 @@ describe('utilities', function () {
   it('truncate long TypedArray', function () {
     chai.use(function (_chai, _) {
 
-      _chai.config.truncateThreshold = 5;
-
       var arr = []
-        , exp = '[ 1, 2, 3, 4, 5, ... ]'
+        , exp = '[ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, ... ]'
         , isNode = true;
 
       // Filling arr with lots of elements

--- a/test/utilities.js
+++ b/test/utilities.js
@@ -391,7 +391,7 @@ describe('utilities', function () {
     });
   });
 
-  it('inspect typedArray conversion', function () {
+  it('inspect every kind of available TypedArray', function () {
     chai.use(function (_chai, _) {
       var arr = [1, 2, 3]
         , exp = '[ 1, 2, 3 ]'
@@ -427,7 +427,7 @@ describe('utilities', function () {
     });
   });
 
-  it('truncate long typedArray', function () {
+  it('truncate long TypedArray', function () {
     chai.use(function (_chai, _) {
 
       var arr = []
@@ -445,9 +445,8 @@ describe('utilities', function () {
 
       if ((!isNode && 'Int8Array' in window) ||
           isNode && typeof 'Int8Array' !== undefined) {
-
-          expect(_.inspect(new Int8Array(arr))).to.equal(exp);
-        }
+        expect(_.inspect(new Int8Array(arr))).to.equal(exp);
+      }
     });
   });
 

--- a/test/utilities.js
+++ b/test/utilities.js
@@ -391,6 +391,42 @@ describe('utilities', function () {
     });
   });
 
+  it('inspect typedArray conversion', function () {
+    chai.use(function (_chai, _) {
+      var arr = [1, 2, 3]
+        , exp = '[ 1, 2, 3 ]'
+        , isNode = true;
+
+      if (typeof window !== 'undefined') {
+        isNode = false;
+      }
+
+      // Checks if engine supports common TypedArrays
+      if ((!isNode && 'Int8Array' in window) ||
+          isNode && typeof 'Int8Array' !== undefined) {
+        // Typed array inspections should work as array inspections do
+        expect(_.inspect(new Int8Array(arr))).to.equal(exp);
+        expect(_.inspect(new Uint8Array(arr))).to.equal(exp);
+        expect(_.inspect(new Int16Array(arr))).to.equal(exp);
+        expect(_.inspect(new Uint16Array(arr))).to.equal(exp);
+        expect(_.inspect(new Int32Array(arr))).to.equal(exp);
+        expect(_.inspect(new Uint32Array(arr))).to.equal(exp);
+        expect(_.inspect(new Float32Array(arr))).to.equal(exp);
+      }
+
+      // These ones may not be available alongside the others above
+      if ((!isNode && 'Uint8ClampedArray' in window) ||
+          isNode && typeof 'Uint8ClampedArray' !== undefined) {
+        expect(_.inspect(new Uint8ClampedArray(arr))).to.equal(exp);
+      }
+
+      if ((!isNode && 'Float64Array' in window) ||
+          isNode && typeof 'Float64Array' !== undefined) {
+        expect(_.inspect(new Float64Array(arr))).to.equal(exp);
+      }
+    });
+  });
+
   it('addChainableMethod', function () {
     chai.use(function (_chai, _) {
       _chai.Assertion.addChainableMethod('x',

--- a/test/utilities.js
+++ b/test/utilities.js
@@ -427,6 +427,30 @@ describe('utilities', function () {
     });
   });
 
+  it('truncate long typedArray', function () {
+    chai.use(function (_chai, _) {
+
+      var arr = []
+        , exp = '[ 1, 2, 3, 4, 5, ... ]'
+        , isNode = true;
+
+      // Filling arr with lots of elements
+      for (var i = 1; i <= 1001; i++) {
+        arr.push(i);
+      }
+
+      if (typeof window !== 'undefined') {
+        isNode = false;
+      }
+
+      if ((!isNode && 'Int8Array' in window) ||
+          isNode && typeof 'Int8Array' !== undefined) {
+
+          expect(_.inspect(new Int8Array(arr))).to.equal(exp);
+        }
+    });
+  });
+
   it('addChainableMethod', function () {
     chai.use(function (_chai, _) {
       _chai.Assertion.addChainableMethod('x',


### PR DESCRIPTION
*Please don't merge yet, I'm still doing some experiments*

As I said on the issue itself (#441), I'm gonna leave this PR here while working on this change so you guys can review my code and guarantee everything's fine.

**Notes/Questions:**
1. It's not possible to check for a single `TypedArray` constructor, we have to check each one of them.
2. Which `TypedArrays` should be considered *"too long"* and how are we going to truncate them?
3. Shouldn't we truncate long `Arrays` too? If the answer for this is "yes" I feel like this code could be improved.

**Progress:** 
- [x] Tests
- [x] `isTypedArray()`
- [x] `formatTypedArray()`
- [x] Truncating TypedArray
- [x] Refactor