### PR TITLE
Apply the same logic in `.throws()` to `.doesNotThrow()` so it matche…

### DIFF
--- a/lib/chai/interface/assert.js
+++ b/lib/chai/interface/assert.js
@@ -1140,13 +1140,13 @@ module.exports = function (chai, util) {
    * @api public
    */
 
-  assert.doesNotThrow = function (fn, type, msg) {
-    if ('string' === typeof type) {
-      msg = type;
-      type = null;
+  assert.doesNotThrow = function (fn, errt, errs, msg) {
+    if ('string' === typeof errt || errt instanceof RegExp) {
+      errs = errt;
+      errt = null;
     }
 
-    new Assertion(fn, msg).to.not.Throw(type);
+    new Assertion(fn, msg).to.not.throw(errt, errs);
   };
 
   /**

--- a/test/assert.js
+++ b/test/assert.js
@@ -608,6 +608,7 @@ describe('assert', function () {
 
     assert.doesNotThrow(function() { });
     assert.doesNotThrow(function() { }, 'foo');
+    assert.doesNotThrow(function () { throw new Error('foo'); }, 'bar');
 
     err(function () {
       assert.doesNotThrow(function() { throw new Error('foo'); });


### PR DESCRIPTION
…it matches error messages

- `.doesNotThrow()` is currently not matching the error message, although its description says so
- Changed `.Throw` to `.throw` so its consistent with `.throws()`
- Added test
- See #634 for examples