### PR TITLE
Use getOwnPropertyDescriptor instead of __lookup methods

### DIFF
--- a/lib/chai/utils/inspect.js
+++ b/lib/chai/utils/inspect.js
@@ -232,16 +232,19 @@ function formatArray(ctx, value, recurseTimes, visibleKeys, keys) {
 
 
 function formatProperty(ctx, value, recurseTimes, visibleKeys, key, array) {
-  var name, str;
-  if (value.__lookupGetter__) {
-    if (value.__lookupGetter__(key)) {
-      if (value.__lookupSetter__(key)) {
+  var name;
+  var propDescriptor = Object.getOwnPropertyDescriptor(value, key);
+  var str;
+
+  if (propDescriptor) {
+    if (propDescriptor.get) {
+      if (propDescriptor.set) {
         str = ctx.stylize('[Getter/Setter]', 'special');
       } else {
         str = ctx.stylize('[Getter]', 'special');
       }
     } else {
-      if (value.__lookupSetter__(key)) {
+      if (propDescriptor.set) {
         str = ctx.stylize('[Setter]', 'special');
       }
     }


### PR DESCRIPTION
Hi!
Well, while reading `inspect.js` code I've researched about `__lookupGetter__` and `__lookupSetter__` and I've came across this [info](https://developer.mozilla.org/pt-BR/docs/Web/JavaScript/Reference/Global_Objects/Object/__lookupGetter__):

> Non-standard
> This feature is non-standard and is not on a standards track. Do not use it on production sites facing the Web: it will not work for every user. There may also be large incompatibilities between implementations and the behavior may change in the future.

> Deprecated
> This feature has been removed from the Web standards. Though some browsers may still support it, it is in the process of being dropped. Do not use it in old or new projects. Pages or Web apps using it may break at any time.

So I thought it would be nice to open a PR before I forget it, just in case you guys want to stop using these functions and start using `Object.getOwnPropertyDescriptor`.