### PR TITLE
addMethod returns a new assertion with flags copied over instead of this

### DIFF
--- a/lib/chai/core/assertions.js
+++ b/lib/chai/core/assertions.js
@@ -43,9 +43,7 @@ module.exports = function (chai, _) {
   , 'is', 'and', 'has', 'have'
   , 'with', 'that', 'which', 'at'
   , 'of', 'same', 'but' ].forEach(function (chain) {
-    Assertion.addProperty(chain, function () {
-      return this;
-    });
+    Assertion.addProperty(chain);
   });
 
   /**

--- a/lib/chai/utils/addMethod.js
+++ b/lib/chai/utils/addMethod.js
@@ -5,6 +5,7 @@
  */
 
 var config = require('../config');
+var transferFlags = require('./transferFlags');
 
 /**
  * ### .addMethod (ctx, name, method)
@@ -39,6 +40,10 @@ module.exports = function (ctx, name, method) {
     if (old_ssfi && config.includeStack === false)
       flag(this, 'ssfi', ctx[name]);
     var result = method.apply(this, arguments);
-    return result === undefined ? this : result;
+
+    var newAssertion = new chai.Assertion();
+    transferFlags(this, newAssertion);
+
+    return result === undefined ? newAssertion: result;
   };
 };

--- a/lib/chai/utils/addProperty.js
+++ b/lib/chai/utils/addProperty.js
@@ -35,6 +35,8 @@ var transferFlags = require('./transferFlags');
  */
 
 module.exports = function (ctx, name, getter) {
+  getter = getter === undefined ? new Function() : getter;
+
   Object.defineProperty(ctx, name,
     { get: function addProperty() {
         var old_ssfi = flag(this, 'ssfi');

--- a/lib/chai/utils/addProperty.js
+++ b/lib/chai/utils/addProperty.js
@@ -6,6 +6,7 @@
 
 var config = require('../config');
 var flag = require('./flag');
+var transferFlags = require('./transferFlags');
 
 /**
  * ### addProperty (ctx, name, getter)
@@ -41,7 +42,10 @@ module.exports = function (ctx, name, getter) {
           flag(this, 'ssfi', addProperty);
 
         var result = getter.call(this);
-        return result === undefined ? this : result;
+        var newAssertion = new chai.Assertion();
+        transferFlags(this, newAssertion);
+
+        return result === undefined ? newAssertion: result;
       }
     , configurable: true
   });

--- a/test/utilities.js
+++ b/test/utilities.js
@@ -232,6 +232,46 @@ describe('utilities', function () {
     expect(expect('foo').result()).to.equal('result');
   });
 
+  it('addMethod returns new assertion with flags copied over', function () {
+    var assertionConstructor;
+
+    chai.use(function(_chai, utils) {
+      assertionConstructor = _chai.Assertion;
+      _chai.Assertion.addMethod('returnNewAssertion', function () {
+        utils.flag(this, 'mySpecificFlag', 'value1');
+        utils.flag(this, 'ultraSpecificFlag', 'value2');
+      });
+
+      _chai.Assertion.addMethod('checkFlags', function() {
+        this.assert(
+            utils.flag(this, 'mySpecificFlag') === 'value1' &&
+            utils.flag(this, 'ultraSpecificFlag') === 'value2'
+          , 'expected assertion to have specific flags'
+          , "this doesn't matter"
+        );
+      });
+    });
+
+    assertion1 = expect('foo');
+    assertion2 = assertion1.to.returnNewAssertion();
+
+    // Checking if a new assertion was returned
+    expect(assertion1).to.not.be.equal(assertion2);
+
+    // Check if flags were copied
+    assertion2.checkFlags();
+
+    // Checking if it's really an instance of an Assertion
+    expect(assertion2).to.be.instanceOf(assertionConstructor);
+
+    // Test chaining `.length` after a method to guarantee it is not a function's `length`
+    var anAssertion = expect([1, 2, 3]).to.be.an.instanceof(Array);
+    expect(anAssertion.length).to.be.an.instanceof(assertionConstructor);
+
+    var anotherAssertion = expect([1, 2, 3]).to.have.a.lengthOf(3).and.to.be.ok;
+    expect(anotherAssertion.length).to.be.an.instanceof(assertionConstructor);
+  });
+
   it('overwriteMethod', function () {
     chai.use(function (_chai, _) {
       expect(_chai.Assertion).to.respondTo('eqqqual');
@@ -289,6 +329,49 @@ describe('utilities', function () {
 
     var assert = expect('chai').to.be.tea;
     expect(assert.__flags.tea).to.equal('chai');
+  });
+
+  it('addProperty returns a new assertion with flags copied over', function () {
+    var assertionConstructor = chai.Assertion;
+
+    chai.use(function(_chai, utils) {
+      assertionConstructor = _chai.Assertion;
+      _chai.Assertion.addProperty('thing', function () {
+        utils.flag(this, 'mySpecificFlag', 'value1');
+        utils.flag(this, 'ultraSpecificFlag', 'value2');
+      });
+
+      _chai.Assertion.addMethod('checkFlags', function() {
+        this.assert(
+            utils.flag(this, 'mySpecificFlag') === 'value1' &&
+            utils.flag(this, 'ultraSpecificFlag') === 'value2'
+          , 'expected assertion to have specific flags'
+          , "this doesn't matter"
+        );
+      });
+    });
+
+    assertion1 = expect('foo');
+    assertion2 = assertion1.is.thing;
+
+    // Checking if a new assertion was returned
+    expect(assertion1).to.not.be.equal(assertion2);
+
+    // Check if flags were copied
+    assertion2.checkFlags();
+
+    // If it is, calling length on it should return an assertion, not a function
+    expect([1, 2, 3]).to.be.an.instanceof(Array);
+
+    // Checking if it's really an instance of an Assertion
+    expect(assertion2).to.be.instanceOf(assertionConstructor);
+
+    // Test chaining `.length` after a property to guarantee it is not a function's `length`
+    expect([1, 2, 3]).to.be.a.thing.with.length.above(2);
+    expect([1, 2, 3]).to.be.an.instanceOf(Array).and.have.length.below(4);
+
+    expect(expect([1, 2, 3]).be).to.be.an.instanceOf(assertionConstructor);
+    expect(expect([1, 2, 3]).thing).to.be.an.instanceOf(assertionConstructor);
   });
 
   it('addProperty returning result', function () {


### PR DESCRIPTION
This aims to solve #562.

Special thanks to @keithamus for the whole idea here, I just made some minor adjustments.

This PR should include:
- [x] `addMethod` returning a `new Assertion` with flags copied over
- [x] Tests for it
- [x] Fix [this](https://github.com/chaijs/chai/pull/642#discussion_r56754878) - EDIT: Unfortunately there is one case we won't be able to cover, so this is only *partially* resolved. [Please read this](https://github.com/chaijs/chai/pull/642#issuecomment-198979726).

I'm currently writing the tests and I'm not sure if they're complete enough.
I was thinking about testing chaining some assertions as described on #562, testing the type of their return and if methods are really returning a new Assertion with the flags which should have been copied. Is this enough? If not, what else should be verified?

EDIT: This needs a review, please see [this](https://github.com/chaijs/chai/pull/642#discussion_r56754878). I'll take a further look at it.