### PR TITLE
Add ES6 Symbol support

### DIFF
--- a/lib/chai/interface/should.js
+++ b/lib/chai/interface/should.js
@@ -10,7 +10,10 @@ module.exports = function (chai, util) {
   function loadShould () {
     // explicitly define this method as function as to have it's name to include as `ssfi`
     function shouldGetter() {
-      if (this instanceof String || this instanceof Number || this instanceof Boolean ) {
+      if (this instanceof String
+          || this instanceof Number
+          || this instanceof Boolean
+          || typeof Symbol === 'function' && this instanceof Symbol) {
         return new Assertion(this.valueOf(), null, shouldGetter);
       }
       return new Assertion(this, null, shouldGetter);

--- a/test/assert.js
+++ b/test/assert.js
@@ -107,12 +107,21 @@ describe('assert', function () {
   it('equal', function () {
     var foo;
     assert.equal(foo, undefined);
+
+    if (typeof Symbol === 'function') {
+      var sym = Symbol();
+      assert.equal(sym, sym);
+    }
   });
 
   it('typeof', function () {
     assert.typeOf('test', 'string');
     assert.typeOf(true, 'boolean');
     assert.typeOf(5, 'number');
+
+    if (typeof Symbol === 'function') {
+      assert.typeOf(Symbol(), 'symbol');
+    }
 
     err(function () {
       assert.typeOf(5, 'string');
@@ -182,6 +191,12 @@ describe('assert', function () {
   it('notEqual', function() {
     assert.notEqual(3, 4);
 
+    if (typeof Symbol === 'function') {
+      var sym1 = Symbol()
+        , sym2 = Symbol();
+      assert.notEqual(sym1, sym2);
+    }
+
     err(function () {
       assert.notEqual(5, 5);
     }, "expected 5 to not equal 5");
@@ -190,6 +205,11 @@ describe('assert', function () {
   it('strictEqual', function() {
     assert.strictEqual('foo', 'foo');
 
+    if (typeof Symbol === 'function') {
+      var sym = Symbol();
+      assert.strictEqual(sym, sym);
+    }
+
     err(function () {
       assert.strictEqual('5', 5);
     }, "expected \'5\' to equal 5");
@@ -197,6 +217,12 @@ describe('assert', function () {
 
   it('notStrictEqual', function() {
     assert.notStrictEqual(5, '5');
+
+    if (typeof Symbol === 'function') {
+      var sym1 = Symbol()
+        , sym2 = Symbol();
+      assert.notStrictEqual(sym1, sym2);
+    }
 
     err(function () {
       assert.notStrictEqual(5, 5);
@@ -435,6 +461,12 @@ describe('assert', function () {
     assert.include([ 1, 2, 3], 3);
     assert.include({a:1, b:2}, {b:2});
 
+    if (typeof Symbol === 'function') {
+      var sym1 = Symbol()
+        , sym2 = Symbol();
+      assert.include([sym1, sym2], sym1);
+    }
+
     err(function () {
       assert.include('foobar', 'baz');
     }, "expected \'foobar\' to include \'baz\'");
@@ -459,6 +491,13 @@ describe('assert', function () {
   it('notInclude', function () {
     assert.notInclude('foobar', 'baz');
     assert.notInclude([ 1, 2, 3 ], 4);
+
+    if (typeof Symbol === 'function') {
+      var sym1 = Symbol()
+        , sym2 = Symbol()
+        , sym3 = Symbol();
+      assert.notInclude([sym1, sym2], sym3);
+    }
 
     err(function(){
       assert.notInclude(true, true);
@@ -1256,6 +1295,10 @@ describe('assert', function () {
       assert[isNotExtensible]('foo');
       assert[isNotExtensible](false);
       assert[isNotExtensible](undefined);
+
+      if (typeof Symbol === 'function') {
+        assert[isNotExtensible](Symbol());
+      }
     });
   });
 
@@ -1276,6 +1319,10 @@ describe('assert', function () {
       assert[isSealed]('foo');
       assert[isSealed](false);
       assert[isSealed](undefined);
+
+      if (typeof Symbol === 'function') {
+        assert[isSealed](Symbol());
+      }
     });
   });
 
@@ -1330,6 +1377,10 @@ describe('assert', function () {
       assert[isFrozen]('foo');
       assert[isFrozen](false);
       assert[isFrozen](undefined);
+
+      if (typeof Symbol === 'function') {
+        assert[isFrozen](Symbol());
+      }
     });
   });
 

--- a/test/expect.js
+++ b/test/expect.js
@@ -116,6 +116,10 @@ describe('expect', function () {
     expect(function() {}).to.be.a('function');
     expect(null).to.be.a('null');
 
+    if (typeof Symbol === 'function') {
+      expect(Symbol()).to.be.a('symbol');
+    }
+
     err(function(){
       expect(5).to.not.be.a('number', 'blah');
     }, "blah: expected 5 not to be a number");
@@ -300,6 +304,11 @@ describe('expect', function () {
     expect(1).to.eql(1);
     expect('4').to.not.eql(4);
 
+    if (typeof Symbol === 'function') {
+      var sym = Symbol();
+      expect(sym).to.eql(sym);
+    }
+
     err(function(){
       expect(4).to.eql(3, 'blah');
     }, 'blah: expected 4 to deeply equal 3');
@@ -318,6 +327,11 @@ describe('expect', function () {
   it('equal(val)', function(){
     expect('test').to.equal('test');
     expect(1).to.equal(1);
+
+    if (typeof Symbol === 'function') {
+      var sym = Symbol();
+      expect(sym).to.equal(sym);
+    }
 
     err(function(){
       expect(4).to.equal(3, 'blah');
@@ -623,6 +637,14 @@ describe('expect', function () {
     expect([{a:1},{b:2}]).to.include({a:1});
     expect([{a:1}]).to.include({a:1});
     expect([{a:1}]).to.not.include({b:1});
+
+    if (typeof Symbol === 'function') {
+      var sym1 = Symbol()
+        , sym2 = Symbol()
+        , sym3 = Symbol();
+      expect([sym1, sym2]).to.include(sym1);
+      expect([sym1, sym2]).to.not.include(sym3);
+    }
 
     err(function(){
       expect(['foo']).to.include('bar', 'blah');
@@ -1283,6 +1305,10 @@ describe('expect', function () {
     expect(false).to.not.be.extensible;
     expect(undefined).to.not.be.extensible;
 
+    if (typeof Symbol === 'function') {
+      expect(Symbol()).to.not.be.extensible;
+    }
+
     err(function() {
       expect(42).to.be.extensible;
     }, 'expected 42 to be extensible');
@@ -1326,6 +1352,10 @@ describe('expect', function () {
     expect(false).to.be.sealed;
     expect(undefined).to.be.sealed;
 
+    if (typeof Symbol === 'function') {
+      expect(Symbol()).to.be.sealed;
+    }
+
     err(function() {
       expect(42).to.not.be.sealed;
     }, 'expected 42 to not be sealed');
@@ -1368,6 +1398,10 @@ describe('expect', function () {
     expect('foo').to.be.frozen;
     expect(false).to.be.frozen;
     expect(undefined).to.be.frozen;
+
+    if (typeof Symbol === 'function') {
+      expect(Symbol()).to.be.frozen;
+    }
 
     err(function() {
       expect(42).to.not.be.frozen;

--- a/test/should.js
+++ b/test/should.js
@@ -146,6 +146,10 @@ describe('should', function() {
     ([]).should.be.a('array');
     (function() {}).should.be.a('function');
 
+    if (typeof Symbol === 'function') {
+      Symbol().should.be.a('symbol');
+    }
+
     (5).should.be.a('number');
 
     err(function(){
@@ -301,6 +305,11 @@ describe('should', function() {
     (1).should.eql(1);
     '4'.should.not.eql(4);
 
+    if (typeof Symbol === 'function') {
+      var sym = Symbol();
+      sym.should.eql(sym);
+    }
+
     err(function(){
       (4).should.eql(3, 'blah');
     }, 'blah: expected 4 to deeply equal 3');
@@ -309,6 +318,11 @@ describe('should', function() {
   it('equal(val)', function(){
     'test'.should.equal('test');
     (1).should.equal(1);
+
+    if (typeof Symbol === 'function') {
+      var sym = Symbol();
+      sym.should.equal(sym);
+    }
 
     err(function(){
       (4).should.equal(3, 'blah');
@@ -483,6 +497,14 @@ describe('should', function() {
     ['foo', 'bar'].should.not.include(1);
     ({a:1,b:2}).should.include({b:2});
     ({a:1,b:2}).should.not.include({b:3});
+
+    if (typeof Symbol === 'function') {
+      var sym1 = Symbol()
+        , sym2 = Symbol()
+        , sym3 = Symbol();
+      [sym1, sym2].should.include(sym1);
+      [sym1, sym2].should.not.include(sym3);
+    }
 
     err(function(){
       ['foo'].should.include('bar', 'blah');
@@ -1132,6 +1154,10 @@ describe('should', function() {
      'foo'.should.not.be.extensible;
      false.should.not.be.extensible;
 
+     if (typeof Symbol === 'function') {
+       Symbol().should.not.be.extensible;
+     }
+
      err(function() {
        (42).should.be.extensible;
      }, 'expected 42 to be extensible');
@@ -1165,6 +1191,10 @@ describe('should', function() {
     'foo'.should.be.sealed;
     false.should.be.sealed;
 
+    if (typeof Symbol === 'function') {
+      Symbol().should.be.sealed;
+    }
+
     err(function() {
       (42).should.not.be.sealed;
     }, 'expected 42 to not be sealed');
@@ -1197,6 +1227,10 @@ describe('should', function() {
     (42).should.be.frozen;
     'foo'.should.be.frozen;
     false.should.be.frozen;
+
+    if (typeof Symbol === 'function') {
+      Symbol().should.be.frozen;
+    }
 
     err(function() {
       (42).should.not.be.frozen;


### PR DESCRIPTION
Changes:

- Fix bug when testing Symbol equality with should syntax (#669)
- Add Symbol tests for assert, expect, and should

Notes:

- No symbol tests were added to the key-checking block because of a separate bug. Will open a new issue on it soon. The bug occurs because both the `expected` and `actual` array of keys were being sorted in the `assertKeys` function using `Array.prototype.sort` but this throws a TypeError when one of the keys is a Symbol in a Map or a Set.

- No Symbol tests were added to the `NaN` block because JavaScript's isNaN() throws a TypeError when passed a Symbol. I don't know if Chai is supposed to mimic this behavior with its NaN test or instead return true?

- No Symbol tests that intentionally cause an error (and then test the string) were added. This is because the currently published version of Mocha doesn't correctly display AssertionError messages containing Symbols. However this issue appears to be resolved in Mocha's master branch; at least it displays "{}" to represent a Symbol.

- I was unable to use the more succinct `typeof this === 'symbol'` approach mentioned in #669 because `this` is wrapped in an object and thus returns 'object' as its typeof.