### PR TITLE
Fix ownProperty on objects with no prototype

### DIFF
--- a/lib/chai/core/assertions.js
+++ b/lib/chai/core/assertions.js
@@ -937,7 +937,7 @@ module.exports = function (chai, _) {
     if (msg) flag(this, 'message', msg);
     var obj = flag(this, 'object');
     this.assert(
-        obj.hasOwnProperty(name)
+        Object.prototype.hasOwnProperty.call(obj, name)
       , 'expected #{this} to have own property ' + _.inspect(name)
       , 'expected #{this} to not have own property ' + _.inspect(name)
     );

--- a/test/expect.js
+++ b/test/expect.js
@@ -565,6 +565,10 @@ describe('expect', function () {
     expect('test').to.haveOwnProperty('length');
     expect({ length: 12 }).to.have.ownProperty('length');
 
+    var objNoProto = Object.create(null);
+    objNoProto.a = 'a';
+    expect(objNoProto).to.have.ownProperty('a');
+
     err(function(){
       expect({ length: 12 }).to.not.have.ownProperty('length', 'blah');
     }, "blah: expected { length: 12 } to not have own property 'length'");

--- a/test/should.js
+++ b/test/should.js
@@ -417,6 +417,10 @@ describe('should', function() {
     ({ length: 12 }).should.have.ownProperty('length');
     ({ 1: 1 }).should.have.ownProperty(1);
 
+    var objNoHasOwnProperty = {hasOwnProperty: null};
+    objNoHasOwnProperty.a = 'a';
+    objNoHasOwnProperty.should.have.ownProperty('a');
+
     err(function(){
       ({ length: 12 }).should.not.have.ownProperty('length', 'blah');
     }, "blah: expected { length: 12 } to not have own property 'length'");


### PR DESCRIPTION
Solves #688 

Objects with no prototype can now be succesfully tested for containing properties.