### PR TITLE
Fix failure when custom inspect method is used

### DIFF
--- a/lib/chai/utils/inspect.js
+++ b/lib/chai/utils/inspect.js
@@ -49,7 +49,7 @@ function formatValue(ctx, value, recurseTimes) {
       value.inspect !== exports.inspect &&
       // Also filter out any prototype objects using the circular check.
       !(value.constructor && value.constructor.prototype === value)) {
-    var ret = value.inspect(recurseTimes);
+    var ret = value.inspect(recurseTimes, ctx);
     if (typeof ret !== 'string') {
       ret = formatValue(ctx, ret, recurseTimes);
     }

--- a/test/utilities.js
+++ b/test/utilities.js
@@ -608,6 +608,19 @@ describe('utilities', function () {
     });
   });
 
+  it('inspect with custom stylize-calling inspect()s', function () {
+    chai.use(function (_chai, _) {
+      var obj = {
+        outer: {
+          inspect: function (depth, options) {
+            return options.stylize('Object content', 'string');
+          }
+        }
+      };
+      expect(_.inspect(obj)).to.equal('{ outer: Object content }');
+    });
+  });
+
   it('inspect with custom object-returning inspect()s', function () {
     chai.use(function (_chai, _) {
       var obj = {


### PR DESCRIPTION
When custom inspect method is used and this method calls stylize test crashes.
Stylize method is documented for Node.js 4.x and 5.x.

Objects which use custom `inspect` method for `util.inspect` in Node.js should not cause test errors.