### PR TITLE
Add script that registers should as a side-effect

### DIFF
--- a/should.js
+++ b/should.js
@@ -1,0 +1,1 @@
+module.exports = require('./').should();


### PR DESCRIPTION
See #594.

Allows a cleaner way to register `should` when using ES6 import syntax.

```js
import 'chai/should';

// as opposed to
import {should} from 'chai';
should();
```