### PR TITLE
fail method on Should and Expect interfaces now has BDD as namespace

### DIFF
--- a/lib/chai/interface/expect.js
+++ b/lib/chai/interface/expect.js
@@ -19,7 +19,7 @@ module.exports = function (chai, util) {
    * @param {Mixed} expected
    * @param {String} message
    * @param {String} operator
-   * @namespace Expect
+   * @namespace BDD
    * @api public
    */
 

--- a/lib/chai/interface/should.js
+++ b/lib/chai/interface/should.js
@@ -51,7 +51,7 @@ module.exports = function (chai, util) {
      * @param {Mixed} expected
      * @param {String} message
      * @param {String} operator
-     * @namespace Should
+     * @namespace BDD
      * @api public
      */
 


### PR DESCRIPTION
This aims to solve #487 