### PR TITLE
Throw using checkError module

### DIFF
--- a/lib/chai/core/assertions.js
+++ b/lib/chai/core/assertions.js
@@ -1273,6 +1273,7 @@ module.exports = function (chai, _) {
    *
    *     var err = new ReferenceError('This is a bad function.');
    *     var fn = function () { throw err; }
+   *     expect(fn).to.throw();
    *     expect(fn).to.throw(ReferenceError);
    *     expect(fn).to.throw(Error);
    *     expect(fn).to.throw(/bad function/);
@@ -1289,8 +1290,8 @@ module.exports = function (chai, _) {
    * @name throw
    * @alias throws
    * @alias Throw
-   * @param {ErrorConstructor} constructor
-   * @param {String|RegExp} expected error message
+   * @param {Error|ErrorConstructor} errorLike
+   * @param {String|RegExp} errMsgMatcher error message
    * @param {String} message _optional_
    * @see https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Error#Error_types
    * @returns error for chaining (null if no error)
@@ -1298,121 +1299,127 @@ module.exports = function (chai, _) {
    * @api public
    */
 
-  function assertThrows (constructor, errMsg, msg) {
+  function assertThrows (errorLike, errMsgMatcher, msg) {
     if (msg) flag(this, 'message', msg);
     var obj = flag(this, 'object');
+    var negate = flag(this, 'negate') || false;
     new Assertion(obj, msg).is.a('function');
 
-    var thrown = false
-      , desiredError = null
-      , name = null
-      , thrownError = null;
-
-    if (arguments.length === 0) {
-      errMsg = null;
-      constructor = null;
-    } else if (constructor && (constructor instanceof RegExp || 'string' === typeof constructor)) {
-      errMsg = constructor;
-      constructor = null;
-    } else if (constructor && constructor instanceof Error) {
-      desiredError = constructor;
-      constructor = null;
-      errMsg = null;
-    } else if (typeof constructor === 'function') {
-      name = constructor.prototype.name;
-      if (!name || (name === 'Error' && constructor !== Error)) {
-        name = constructor.name || (new constructor()).name;
-      }
-    } else {
-      constructor = null;
+    if (errorLike instanceof RegExp || typeof errorLike === 'string') {
+      errMsgMatcher = errorLike;
+      errorLike = null;
     }
 
+    var caughtErr;
     try {
       obj();
     } catch (err) {
-      // first, check desired error
-      if (desiredError) {
-        this.assert(
-            err === desiredError
-          , 'expected #{this} to throw #{exp} but #{act} was thrown'
-          , 'expected #{this} to not throw #{exp}'
-          , (desiredError instanceof Error ? desiredError.toString() : desiredError)
-          , (err instanceof Error ? err.toString() : err)
-        );
+      caughtErr = err;
+    }
 
-        flag(this, 'object', err);
-        return this;
+    // If we have the negate flag enabled and at least one valid argument it means we do expect an error
+    // but we want it to match a given set of criteria
+    var everyArgIsUndefined = errorLike === undefined && errMsgMatcher === undefined;
+
+    // If we've got the negate flag enabled and both args, we should only fail if both aren't compatible
+    // See Issue #551 and PR #683@GitHub
+    var everyArgIsDefined = Boolean(errorLike && errMsgMatcher);
+    var errorLikeFail = false;
+    var errMsgMatcherFail = false;
+
+    // Checking if error was thrown
+    if (everyArgIsUndefined || !everyArgIsUndefined && !negate) {
+      // We need this to display results correctly according to their types
+      var errorLikeString = 'an error';
+      if (errorLike instanceof Error) {
+        errorLikeString = '#{exp}';
+      } else if (errorLike) {
+        errorLikeString = errorLike.name;
       }
 
-      // next, check constructor
-      if (constructor) {
-        this.assert(
-            err instanceof constructor
-          , 'expected #{this} to throw #{exp} but #{act} was thrown'
-          , 'expected #{this} to not throw #{exp} but #{act} was thrown'
-          , name
-          , (err instanceof Error ? err.toString() : err)
-        );
+      this.assert(
+          caughtErr
+        , 'expected #{this} to throw ' + errorLikeString
+        , 'expected #{this} to not throw an error but #{act} was thrown'
+        , errorLike && errorLike.toString()
+        , (caughtErr instanceof Error ?
+            caughtErr.toString() : (typeof caughtErr === 'string' ? caughtErr : caughtErr && caughtErr.name))
+      );
+    }
 
-        if (!errMsg) {
-          flag(this, 'object', err);
-          return this;
+    if (errorLike && caughtErr) {
+      // We should compare instances only if `errorLike` is an instance of `Error`
+      if (errorLike instanceof Error) {
+        var isCompatibleInstance = _.checkError.compatibleInstance(caughtErr, errorLike);
+
+        if (isCompatibleInstance === negate) {
+          // These checks were created to ensure we won't fail too soon when we've got both args and a negate
+          // See Issue #551 and PR #683@GitHub
+          if (everyArgIsDefined && negate) {
+            errorLikeFail = true;
+          } else {
+            this.assert(
+                negate
+              , 'expected #{this} to throw #{exp} but #{act} was thrown'
+              , 'expected #{this} to not throw #{exp}' + (caughtErr && !negate ? ' but #{act} was thrown' : '')
+              , errorLike.toString()
+              , caughtErr.toString()
+            );
+          }
         }
       }
 
-      // next, check message
-      var message = 'error' === _.type(err) && "message" in err
-        ? err.message
-        : '' + err;
-
-      if ((message != null) && errMsg && errMsg instanceof RegExp) {
-        this.assert(
-            errMsg.exec(message)
-          , 'expected #{this} to throw error matching #{exp} but got #{act}'
-          , 'expected #{this} to throw error not matching #{exp}'
-          , errMsg
-          , message
-        );
-
-        flag(this, 'object', err);
-        return this;
-      } else if ((message != null) && errMsg && 'string' === typeof errMsg) {
-        this.assert(
-            ~message.indexOf(errMsg)
-          , 'expected #{this} to throw error including #{exp} but got #{act}'
-          , 'expected #{this} to throw error not including #{act}'
-          , errMsg
-          , message
-        );
-
-        flag(this, 'object', err);
-        return this;
-      } else {
-        thrown = true;
-        thrownError = err;
+      var isCompatibleConstructor = _.checkError.compatibleConstructor(caughtErr, errorLike);
+      if (isCompatibleConstructor === negate) {
+        if (everyArgIsDefined && negate) {
+            errorLikeFail = true;
+        } else {
+          this.assert(
+              negate
+            , 'expected #{this} to throw #{exp} but #{act} was thrown'
+            , 'expected #{this} to not throw #{exp}' + (caughtErr ? ' but #{act} was thrown' : '')
+            , (errorLike instanceof Error ? errorLike.toString() : errorLike && _.checkError.getConstructorName(errorLike))
+            , (caughtErr instanceof Error ? caughtErr.toString() : caughtErr && _.checkError.getConstructorName(caughtErr))
+          );
+        }
       }
     }
 
-    var actuallyGot = ''
-      , expectedThrown = name !== null
-        ? name
-        : desiredError
-          ? '#{exp}' //_.inspect(desiredError)
-          : 'an error';
+    if (errMsgMatcher) {
+      // Here we check compatible messages
+      var placeholder = 'including';
+      if (errMsgMatcher instanceof RegExp) {
+        placeholder = 'matching'
+      }
 
-    if (thrown) {
-      actuallyGot = ' but #{act} was thrown'
+      var isCompatibleMessage = _.checkError.compatibleMessage(caughtErr, errMsgMatcher);
+      if (isCompatibleMessage === negate) {
+        if (everyArgIsDefined && negate) {
+            errMsgMatcherFail = true;
+        } else {
+          this.assert(
+            negate
+            , 'expected #{this} to throw error ' + placeholder + ' #{exp} but got #{act}'
+            , 'expected #{this} to throw error not ' + placeholder + ' #{exp}'
+            ,  errMsgMatcher
+            ,  _.checkError.getMessage(caughtErr)
+          );
+        }
+      }
     }
 
-    this.assert(
-        thrown === true
-      , 'expected #{this} to throw ' + expectedThrown + actuallyGot
-      , 'expected #{this} to not throw ' + expectedThrown + actuallyGot
-      , (desiredError instanceof Error ? desiredError.toString() : desiredError)
-      , (thrownError instanceof Error ? thrownError.toString() : thrownError)
-    );
+    // If both assertions failed and both should've matched we throw an error
+    if (errorLikeFail && errMsgMatcherFail) {
+      this.assert(
+        negate
+        , 'expected #{this} to throw #{exp} but #{act} was thrown'
+        , 'expected #{this} to not throw #{exp}' + (caughtErr ? ' but #{act} was thrown' : '')
+        , (errorLike instanceof Error ? errorLike.toString() : errorLike && _.checkError.getConstructorName(errorLike))
+        , (caughtErr instanceof Error ? caughtErr.toString() : caughtErr && _.checkError.getConstructorName(caughtErr))
+      );
+    }
 
-    flag(this, 'object', thrownError);
+    flag(this, 'object', caughtErr);
   };
 
   Assertion.addMethod('throw', assertThrows);

--- a/lib/chai/utils/index.js
+++ b/lib/chai/utils/index.js
@@ -146,3 +146,9 @@ exports.getOwnEnumerablePropertySymbols = require('./getOwnEnumerablePropertySym
  */
 
 exports.getOwnEnumerableProperties = require('./getOwnEnumerableProperties');
+
+/*!
+ * Checks error against a given set of criteria
+ */
+
+exports.checkError = require('check-error');

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   },
   "dependencies": {
     "assertion-error": "^1.0.1",
+    "check-error": "^1.0.1",
     "deep-eql": "^0.1.3",
     "type-detect": "^2.0.1"
   },

--- a/test/expect.js
+++ b/test/expect.js
@@ -1163,6 +1163,9 @@ describe('expect', function () {
     expect(badFn).to.throw(Error, /testing/);
     expect(badFn).to.throw(Error, 'testing');
 
+    expect(badFn).to.not.throw(Error, 'I am the wrong error message');
+    expect(badFn).to.not.throw(TypeError, 'testing');
+
     err(function(){
       expect(goodFn).to.throw();
     }, "expected [Function] to throw an error");
@@ -1234,6 +1237,10 @@ describe('expect', function () {
     err(function () {
       (customErrFn).should.not.throw();
     }, "expected [Function] to not throw an error but 'CustomError: foo' was thrown");
+
+    err(function(){
+      expect(badFn).to.not.throw(Error, 'testing');
+    }, "expected [Function] to not throw 'Error' but 'Error: testing' was thrown");
   });
 
   it('respondTo', function(){

--- a/test/should.js
+++ b/test/should.js
@@ -1003,6 +1003,9 @@ describe('should', function() {
     should.throw(badFn, Error, /testing/);
     should.throw(badFn, Error, 'testing');
 
+    (badFn).should.not.throw(Error, 'I am the wrong error message');
+    (badFn).should.not.throw(TypeError, 'testing');
+
     err(function(){
       (goodFn).should.throw();
     }, "expected [Function] to throw an error");
@@ -1090,6 +1093,10 @@ describe('should', function() {
     err(function () {
       (customErrFn).should.not.throw();
     }, "expected [Function] to not throw an error but 'CustomError: foo' was thrown");
+
+    err(function(){
+      (badFn).should.not.throw(Error, 'testing');
+    }, "expected [Function] to not throw 'Error' but 'Error: testing' was thrown");
   });
 
   it('respondTo', function(){

--- a/test/utilities.js
+++ b/test/utilities.js
@@ -109,7 +109,7 @@ describe('utilities', function () {
       info.value.should.equal(obj.dimensions.units);
       info.name.should.equal('units');
       info.exists.should.be.true;
-    }); 
+    });
 
     it('should handle non-existent property', function() {
       var info = gpi('dimensions.size', obj);
@@ -118,7 +118,7 @@ describe('utilities', function () {
       expect(info.value).to.be.undefined;
       info.name.should.equal('size');
       info.exists.should.be.false;
-    }); 
+    });
 
     it('should handle array index', function() {
       var info = gpi('primes[2]', obj);
@@ -127,7 +127,7 @@ describe('utilities', function () {
       info.value.should.equal(obj.primes[2]);
       info.name.should.equal(2);
       info.exists.should.be.true;
-    }); 
+    });
 
     it('should handle dimensional array', function() {
       var info = gpi('dimensions.lengths[2][1]', obj);
@@ -136,7 +136,7 @@ describe('utilities', function () {
       info.value.should.equal(obj.dimensions.lengths[2][1]);
       info.name.should.equal(1);
       info.exists.should.be.true;
-    }); 
+    });
 
     it('should handle out of bounds array index', function() {
       var info = gpi('dimensions.lengths[3]', obj);
@@ -180,13 +180,13 @@ describe('utilities', function () {
       hp(1, arr).should.be.true;
       hp(3, arr).should.be.false;
     });
-    
+
     it('should handle literal types', function() {
       var s = 'string literal';
       hp('length', s).should.be.true;
       hp(3, s).should.be.true;
       hp(14, s).should.be.false;
-      
+
       hp('foo', 1).should.be.false;
     });
 
@@ -770,13 +770,13 @@ describe('utilities', function () {
 
     it('returns enumerable symbols only', function () {
       if (typeof Symbol !== 'function') return;
-      
+
       var cat = Symbol('cat')
         , dog = Symbol('dog')
         , frog = Symbol('frog')
         , cow = 'cow'
         , obj = {};
-      
+
       obj[cat] = 'meow';
       obj[dog] = 'woof';
 
@@ -819,14 +819,14 @@ describe('utilities', function () {
 
     it('returns enumerable property names and symbols', function () {
       if (typeof Symbol !== 'function') return;
-      
+
       var cat = Symbol('cat')
         , dog = Symbol('dog')
         , frog = Symbol('frog')
         , bird = 'bird'
         , cow = 'cow'
         , obj = {};
-      
+
       obj[cat] = 'meow';
       obj[dog] = 'woof';
       obj[bird] = 'chirp';


### PR DESCRIPTION
Hello everyone!
This one is pretty big and we've got plenty of special cases at the `throws` assertion, so be careful when reviewing :smile:

This one aims to solve an issue for the 4.0.0 release (as stated on our Roadmap #457) and finish #470 implementation. I thought that before moving `checkError` to a repository of its own it would be nice to have it reviewed and merged by more people here and only then we would move it to a new repo, but I'll do what you guys think it's better, this is just my opinion, please let me know if you disagree :wink: 

-----------------------------------------------------------

This PR includes:
- [x] The `checkError` module including *DocStrings*, `compatibleInstance`, `compatibleMessage`, `compatibleConstructor`, `getConstructorName` and `getMessage`
- [x] Tests for each one of the `checkError` functions
- [x] A full BC refactor of the `throws` assertion in order for it to use `checkError`

I couldn't make the `throws` assertion more simple than this, because we've got lots of edge/special cases, so this is the most generic and clean code I could get to while maintaining BC. If any of you can think of a better way to implement this please share your idea, it will certainly be welcome :smiley: 

I look forward to hearing your feedback :+1: 

-------------------------------
**EDIT**: This will be added to the [check-error repo](https://github.com/chaijs/check-error) as requested by @keithamus.
I'll write the complete repo structure and submit a PR there as soon as it's done.

Please don't merge this since it requires changes to use the external module instead of the local one.