### PR TITLE
Added includeDeepMembers

### DIFF
--- a/lib/chai/interface/assert.js
+++ b/lib/chai/interface/assert.js
@@ -1304,6 +1304,27 @@ module.exports = function (chai, util) {
   }
 
   /**
+   * ### .includeDeepMembers(superset, subset, [message])
+   *
+   * Asserts that `subset` is included in `superset` - using deep equality checking.
+   * Order is not taken into account.
+   * Duplicates are ignored.
+   *
+   *     assert.includeDeepMembers([ {a: 1}, {b: 2}, {c: 3} ], [ {b: 2}, {a: 1}, {b: 2} ], 'include deep members');
+   *
+   * @name includeDeepMembers
+   * @param {Array} superset
+   * @param {Array} subset
+   * @param {String} message
+   * @namespace Assert
+   * @api public
+   */
+
+  assert.includeDeepMembers = function (superset, subset, msg) {
+    new Assertion(superset, msg).to.include.deep.members(subset);
+  }
+
+  /**
    * ### .oneOf(inList, list, [message])
    *
    * Asserts that non-object, non-array value `inList` appears in the flat array `list`.

--- a/test/assert.js
+++ b/test/assert.js
@@ -855,6 +855,22 @@ describe('assert', function () {
     }, 'expected [ { b: 3 } ] to have the same members as [ { b: 5 } ]');
   });
 
+  it('includeDeepMembers', function() {
+    assert.includeDeepMembers([{a:1}, {b:2}, {c:3}], [{c:3}, {b:2}]);
+    assert.includeDeepMembers([{a:1}, {b:2}, {c:3}], []);
+    assert.includeDeepMembers([{a:1}, {b:2}, {c:3}], [{c:3}]);
+    assert.includeDeepMembers([{a:1}, {b:2}, {c:3}, {c:3}], [{c:3}, {c:3}]);
+    assert.includeDeepMembers([{a:1}, {b:2}, {c:3}], [{c:3}, {c:3}]);
+
+    err(function() {
+      assert.includeDeepMembers([{e:5}, {f:6}], [{g:7}, {h:8}]);
+    }, 'expected [ { e: 5 }, { f: 6 } ] to be a superset of [ { g: 7 }, { h: 8 } ]');
+
+    err(function() {
+      assert.includeDeepMembers([{e:5}, {f:6}], [{e:5}, {f:6}, {z:0}]);
+    }, 'expected [ { e: 5 }, { f: 6 } ] to be a superset of [ { e: 5 }, { f: 6 }, { z: 0 } ]');
+  });
+
   it('change', function() {
     var obj = { value: 10, str: 'foo' },
         fn     = function() { obj.value += 5 },


### PR DESCRIPTION
This is a proposition to add `assert.includeDeepMembers`.
It's a second attempt, as previous https://github.com/chaijs/chai/pull/588 was flawed due to my ignorance of git.
Hopefully now we can discus a the merit of the change, as I have some doubts:
- is it ok that includeDeepMembers and includeMembers ignore duplicates in the subset argument? I'd expect the function to ignore order, but not quantity of elements to be a useful feature for some scenarios (same question for sameDeepMembers, and sameMembers). The motivating example is when I want to make sure that one array is permutation of another one.
- I've added a testcase to explicitly document current behaviour described above. Is it ok to add such tests or is it unnecessarily constraining future modifications of implementation? I'm not sure if I describe my dilemma clearly, so let me paraphrase it: if the specification of a function is quite general, should the tests be more precise than the spec or be as general as the spec? I see benefits on both sides.
