### PR TITLE
Fix failing tests in IE 10 and 11

### DIFF
--- a/lib/chai/core/assertions.js
+++ b/lib/chai/core/assertions.js
@@ -1164,7 +1164,10 @@ module.exports = function (chai, _) {
       , mixedArgsMsg = 'when testing keys against an object or an array you must give a single Array|Object|String argument or multiple String arguments';
 
     if (_.type(obj) === 'map' || _.type(obj) === 'set') {
-      actual = Array.from(obj.keys());
+      actual = [];
+
+      // Map and Set '.keys' aren't supported in IE 11. Therefore, use .forEach.
+      obj.forEach(function (val, key) { actual.push(key) });
 
       if (_.type(keys) !== 'array') {
         keys = Array.prototype.slice.call(arguments);

--- a/test/assert.js
+++ b/test/assert.js
@@ -595,160 +595,197 @@ describe('assert', function () {
     }
 
     if (typeof Map !== 'undefined') {
-      var aKey = {thisIs: 'anExampleObject'};
-      var anotherKey = {doingThisBecauseOf: 'referential equality'};
+      // Not using Map constructor args because not supported in IE 11.
+      var aKey = {thisIs: 'anExampleObject'}
+        , anotherKey = {doingThisBecauseOf: 'referential equality'}
+        , testMap = new Map();
+      
+      testMap.set(aKey, 'aValue');
+      testMap.set(anotherKey, 'anotherValue');
 
-      assert.hasAnyKeys(new Map([[aKey, 'aValue'], [anotherKey, 'anotherValue']]), [ aKey ]);
-      assert.hasAnyKeys(new Map([[aKey, 'aValue'], [anotherKey, 'anotherValue']]), [ 'thisDoesNotExist', 'thisToo', aKey ]);
-      assert.hasAllKeys(new Map([[aKey, 'aValue'], [anotherKey, 'anotherValue']]), [ aKey, anotherKey ]);
+      assert.hasAnyKeys(testMap, [ aKey ]);
+      assert.hasAnyKeys(testMap, [ 'thisDoesNotExist', 'thisToo', aKey ]);
+      assert.hasAllKeys(testMap, [ aKey, anotherKey ]);
 
-      assert.containsAllKeys(new Map([[aKey, 'aValue'], [anotherKey, 'anotherValue']]), [ aKey ]);
-      assert.doesNotHaveAllKeys(new Map([[aKey, 'aValue'], [anotherKey, 'anotherValue']]), [ aKey, {iDoNot: 'exist'} ]);
+      assert.containsAllKeys(testMap, [ aKey ]);
+      assert.doesNotHaveAllKeys(testMap, [ aKey, {iDoNot: 'exist'} ]);
 
-      assert.doesNotHaveAnyKeys(new Map([[aKey, 'aValue'], [anotherKey, 'anotherValue']]), [ {iDoNot: 'exist'} ]);
-      assert.doesNotHaveAnyKeys(new Map([[aKey, 'aValue'], [anotherKey, 'anotherValue']]), [ 'thisDoesNotExist', 'thisToo', {iDoNot: 'exist'} ]);
-      assert.doesNotHaveAllKeys(new Map([[aKey, 'aValue'], [anotherKey, 'anotherValue']]), [ 'thisDoesNotExist', 'thisToo', anotherKey ]);
+      assert.doesNotHaveAnyKeys(testMap, [ {iDoNot: 'exist'} ]);
+      assert.doesNotHaveAnyKeys(testMap, [ 'thisDoesNotExist', 'thisToo', {iDoNot: 'exist'} ]);
+      assert.doesNotHaveAllKeys(testMap, [ 'thisDoesNotExist', 'thisToo', anotherKey ]);
 
-      assert.doesNotHaveAnyKeys(new Map([[aKey, 'aValue'], [anotherKey, 'anotherValue']]), [ {iDoNot: 'exist'}, 'thisDoesNotExist' ]);
-      assert.doesNotHaveAnyKeys(new Map([[aKey, 'aValue'], [anotherKey, 'anotherValue']]), [ 'thisDoesNotExist', 'thisToo', {iDoNot: 'exist'} ]);
-      assert.doesNotHaveAllKeys(new Map([[aKey, 'aValue'], [anotherKey, 'anotherValue']]), [ aKey, {iDoNot: 'exist'} ]);
+      assert.doesNotHaveAnyKeys(testMap, [ {iDoNot: 'exist'}, 'thisDoesNotExist' ]);
+      assert.doesNotHaveAnyKeys(testMap, [ 'thisDoesNotExist', 'thisToo', {iDoNot: 'exist'} ]);
+      assert.doesNotHaveAllKeys(testMap, [ aKey, {iDoNot: 'exist'} ]);
 
       var weirdMapKey1 = Object.create(null)
         , weirdMapKey2 = {toString: NaN}
-        , weirdMapKey3 = [];
-      assert.hasAllKeys(new Map([[weirdMapKey1, 'val1'], [weirdMapKey2, 'val2']]), [weirdMapKey1, weirdMapKey2]);
-      assert.doesNotHaveAllKeys(new Map([[weirdMapKey1, 'val1'], [weirdMapKey2, 'val2']]), [weirdMapKey1, weirdMapKey3]);
+        , weirdMapKey3 = []
+        , weirdMap = new Map();
+      
+      weirdMap.set(weirdMapKey1, 'val1');
+      weirdMap.set(weirdMapKey2, 'val2');
+
+      assert.hasAllKeys(weirdMap, [weirdMapKey1, weirdMapKey2]);
+      assert.doesNotHaveAllKeys(weirdMap, [weirdMapKey1, weirdMapKey3]);
 
       if (typeof Symbol === 'function') {
         var symMapKey1 = Symbol()
           , symMapKey2 = Symbol()
-          , symMapKey3 = Symbol();
+          , symMapKey3 = Symbol()
+          , symMap = new Map();
+        
+        symMap.set(symMapKey1, 'val1');
+        symMap.set(symMapKey2, 'val2');
 
-        assert.hasAllKeys(new Map([[symMapKey1, 'symValue1'], [symMapKey2, 'symValue2']]), [symMapKey1, symMapKey2]);
-        assert.hasAnyKeys(new Map([[symMapKey1, 'symValue1'], [symMapKey2, 'symValue2']]), [symMapKey1, symMapKey3]);
-        assert.containsAllKeys(new Map([[symMapKey1, 'symValue1'], [symMapKey2, 'symValue2']]), [symMapKey2, symMapKey1]);
+        assert.hasAllKeys(symMap, [symMapKey1, symMapKey2]);
+        assert.hasAnyKeys(symMap, [symMapKey1, symMapKey3]);
+        assert.containsAllKeys(symMap, [symMapKey2, symMapKey1]);
 
-        assert.doesNotHaveAllKeys(new Map([[symMapKey1, 'symValue1'], [symMapKey2, 'symValue2']]), [symMapKey1, symMapKey3]);
-        assert.doesNotHaveAnyKeys(new Map([[symMapKey1, 'symValue1'], [symMapKey2, 'symValue2']]), [symMapKey3]);
+        assert.doesNotHaveAllKeys(symMap, [symMapKey1, symMapKey3]);
+        assert.doesNotHaveAnyKeys(symMap, [symMapKey3]);
       }
 
+      var errMap = new Map();
+
+      errMap.set({1: 20}, 'number');
+
       err(function(){
-        assert.hasAllKeys(new Map([[{1: 20}, 'number']]));
+        assert.hasAllKeys(errMap);
       }, "keys required");
 
       err(function(){
-        assert.hasAllKeys(new Map([[{1: 20}, 'number']]), []);
+        assert.hasAllKeys(errMap, []);
       }, "keys required");
 
       err(function(){
-        assert.containsAllKeys(new Map([[{1: 20}, 'number']]));
+        assert.containsAllKeys(errMap);
       }, "keys required");
 
       err(function(){
-        assert.containsAllKeys(new Map([[{1: 20}, 'number']]), []);
+        assert.containsAllKeys(errMap, []);
       }, "keys required");
 
       err(function(){
-        assert.doesNotHaveAllKeys(new Map([[{1: 20}, 'number']]));
+        assert.doesNotHaveAllKeys(errMap);
       }, "keys required");
 
       err(function(){
-        assert.doesNotHaveAllKeys(new Map([[{1: 20}, 'number']]), []);
+        assert.doesNotHaveAllKeys(errMap, []);
       }, "keys required");
 
       err(function(){
-        assert.hasAnyKeys(new Map([[{1: 20}, 'number']]));
+        assert.hasAnyKeys(errMap);
       }, "keys required");
 
       err(function(){
-        assert.hasAnyKeys(new Map([[{1: 20}, 'number']]), []);
+        assert.hasAnyKeys(errMap, []);
       }, "keys required");
 
       err(function(){
-        assert.doesNotHaveAnyKeys(new Map([[{1: 20}, 'number']]));
+        assert.doesNotHaveAnyKeys(errMap);
       }, "keys required");
 
       err(function(){
-        assert.doesNotHaveAnyKeys(new Map([[{1: 20}, 'number']]), []);
+        assert.doesNotHaveAnyKeys(errMap, []);
       }, "keys required");
     }
 
     if (typeof Set !== 'undefined') {
-      var aKey = {thisIs: 'anExampleObject'};
-      var anotherKey = {doingThisBecauseOf: 'referential equality'};
+      // Not using Set constructor args because not supported in IE 11.
+      var aKey = {thisIs: 'anExampleObject'}
+        , anotherKey = {doingThisBecauseOf: 'referential equality'}
+        , testSet = new Set();
+      
+      testSet.add(aKey);
+      testSet.add(anotherKey);
 
-      assert.hasAnyKeys(new Set([aKey, anotherKey]), [ aKey ]);
-      assert.hasAnyKeys(new Set([aKey, anotherKey]), [ 20, 1, aKey ]);
-      assert.hasAllKeys(new Set([aKey, anotherKey]), [ aKey, anotherKey ]);
+      assert.hasAnyKeys(testSet, [ aKey ]);
+      assert.hasAnyKeys(testSet, [ 20, 1, aKey ]);
+      assert.hasAllKeys(testSet, [ aKey, anotherKey ]);
 
-      assert.containsAllKeys(new Set([aKey, anotherKey]), [ aKey ]);
-      assert.doesNotHaveAllKeys(new Set([aKey, anotherKey]), [ aKey, {iDoNot: 'exist'} ]);
+      assert.containsAllKeys(testSet, [ aKey ]);
+      assert.doesNotHaveAllKeys(testSet, [ aKey, {iDoNot: 'exist'} ]);
 
-      assert.doesNotHaveAnyKeys(new Set([aKey, anotherKey]), [ {iDoNot: 'exist'} ]);
-      assert.doesNotHaveAnyKeys(new Set([aKey, anotherKey]), [ 'thisDoesNotExist', 'thisToo', {iDoNot: 'exist'} ]);
-      assert.doesNotHaveAllKeys(new Set([aKey, anotherKey]), [ 'thisDoesNotExist', 'thisToo', anotherKey ]);
+      assert.doesNotHaveAnyKeys(testSet, [ {iDoNot: 'exist'} ]);
+      assert.doesNotHaveAnyKeys(testSet, [ 'thisDoesNotExist', 'thisToo', {iDoNot: 'exist'} ]);
+      assert.doesNotHaveAllKeys(testSet, [ 'thisDoesNotExist', 'thisToo', anotherKey ]);
 
-      assert.doesNotHaveAnyKeys(new Set([aKey, anotherKey]), [ {iDoNot: 'exist'}, 'thisDoesNotExist' ]);
-      assert.doesNotHaveAnyKeys(new Set([aKey, anotherKey]), [ 20, 1, {iDoNot: 'exist'} ]);
-      assert.doesNotHaveAllKeys(new Set([aKey, anotherKey]), [ 'thisDoesNotExist', 'thisToo', {iDoNot: 'exist'} ]);
+      assert.doesNotHaveAnyKeys(testSet, [ {iDoNot: 'exist'}, 'thisDoesNotExist' ]);
+      assert.doesNotHaveAnyKeys(testSet, [ 20, 1, {iDoNot: 'exist'} ]);
+      assert.doesNotHaveAllKeys(testSet, [ 'thisDoesNotExist', 'thisToo', {iDoNot: 'exist'} ]);
 
       var weirdSetKey1 = Object.create(null)
         , weirdSetKey2 = {toString: NaN}
-        , weirdSetKey3 = [];
-      assert.hasAllKeys(new Set([weirdSetKey1, weirdSetKey2]), [weirdSetKey1, weirdSetKey2]);
-      assert.doesNotHaveAllKeys(new Set([weirdSetKey1, weirdSetKey2]), [weirdSetKey1, weirdSetKey3]);
+        , weirdSetKey3 = []
+        , weirdSet = new Set();
+      
+      weirdSet.add(weirdSetKey1);
+      weirdSet.add(weirdSetKey2);
+
+      assert.hasAllKeys(weirdSet, [weirdSetKey1, weirdSetKey2]);
+      assert.doesNotHaveAllKeys(weirdSet, [weirdSetKey1, weirdSetKey3]);
 
       if (typeof Symbol === 'function') {
         var symSetKey1 = Symbol()
           , symSetKey2 = Symbol()
-          , symSetKey3 = Symbol();
+          , symSetKey3 = Symbol()
+          , symSet = new Set();
+        
+        symSet.add(symSetKey1);
+        symSet.add(symSetKey2);
 
-        assert.hasAllKeys(new Set([symSetKey1, symSetKey2]), [symSetKey1, symSetKey2]);
-        assert.hasAnyKeys(new Set([symSetKey1, symSetKey2]), [symSetKey1, symSetKey3]);
-        assert.containsAllKeys(new Set([symSetKey1, symSetKey2]), [symSetKey2, symSetKey1]);
+        assert.hasAllKeys(symSet, [symSetKey1, symSetKey2]);
+        assert.hasAnyKeys(symSet, [symSetKey1, symSetKey3]);
+        assert.containsAllKeys(symSet, [symSetKey2, symSetKey1]);
 
-        assert.doesNotHaveAllKeys(new Set([symSetKey1, symSetKey2]), [symSetKey1, symSetKey3]);
-        assert.doesNotHaveAnyKeys(new Set([symSetKey1, symSetKey2]), [symSetKey3]);
+        assert.doesNotHaveAllKeys(symSet, [symSetKey1, symSetKey3]);
+        assert.doesNotHaveAnyKeys(symSet, [symSetKey3]);
       }
 
+      var errSet = new Set();
+      
+      errSet.add({1: 20});
+      errSet.add('number');
+
       err(function(){
-        assert.hasAllKeys(new Set([{1: 20}, 'number']));
+        assert.hasAllKeys(errSet);
       }, "keys required");
 
       err(function(){
-        assert.hasAllKeys(new Set([{1: 20}, 'number']), []);
+        assert.hasAllKeys(errSet, []);
       }, "keys required");
 
       err(function(){
-        assert.containsAllKeys(new Set([{1: 20}, 'number']));
+        assert.containsAllKeys(errSet);
       }, "keys required");
 
       err(function(){
-        assert.containsAllKeys(new Set([{1: 20}, 'number']), []);
+        assert.containsAllKeys(errSet, []);
       }, "keys required");
 
       err(function(){
-        assert.doesNotHaveAllKeys(new Set([{1: 20}, 'number']));
+        assert.doesNotHaveAllKeys(errSet);
       }, "keys required");
 
       err(function(){
-        assert.doesNotHaveAllKeys(new Set([{1: 20}, 'number']), []);
+        assert.doesNotHaveAllKeys(errSet, []);
       }, "keys required");
 
       err(function(){
-        assert.hasAnyKeys(new Set([{1: 20}, 'number']));
+        assert.hasAnyKeys(errSet);
       }, "keys required");
 
       err(function(){
-        assert.hasAnyKeys(new Set([{1: 20}, 'number']), []);
+        assert.hasAnyKeys(errSet, []);
       }, "keys required");
 
       err(function(){
-        assert.doesNotHaveAnyKeys(new Set([{1: 20}, 'number']));
+        assert.doesNotHaveAnyKeys(errSet);
       }, "keys required");
 
       err(function(){
-        assert.doesNotHaveAnyKeys(new Set([{1: 20}, 'number']), []);
+        assert.doesNotHaveAnyKeys(errSet, []);
       }, "keys required");
     }
 

--- a/test/expect.js
+++ b/test/expect.js
@@ -808,126 +808,161 @@ describe('expect', function () {
     }
 
     if (typeof Map !== 'undefined') {
-      var aKey = {thisIs: 'anExampleObject'};
-      var anotherKey = {doingThisBecauseOf: 'referential equality'};
+      // Not using Map constructor args because not supported in IE 11.
+      var aKey = {thisIs: 'anExampleObject'}
+        , anotherKey = {doingThisBecauseOf: 'referential equality'}
+        , testMap = new Map();
+      
+      testMap.set(aKey, 'aValue');
+      testMap.set(anotherKey, 'anotherValue');
 
-      expect(new Map([[aKey, 'aValue'], [anotherKey, 'anotherValue']])).to.have.any.keys(aKey);
-      expect(new Map([[aKey, 'aValue'], [anotherKey, 'anotherValue']])).to.have.any.keys('thisDoesNotExist', 'thisToo', aKey);
-      expect(new Map([[aKey, 'aValue'], [anotherKey, 'anotherValue']])).to.have.all.keys(aKey, anotherKey);
+      expect(testMap).to.have.any.keys(aKey);
+      expect(testMap).to.have.any.keys('thisDoesNotExist', 'thisToo', aKey);
+      expect(testMap).to.have.all.keys(aKey, anotherKey);
 
-      expect(new Map([[aKey, 'aValue'], [anotherKey, 'anotherValue']])).to.contain.all.keys(aKey);
-      expect(new Map([[aKey, 'aValue'], [anotherKey, 'anotherValue']])).to.not.contain.all.keys(aKey, 'thisDoesNotExist');
+      expect(testMap).to.contain.all.keys(aKey);
+      expect(testMap).to.not.contain.all.keys(aKey, 'thisDoesNotExist');
 
-      expect(new Map([[aKey, 'aValue'], [anotherKey, 'anotherValue']])).to.not.have.any.keys({iDoNot: 'exist'});
-      expect(new Map([[aKey, 'aValue'], [anotherKey, 'anotherValue']])).to.not.have.any.keys('thisIsNotAkey', {iDoNot: 'exist'}, {33: 20});
-      expect(new Map([[aKey, 'aValue'], [anotherKey, 'anotherValue']])).to.not.have.all.keys('thisDoesNotExist', 'thisToo', anotherKey);
+      expect(testMap).to.not.have.any.keys({iDoNot: 'exist'});
+      expect(testMap).to.not.have.any.keys('thisIsNotAkey', {iDoNot: 'exist'}, {33: 20});
+      expect(testMap).to.not.have.all.keys('thisDoesNotExist', 'thisToo', anotherKey);
 
-      expect(new Map([[aKey, 'aValue'], [anotherKey, 'anotherValue']])).to.have.any.keys([aKey]);
-      expect(new Map([[aKey, 'aValue'], [anotherKey, 'anotherValue']])).to.have.any.keys([20, 1, aKey]);
-      expect(new Map([[aKey, 'aValue'], [anotherKey, 'anotherValue']])).to.have.all.keys([aKey, anotherKey]);
+      expect(testMap).to.have.any.keys([aKey]);
+      expect(testMap).to.have.any.keys([20, 1, aKey]);
+      expect(testMap).to.have.all.keys([aKey, anotherKey]);
 
-      expect(new Map([[aKey, 'aValue'], [anotherKey, 'anotherValue']])).to.not.have.any.keys([{13: 37}, 'thisDoesNotExist', 'thisToo']);
-      expect(new Map([[aKey, 'aValue'], [anotherKey, 'anotherValue']])).to.not.have.any.keys([20, 1, {13: 37}]);
-      expect(new Map([[aKey, 'aValue'], [anotherKey, 'anotherValue']])).to.not.have.all.keys([aKey, {'iDoNot': 'exist'}]);
+      expect(testMap).to.not.have.any.keys([{13: 37}, 'thisDoesNotExist', 'thisToo']);
+      expect(testMap).to.not.have.any.keys([20, 1, {13: 37}]);
+      expect(testMap).to.not.have.all.keys([aKey, {'iDoNot': 'exist'}]);
 
       var weirdMapKey1 = Object.create(null)
         , weirdMapKey2 = {toString: NaN}
-        , weirdMapKey3 = [];
-      expect(new Map([[weirdMapKey1, 'val1'], [weirdMapKey2, 'val2']])).to.have.all.keys([weirdMapKey1, weirdMapKey2]);
-      expect(new Map([[weirdMapKey1, 'val1'], [weirdMapKey2, 'val2']])).to.not.have.all.keys([weirdMapKey1, weirdMapKey3]);
+        , weirdMapKey3 = []
+        , weirdMap = new Map();
+      
+      weirdMap.set(weirdMapKey1, 'val1');
+      weirdMap.set(weirdMapKey2, 'val2');
+
+      expect(weirdMap).to.have.all.keys([weirdMapKey1, weirdMapKey2]);
+      expect(weirdMap).to.not.have.all.keys([weirdMapKey1, weirdMapKey3]);
 
       if (typeof Symbol === 'function') {
         var symMapKey1 = Symbol()
           , symMapKey2 = Symbol()
-          , symMapKey3 = Symbol();
+          , symMapKey3 = Symbol()
+          , symMap = new Map();
+        
+        symMap.set(symMapKey1, 'val1');
+        symMap.set(symMapKey2, 'val2');
 
-        expect(new Map([[symMapKey1, 'symValue1'], [symMapKey2, 'symValue2']])).to.have.all.keys(symMapKey1, symMapKey2);
-        expect(new Map([[symMapKey1, 'symValue1'], [symMapKey2, 'symValue2']])).to.have.any.keys(symMapKey1, symMapKey3);
-        expect(new Map([[symMapKey1, 'symValue1'], [symMapKey2, 'symValue2']])).to.contain.all.keys(symMapKey2, symMapKey1);
-        expect(new Map([[symMapKey1, 'symValue1'], [symMapKey2, 'symValue2']])).to.contain.any.keys(symMapKey3, symMapKey1);
+        expect(symMap).to.have.all.keys(symMapKey1, symMapKey2);
+        expect(symMap).to.have.any.keys(symMapKey1, symMapKey3);
+        expect(symMap).to.contain.all.keys(symMapKey2, symMapKey1);
+        expect(symMap).to.contain.any.keys(symMapKey3, symMapKey1);
 
-        expect(new Map([[symMapKey1, 'symValue1'], [symMapKey2, 'symValue2']])).to.not.have.all.keys(symMapKey1, symMapKey3);
-        expect(new Map([[symMapKey1, 'symValue1'], [symMapKey2, 'symValue2']])).to.not.have.any.keys(symMapKey3);
-        expect(new Map([[symMapKey1, 'symValue1'], [symMapKey2, 'symValue2']])).to.not.contain.all.keys(symMapKey3, symMapKey1);
-        expect(new Map([[symMapKey1, 'symValue1'], [symMapKey2, 'symValue2']])).to.not.contain.any.keys(symMapKey3);
+        expect(symMap).to.not.have.all.keys(symMapKey1, symMapKey3);
+        expect(symMap).to.not.have.any.keys(symMapKey3);
+        expect(symMap).to.not.contain.all.keys(symMapKey3, symMapKey1);
+        expect(symMap).to.not.contain.any.keys(symMapKey3);
       }
 
+      var errMap = new Map();
+
+      errMap.set({ foo: 1 });
+
       err(function(){
-        expect(new Map().set({ foo: 1 })).to.have.keys();
+        expect(errMap).to.have.keys();
       }, "keys required");
 
       err(function(){
-        expect(new Map().set({ foo: 1 })).to.have.keys([]);
+        expect(errMap).to.have.keys([]);
       }, "keys required");
 
       err(function(){
-        expect(new Map().set({ foo: 1 })).to.contain.keys();
+        expect(errMap).to.contain.keys();
       }, "keys required");
 
       err(function(){
-        expect(new Map().set({ foo: 1 })).to.contain.keys([]);
+        expect(errMap).to.contain.keys([]);
       }, "keys required");
     }
 
     if (typeof Set !== 'undefined') {
-      var aKey = {thisIs: 'anExampleObject'};
-      var anotherKey = {doingThisBecauseOf: 'referential equality'};
+      // Not using Set constructor args because not supported in IE 11.
+      var aKey = {thisIs: 'anExampleObject'}
+        , anotherKey = {doingThisBecauseOf: 'referential equality'}
+        , testSet = new Set();
+      
+      testSet.add(aKey);
+      testSet.add(anotherKey);
 
-      expect(new Set([aKey, anotherKey])).to.have.any.keys(aKey);
-      expect(new Set([aKey, anotherKey])).to.have.any.keys('thisDoesNotExist', 'thisToo', aKey);
-      expect(new Set([aKey, anotherKey])).to.have.all.keys(aKey, anotherKey);
+      expect(testSet).to.have.any.keys(aKey);
+      expect(testSet).to.have.any.keys('thisDoesNotExist', 'thisToo', aKey);
+      expect(testSet).to.have.all.keys(aKey, anotherKey);
 
-      expect(new Set([aKey, anotherKey])).to.contain.all.keys(aKey);
-      expect(new Set([aKey, anotherKey])).to.not.contain.all.keys(aKey, 'thisDoesNotExist');
+      expect(testSet).to.contain.all.keys(aKey);
+      expect(testSet).to.not.contain.all.keys(aKey, 'thisDoesNotExist');
 
-      expect(new Set([aKey, anotherKey])).to.not.have.any.keys({iDoNot: 'exist'});
-      expect(new Set([aKey, anotherKey])).to.not.have.any.keys('thisIsNotAkey', {iDoNot: 'exist'}, {33: 20});
-      expect(new Set([aKey, anotherKey])).to.not.have.all.keys('thisDoesNotExist', 'thisToo', anotherKey);
+      expect(testSet).to.not.have.any.keys({iDoNot: 'exist'});
+      expect(testSet).to.not.have.any.keys('thisIsNotAkey', {iDoNot: 'exist'}, {33: 20});
+      expect(testSet).to.not.have.all.keys('thisDoesNotExist', 'thisToo', anotherKey);
 
-      expect(new Set([aKey, anotherKey])).to.have.any.keys([aKey]);
-      expect(new Set([aKey, anotherKey])).to.have.any.keys([20, 1, aKey]);
-      expect(new Set([aKey, anotherKey])).to.have.all.keys([aKey, anotherKey]);
+      expect(testSet).to.have.any.keys([aKey]);
+      expect(testSet).to.have.any.keys([20, 1, aKey]);
+      expect(testSet).to.have.all.keys([aKey, anotherKey]);
 
-      expect(new Set([aKey, anotherKey])).to.not.have.any.keys([{13: 37}, 'thisDoesNotExist', 'thisToo']);
-      expect(new Set([aKey, anotherKey])).to.not.have.any.keys([20, 1, {13: 37}]);
-      expect(new Set([aKey, anotherKey])).to.not.have.all.keys([aKey, {'iDoNot': 'exist'}]);
+      expect(testSet).to.not.have.any.keys([{13: 37}, 'thisDoesNotExist', 'thisToo']);
+      expect(testSet).to.not.have.any.keys([20, 1, {13: 37}]);
+      expect(testSet).to.not.have.all.keys([aKey, {'iDoNot': 'exist'}]);
 
       var weirdSetKey1 = Object.create(null)
         , weirdSetKey2 = {toString: NaN}
-        , weirdSetKey3 = [];
-      expect(new Set([weirdSetKey1, weirdSetKey2])).to.have.all.keys([weirdSetKey1, weirdSetKey2]);
-      expect(new Set([weirdSetKey1, weirdSetKey2])).to.not.have.all.keys([weirdSetKey1, weirdSetKey3]);
+        , weirdSetKey3 = []
+        , weirdSet = new Set();
+      
+      weirdSet.add(weirdSetKey1);
+      weirdSet.add(weirdSetKey2);
+
+      expect(weirdSet).to.have.all.keys([weirdSetKey1, weirdSetKey2]);
+      expect(weirdSet).to.not.have.all.keys([weirdSetKey1, weirdSetKey3]);
 
       if (typeof Symbol === 'function') {
         var symSetKey1 = Symbol()
           , symSetKey2 = Symbol()
-          , symSetKey3 = Symbol();
+          , symSetKey3 = Symbol()
+          , symSet = new Set();
+        
+        symSet.add(symSetKey1);
+        symSet.add(symSetKey2);
 
-        expect(new Set([symSetKey1, symSetKey2])).to.have.all.keys(symSetKey1, symSetKey2);
-        expect(new Set([symSetKey1, symSetKey2])).to.have.any.keys(symSetKey1, symSetKey3);
-        expect(new Set([symSetKey1, symSetKey2])).to.contain.all.keys(symSetKey2, symSetKey1);
-        expect(new Set([symSetKey1, symSetKey2])).to.contain.any.keys(symSetKey3, symSetKey1);
+        expect(symSet).to.have.all.keys(symSetKey1, symSetKey2);
+        expect(symSet).to.have.any.keys(symSetKey1, symSetKey3);
+        expect(symSet).to.contain.all.keys(symSetKey2, symSetKey1);
+        expect(symSet).to.contain.any.keys(symSetKey3, symSetKey1);
 
-        expect(new Set([symSetKey1, symSetKey2])).to.not.have.all.keys(symSetKey1, symSetKey3);
-        expect(new Set([symSetKey1, symSetKey2])).to.not.have.any.keys(symSetKey3);
-        expect(new Set([symSetKey1, symSetKey2])).to.not.contain.all.keys(symSetKey3, symSetKey1);
-        expect(new Set([symSetKey1, symSetKey2])).to.not.contain.any.keys(symSetKey3);
+        expect(symSet).to.not.have.all.keys(symSetKey1, symSetKey3);
+        expect(symSet).to.not.have.any.keys(symSetKey3);
+        expect(symSet).to.not.contain.all.keys(symSetKey3, symSetKey1);
+        expect(symSet).to.not.contain.any.keys(symSetKey3);
       }
 
+      var errSet = new Set();
+      errSet.add({ foo: 1});
+
       err(function(){
-        expect(new Set().add({ foo: 1 })).to.have.keys();
+        expect(errSet).to.have.keys();
       }, "keys required");
 
       err(function(){
-        expect(new Set().add({ foo: 1 })).to.have.keys([]);
+        expect(errSet).to.have.keys([]);
       }, "keys required");
 
       err(function(){
-        expect(new Set().add({ foo: 1 })).to.contain.keys();
+        expect(errSet).to.contain.keys();
       }, "keys required");
 
       err(function(){
-        expect(new Set().add({ foo: 1 })).to.contain.keys([]);
+        expect(errSet).to.contain.keys([]);
       }, "keys required");
     }
 

--- a/test/should.js
+++ b/test/should.js
@@ -650,125 +650,160 @@ describe('should', function() {
     }
 
     if (typeof Map !== 'undefined') {
-      var aKey = {thisIs: 'anExampleObject'};
-      var anotherKey = {doingThisBecauseOf: 'referential equality'};
+      // Not using Map constructor args because not supported in IE 11.
+      var aKey = {thisIs: 'anExampleObject'}
+        , anotherKey = {doingThisBecauseOf: 'referential equality'}
+        , testMap = new Map();
+      
+      testMap.set(aKey, 'aValue');
+      testMap.set(anotherKey, 'anotherValue');
 
-      new Map([[aKey, 'aValue'], [anotherKey, 'anotherValue']]).should.have.any.keys(aKey);
-      new Map([[aKey, 'aValue'], [anotherKey, 'anotherValue']]).should.have.any.keys('thisDoesNotExist', 'thisToo', aKey);
-      new Map([[aKey, 'aValue'], [anotherKey, 'anotherValue']]).should.have.all.keys(aKey, anotherKey);
+      testMap.should.have.any.keys(aKey);
+      testMap.should.have.any.keys('thisDoesNotExist', 'thisToo', aKey);
+      testMap.should.have.all.keys(aKey, anotherKey);
 
+      testMap.should.contain.all.keys(aKey);
+      testMap.should.not.contain.all.keys(aKey, 'thisDoesNotExist');
+      testMap.should.not.have.any.keys({iDoNot: 'exist'});
+      testMap.should.not.have.all.keys('thisDoesNotExist', 'thisToo', anotherKey);
 
-      new Map([[aKey, 'aValue'], [anotherKey, 'anotherValue']]).should.contain.all.keys(aKey);
-      new Map([[aKey, 'aValue'], [anotherKey, 'anotherValue']]).should.not.contain.all.keys(aKey, 'thisDoesNotExist');
-      new Map([[aKey, 'aValue'], [anotherKey, 'anotherValue']]).should.not.have.any.keys({iDoNot: 'exist'});
-      new Map([[aKey, 'aValue'], [anotherKey, 'anotherValue']]).should.not.have.all.keys('thisDoesNotExist', 'thisToo', anotherKey);
+      testMap.should.have.any.keys([aKey]);
+      testMap.should.have.any.keys([20, 1, aKey]);
+      testMap.should.have.all.keys([aKey, anotherKey]);
 
-      new Map([[aKey, 'aValue'], [anotherKey, 'anotherValue']]).should.have.any.keys([aKey]);
-      new Map([[aKey, 'aValue'], [anotherKey, 'anotherValue']]).should.have.any.keys([20, 1, aKey]);
-      new Map([[aKey, 'aValue'], [anotherKey, 'anotherValue']]).should.have.all.keys([aKey, anotherKey]);
-
-      new Map([[aKey, 'aValue'], [anotherKey, 'anotherValue']]).should.not.have.any.keys([{13: 37}, 'thisDoesNotExist', 'thisToo']);
-      new Map([[aKey, 'aValue'], [anotherKey, 'anotherValue']]).should.not.have.any.keys([20, 1, {13: 37}]);
-      new Map([[aKey, 'aValue'], [anotherKey, 'anotherValue']]).should.not.have.all.keys([aKey, {'iDoNot': 'exist'}]);
+      testMap.should.not.have.any.keys([{13: 37}, 'thisDoesNotExist', 'thisToo']);
+      testMap.should.not.have.any.keys([20, 1, {13: 37}]);
+      testMap.should.not.have.all.keys([aKey, {'iDoNot': 'exist'}]);
 
       var weirdMapKey1 = Object.create(null)
         , weirdMapKey2 = {toString: NaN}
-        , weirdMapKey3 = [];
-      new Map([[weirdMapKey1, 'val1'], [weirdMapKey2, 'val2']]).should.have.all.keys([weirdMapKey1, weirdMapKey2]);
-      new Map([[weirdMapKey1, 'val1'], [weirdMapKey2, 'val2']]).should.not.have.all.keys([weirdMapKey1, weirdMapKey3]);
+        , weirdMapKey3 = []
+        , weirdMap = new Map();
+      
+      weirdMap.set(weirdMapKey1, 'val1');
+      weirdMap.set(weirdMapKey2, 'val2');
+
+      weirdMap.should.have.all.keys([weirdMapKey1, weirdMapKey2]);
+      weirdMap.should.not.have.all.keys([weirdMapKey1, weirdMapKey3]);
 
       if (typeof Symbol === 'function') {
         var symMapKey1 = Symbol()
           , symMapKey2 = Symbol()
-          , symMapKey3 = Symbol();
+          , symMapKey3 = Symbol()
+          , symMap = new Map();
+        
+        symMap.set(symMapKey1, 'val1');
+        symMap.set(symMapKey2, 'val2');
 
-        new Map([[symMapKey1, 'symValue1'], [symMapKey2, 'symValue2']]).should.have.all.keys(symMapKey1, symMapKey2);
-        new Map([[symMapKey1, 'symValue1'], [symMapKey2, 'symValue2']]).should.have.any.keys(symMapKey1, symMapKey3);
-        new Map([[symMapKey1, 'symValue1'], [symMapKey2, 'symValue2']]).should.contain.all.keys(symMapKey2, symMapKey1);
-        new Map([[symMapKey1, 'symValue1'], [symMapKey2, 'symValue2']]).should.contain.any.keys(symMapKey3, symMapKey1);
+        symMap.should.have.all.keys(symMapKey1, symMapKey2);
+        symMap.should.have.any.keys(symMapKey1, symMapKey3);
+        symMap.should.contain.all.keys(symMapKey2, symMapKey1);
+        symMap.should.contain.any.keys(symMapKey3, symMapKey1);
 
-        new Map([[symMapKey1, 'symValue1'], [symMapKey2, 'symValue2']]).should.not.have.all.keys(symMapKey1, symMapKey3);
-        new Map([[symMapKey1, 'symValue1'], [symMapKey2, 'symValue2']]).should.not.have.any.keys(symMapKey3);
-        new Map([[symMapKey1, 'symValue1'], [symMapKey2, 'symValue2']]).should.not.contain.all.keys(symMapKey3, symMapKey1);
-        new Map([[symMapKey1, 'symValue1'], [symMapKey2, 'symValue2']]).should.not.contain.any.keys(symMapKey3);
+        symMap.should.not.have.all.keys(symMapKey1, symMapKey3);
+        symMap.should.not.have.any.keys(symMapKey3);
+        symMap.should.not.contain.all.keys(symMapKey3, symMapKey1);
+        symMap.should.not.contain.any.keys(symMapKey3);
       }
 
+      var errMap = new Map();
+
+      errMap.set({ foo: 1 });
+
       err(function(){
-        new Map().set({ foo: 1 }).should.have.keys();
+        errMap.should.have.keys();
       }, "keys required");
 
       err(function(){
-        new Map().set({ foo: 1 }).should.have.keys([]);
+        errMap.should.have.keys([]);
       }, "keys required");
 
       err(function(){
-        new Map().set({ foo: 1 }).should.contain.keys();
+        errMap.should.contain.keys();
       }, "keys required");
 
       err(function(){
-        new Map().set({ foo: 1 }).should.contain.keys([]);
+        errMap.should.contain.keys([]);
       }, "keys required");
     }
 
     if (typeof Set !== 'undefined') {
-      var aKey = {thisIs: 'anExampleObject'};
-      var anotherKey = {doingThisBecauseOf: 'referential equality'};
+      // Not using Set constructor args because not supported in IE 11.
+      var aKey = {thisIs: 'anExampleObject'}
+        , anotherKey = {doingThisBecauseOf: 'referential equality'}
+        , testSet = new Set();
+      
+      testSet.add(aKey);
+      testSet.add(anotherKey);
 
-      new Set([aKey, anotherKey]).should.have.any.keys(aKey);
-      new Set([aKey, anotherKey]).should.have.any.keys('thisDoesNotExist', 'thisToo', aKey);
-      new Set([aKey, anotherKey]).should.have.all.keys(aKey, anotherKey);
+      testSet.should.have.any.keys(aKey);
+      testSet.should.have.any.keys('thisDoesNotExist', 'thisToo', aKey);
+      testSet.should.have.all.keys(aKey, anotherKey);
 
-      new Set([aKey, anotherKey]).should.contain.all.keys(aKey);
-      new Set([aKey, anotherKey]).should.not.contain.all.keys(aKey, 'thisDoesNotExist');
+      testSet.should.contain.all.keys(aKey);
+      testSet.should.not.contain.all.keys(aKey, 'thisDoesNotExist');
 
-      new Set([aKey, anotherKey]).should.not.have.any.keys({iDoNot: 'exist'});
-      new Set([aKey, anotherKey]).should.not.have.any.keys('thisIsNotAkey', {iDoNot: 'exist'}, {33: 20});
-      new Set([aKey, anotherKey]).should.not.have.all.keys('thisDoesNotExist', 'thisToo', anotherKey);
+      testSet.should.not.have.any.keys({iDoNot: 'exist'});
+      testSet.should.not.have.any.keys('thisIsNotAkey', {iDoNot: 'exist'}, {33: 20});
+      testSet.should.not.have.all.keys('thisDoesNotExist', 'thisToo', anotherKey);
 
-      new Set([aKey, anotherKey]).should.have.any.keys([aKey]);
-      new Set([aKey, anotherKey]).should.have.any.keys([20, 1, aKey]);
-      new Set([aKey, anotherKey]).should.have.all.keys([aKey, anotherKey]);
+      testSet.should.have.any.keys([aKey]);
+      testSet.should.have.any.keys([20, 1, aKey]);
+      testSet.should.have.all.keys([aKey, anotherKey]);
 
-      new Set([aKey, anotherKey]).should.not.have.any.keys([{13: 37}, 'thisDoesNotExist', 'thisToo']);
-      new Set([aKey, anotherKey]).should.not.have.any.keys([20, 1, {13: 37}]);
-      new Set([aKey, anotherKey]).should.not.have.all.keys([aKey, {'iDoNot': 'exist'}]);
+      testSet.should.not.have.any.keys([{13: 37}, 'thisDoesNotExist', 'thisToo']);
+      testSet.should.not.have.any.keys([20, 1, {13: 37}]);
+      testSet.should.not.have.all.keys([aKey, {'iDoNot': 'exist'}]);
 
       var weirdSetKey1 = Object.create(null)
         , weirdSetKey2 = {toString: NaN}
-        , weirdSetKey3 = [];
-      new Set([weirdSetKey1, weirdSetKey2]).should.have.all.keys([weirdSetKey1, weirdSetKey2]);
-      new Set([weirdSetKey1, weirdSetKey2]).should.not.have.all.keys([weirdSetKey1, weirdSetKey3]);
+        , weirdSetKey3 = []
+        , weirdSet = new Set();
+      
+      weirdSet.add(weirdSetKey1);
+      weirdSet.add(weirdSetKey2);
+
+      weirdSet.should.have.all.keys([weirdSetKey1, weirdSetKey2]);
+      weirdSet.should.not.have.all.keys([weirdSetKey1, weirdSetKey3]);
 
       if (typeof Symbol === 'function') {
         var symSetKey1 = Symbol()
           , symSetKey2 = Symbol()
-          , symSetKey3 = Symbol();
+          , symSetKey3 = Symbol()
+          , symSet = new Set();
+        
+        symSet.add(symSetKey1);
+        symSet.add(symSetKey2);
 
-        new Set([symSetKey1, symSetKey2]).should.have.all.keys(symSetKey1, symSetKey2);
-        new Set([symSetKey1, symSetKey2]).should.have.any.keys(symSetKey1, symSetKey3);
-        new Set([symSetKey1, symSetKey2]).should.contain.all.keys(symSetKey2, symSetKey1);
-        new Set([symSetKey1, symSetKey2]).should.contain.any.keys(symSetKey3, symSetKey1);
+        symSet.should.have.all.keys(symSetKey1, symSetKey2);
+        symSet.should.have.any.keys(symSetKey1, symSetKey3);
+        symSet.should.contain.all.keys(symSetKey2, symSetKey1);
+        symSet.should.contain.any.keys(symSetKey3, symSetKey1);
 
-        new Set([symSetKey1, symSetKey2]).should.not.have.all.keys(symSetKey1, symSetKey3);
-        new Set([symSetKey1, symSetKey2]).should.not.have.any.keys(symSetKey3);
-        new Set([symSetKey1, symSetKey2]).should.not.contain.all.keys(symSetKey3, symSetKey1);
-        new Set([symSetKey1, symSetKey2]).should.not.contain.any.keys(symSetKey3);
+        symSet.should.not.have.all.keys(symSetKey1, symSetKey3);
+        symSet.should.not.have.any.keys(symSetKey3);
+        symSet.should.not.contain.all.keys(symSetKey3, symSetKey1);
+        symSet.should.not.contain.any.keys(symSetKey3);
       }
 
+      var errSet = new Set();
+
+      errSet.add({ foo: 1 });
+
       err(function(){
-        new Set().add({ foo: 1 }).should.have.keys();
+        errSet.should.have.keys();
       }, "keys required");
 
       err(function(){
-        new Set().add({ foo: 1 }).should.have.keys([]);
+        errSet.should.have.keys([]);
       }, "keys required");
 
       err(function(){
-        new Set().add({ foo: 1 }).should.contain.keys();
+        errSet.should.contain.keys();
       }, "keys required");
 
       err(function(){
-        new Set().add({ foo: 1 }).should.contain.keys([]);
+        errSet.should.contain.keys([]);
       }, "keys required");
     }
 

--- a/test/utilities.js
+++ b/test/utilities.js
@@ -264,12 +264,15 @@ describe('utilities', function () {
     // Checking if it's really an instance of an Assertion
     expect(assertion2).to.be.instanceOf(assertionConstructor);
 
-    // Test chaining `.length` after a method to guarantee it is not a function's `length`
+    // Test chaining `.length` after a method to guarantee it's not a function's
+    // `length`. Note: 'instanceof' cannot be used here because the test will
+    // fail in IE 10 due to how addChainableMethod works without __proto__
+    // support. Therefore, test the constructor property of length instead.
     var anAssertion = expect([1, 2, 3]).to.be.an.instanceof(Array);
-    expect(anAssertion.length).to.be.an.instanceof(assertionConstructor);
+    expect(anAssertion.length.constructor).to.equal(assertionConstructor);
 
     var anotherAssertion = expect([1, 2, 3]).to.have.a.lengthOf(3).and.to.be.ok;
-    expect(anotherAssertion.length).to.be.an.instanceof(assertionConstructor);
+    expect(anotherAssertion.length.constructor).to.equal(assertionConstructor);
   });
 
   it('overwriteMethod', function () {


### PR DESCRIPTION
There are 4 failing tests in IE 11 and 1 failing test in IE 10. 

This PR in combination with #640 (which updates type-detect to v2.0.0) resolves all of them, hopefully making Travis CI happy so that our builds stop showing as "Failing".

Covered by this PR:

- IE 11's `Set` and `Map` don't support constructor arguments or `.set`/`.add` chaining. Therefore, I refactored tests to setup their `Set`s and `Map`s without using either unsupported feature.
- IE 11's `Set` and `Map` don't support the `.keys` method. Therefore, I made a small change to `assertKeys` to populate the `actual` array using `forEach` instead.
- IE 10 doesn't support `__proto__`, which means `addChainableMethod` uses different logic to do its thing. Unfortunately, this different logic isn't compatible with one of the `addMethod` assertions that validates the `.length` chainable method using `instanceof`. Therefore, I switched the assertion to perform the validation using `length.constructor`.

Covered by #640:

- IE 11's `Set` and `Map` aren't properly detected by `type-detect` v1.0.0. Both `assertKeys` and `globalErr` rely on proper type detection, so some tests will fail until type-detect is upgraded.