### PR TITLE
Fix missing msg argument for change related assertions

### DIFF
--- a/lib/chai/interface/assert.js
+++ b/lib/chai/interface/assert.js
@@ -1344,7 +1344,7 @@ module.exports = function (chai, util) {
   }
 
    /**
-   * ### .changes(function, object, property)
+   * ### .changes(function, object, property, [message])
    *
    * Asserts that a function changes the value of a property
    *
@@ -1366,7 +1366,7 @@ module.exports = function (chai, util) {
   }
 
    /**
-   * ### .doesNotChange(function, object, property)
+   * ### .doesNotChange(function, object, property, [message])
    *
    * Asserts that a function does not changes the value of a property
    *
@@ -1388,7 +1388,7 @@ module.exports = function (chai, util) {
   }
 
    /**
-   * ### .increases(function, object, property)
+   * ### .increases(function, object, property, [message])
    *
    * Asserts that a function increases an object property
    *
@@ -1410,7 +1410,7 @@ module.exports = function (chai, util) {
   }
 
    /**
-   * ### .doesNotIncrease(function, object, property)
+   * ### .doesNotIncrease(function, object, property, [message])
    *
    * Asserts that a function does not increase object property
    *
@@ -1432,7 +1432,7 @@ module.exports = function (chai, util) {
   }
 
    /**
-   * ### .decreases(function, object, property)
+   * ### .decreases(function, object, property, [message])
    *
    * Asserts that a function decreases an object property
    *
@@ -1454,7 +1454,7 @@ module.exports = function (chai, util) {
   }
 
    /**
-   * ### .doesNotDecrease(function, object, property)
+   * ### .doesNotDecrease(function, object, property, [message])
    *
    * Asserts that a function does not decreases an object property
    *

--- a/lib/chai/interface/assert.js
+++ b/lib/chai/interface/assert.js
@@ -1361,8 +1361,8 @@ module.exports = function (chai, util) {
    * @api public
    */
 
-  assert.changes = function (fn, obj, prop) {
-    new Assertion(fn).to.change(obj, prop);
+  assert.changes = function (fn, obj, prop, msg) {
+    new Assertion(fn, msg).to.change(obj, prop);
   }
 
    /**
@@ -1383,8 +1383,8 @@ module.exports = function (chai, util) {
    * @api public
    */
 
-  assert.doesNotChange = function (fn, obj, prop) {
-    new Assertion(fn).to.not.change(obj, prop);
+  assert.doesNotChange = function (fn, obj, prop, msg) {
+    new Assertion(fn, msg).to.not.change(obj, prop);
   }
 
    /**
@@ -1405,8 +1405,8 @@ module.exports = function (chai, util) {
    * @api public
    */
 
-  assert.increases = function (fn, obj, prop) {
-    new Assertion(fn).to.increase(obj, prop);
+  assert.increases = function (fn, obj, prop, msg) {
+    new Assertion(fn, msg).to.increase(obj, prop);
   }
 
    /**
@@ -1427,8 +1427,8 @@ module.exports = function (chai, util) {
    * @api public
    */
 
-  assert.doesNotIncrease = function (fn, obj, prop) {
-    new Assertion(fn).to.not.increase(obj, prop);
+  assert.doesNotIncrease = function (fn, obj, prop, msg) {
+    new Assertion(fn, msg).to.not.increase(obj, prop);
   }
 
    /**
@@ -1449,8 +1449,8 @@ module.exports = function (chai, util) {
    * @api public
    */
 
-  assert.decreases = function (fn, obj, prop) {
-    new Assertion(fn).to.decrease(obj, prop);
+  assert.decreases = function (fn, obj, prop, msg) {
+    new Assertion(fn, msg).to.decrease(obj, prop);
   }
 
    /**
@@ -1471,8 +1471,8 @@ module.exports = function (chai, util) {
    * @api public
    */
 
-  assert.doesNotDecrease = function (fn, obj, prop) {
-    new Assertion(fn).to.not.decrease(obj, prop);
+  assert.doesNotDecrease = function (fn, obj, prop, msg) {
+    new Assertion(fn, msg).to.not.decrease(obj, prop);
   }
 
   /*!


### PR DESCRIPTION
As I was reading the code to solve #544 I found out the message parameter for change related methods (increases, decreases, etc...) on the assert interface wasn't being used at all.

I also took a look at [chai's docs](http://chaijs.com/api/assert/#changes) just to make sure it should be used.