### PR TITLE
Fix chai.use as ES6 named export

### DIFF
--- a/lib/chai.js
+++ b/lib/chai.js
@@ -37,11 +37,11 @@ var util = require('./chai/utils');
 
 exports.use = function (fn) {
   if (!~used.indexOf(fn)) {
-    fn(this, util);
+    fn(exports, util);
     used.push(fn);
   }
 
-  return this;
+  return exports;
 };
 
 /*!

--- a/test/plugins.js
+++ b/test/plugins.js
@@ -21,4 +21,20 @@ describe('plugins', function () {
       chai.use(plugin);
     }).to.not.throw();
   });
+
+  it('.use detached from chai object', function () {
+    function anotherPlugin (chai) {
+      Object.defineProperty(chai.Assertion.prototype, 'moreTesting', {
+        get: function () {
+          return 'more success';
+        }
+      });
+    }
+
+    var use = chai.use;
+    use(anotherPlugin);
+
+    var expect = chai.expect;
+    expect(expect('').moreTesting).to.equal('more success');
+  });
 });


### PR DESCRIPTION
- Fixes #718 
- Allows `use` to be imported in ES6 as follows:
```js
import {use} from "chai";
```