### PR TITLE
Add but to the list of language chains

### DIFF
--- a/lib/chai/core/assertions.js
+++ b/lib/chai/core/assertions.js
@@ -33,6 +33,7 @@ module.exports = function (chai, _) {
    * - at
    * - of
    * - same
+   * - but
    *
    * @name language chains
    * @namespace BDD


### PR DESCRIPTION
This includes a small commit adding `but` to the list of available language chains.
I added it at [this commit](https://github.com/chaijs/chai/commit/8e8a728921085351ecd050cd606b2ef6a1fb1338) but unfortunately I forgot to add it to the doc comments.

I thought about sending this one alongside the PR for the `deep` flag support, but I think it's better to send it separately for the sake of granularity, even though it's a single line change.