### PR TITLE
.members should show diff

### DIFF
--- a/lib/chai/core/assertions.js
+++ b/lib/chai/core/assertions.js
@@ -1589,19 +1589,19 @@ module.exports = function (chai, _) {
     if (flag(this, 'contains')) {
       return this.assert(
           isSubsetOf(subset, obj, cmp)
-        , 'expected #{this} to be a superset of #{act}'
-        , 'expected #{this} to not be a superset of #{act}'
-        , obj
+        , 'expected #{this} to be a superset of #{exp}'
+        , 'expected #{this} to not be a superset of #{exp}'
         , subset
+        , obj
       );
     }
 
     this.assert(
         isSubsetOf(obj, subset, cmp) && isSubsetOf(subset, obj, cmp)
-        , 'expected #{this} to have the same members as #{act}'
-        , 'expected #{this} to not have the same members as #{act}'
-        , obj
+        , 'expected #{this} to have the same members as #{exp}'
+        , 'expected #{this} to not have the same members as #{exp}'
         , subset
+        , obj
     );
   });
 


### PR DESCRIPTION
It would be great to show what's missing; this works for me. Comments are welcome. 
I'm not sure why the previous code had `#{act}` instead of `#{exp}` or why it apparently swapped expected/actual.