### PR TITLE
Update include assertion docs for object properties

### DIFF
--- a/lib/chai/core/assertions.js
+++ b/lib/chai/core/assertions.js
@@ -179,13 +179,17 @@ module.exports = function (chai, _) {
   /**
    * ### .include(value)
    *
-   * The `include` and `contain` assertions can be used as either property
-   * based language chains or as methods to assert the inclusion of an object
-   * in an array or a substring in a string. When used as language chains,
-   * they toggle the `contains` flag for the `keys` assertion.
+   * The `include` and `contain` assertions can be used as methods to assert
+   * the inclusion of a value in an array, a substring in a string, or a subset
+   * of properties in an object.
    *
    *     expect([1,2,3]).to.include(2);
    *     expect('foobar').to.contain('foo');
+   *     expect({ foo: 'bar', hello: 'universe' }).to.include({ foo: 'bar' });
+   *
+   * These assertions can also be used as property based language chains,
+   * enabling the `contains` flag for the `keys` assertion. For instance:
+   *
    *     expect({ foo: 'bar', hello: 'universe' }).to.include.keys('foo');
    *
    * @name include


### PR DESCRIPTION
Originally added in #230, asserting that an object contains a subset of properties and values was never documented. Questions like #193 have popped up asking for this feature even though it's been present since 1.9.0.

The discussion in #193 focused mostly around getting something like this to work via the `property` assertion, but that discussion should be considered moot by the existing functionality already present in `include` that was simply overlooked.