### PR TITLE
Fix non ES5 compliant regexp

### DIFF
--- a/lib/chai/utils/getMessage.js
+++ b/lib/chai/utils/getMessage.js
@@ -43,9 +43,9 @@ module.exports = function (obj, args) {
   if(typeof msg === "function") msg = msg();
   msg = msg || '';
   msg = msg
-    .replace(/#{this}/g, function () { return objDisplay(val); })
-    .replace(/#{act}/g, function () { return objDisplay(actual); })
-    .replace(/#{exp}/g, function () { return objDisplay(expected); });
+    .replace(/#\{this\}/g, function () { return objDisplay(val); })
+    .replace(/#\{act\}/g, function () { return objDisplay(actual); })
+    .replace(/#\{exp\}/g, function () { return objDisplay(expected); });
 
   return flagMsg ? flagMsg + ': ' + msg : msg;
 };


### PR DESCRIPTION
ES5 appears to require that `{` be escaped when not used as part of a quantifier. While this works fine in browsers, it appears to choke less lenient runtimes (e.g. Duktape).

A similar case is discussed in Duktape (svaarala/duktape#69 and svaarala/duktape#74).

Please find attached a simple Duktape-powered C file that tries to parse the given argument file. 
[test.c.zip](https://github.com/chaijs/chai/files/70822/test.c.zip)

Compile and run using:
```
$  gcc -std=c99 -o test test.c duktape-1.3.1/src/duktape.c -I duktape-1.3.1/src/  -lm && ./test chai/chai.js
```
When choking it produces a:
`eval failed: SyntaxError: invalid regexp quantifier (unknown char) (line 4401)`
when the parsing is fine it will produce :
`result is: undefined`