### PR TITLE
docs: add @meeber to core contributor avatars

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ concerns. We will do our best to respond in a timely manner.
 [![Veselin Todorov](https://avatars3.githubusercontent.com/u/330048?v=3&s=50)](https://github.com/vesln)
 [![Keith Cirkel](https://avatars3.githubusercontent.com/u/118266?v=3&s=50)](https://github.com/keithamus)
 [![Lucas Fernandes da Costa](https://avatars3.githubusercontent.com/u/6868147?v=3&s=50)](https://github.com/lucasfcosta)
+[![Grant Snodgrass](https://avatars3.githubusercontent.com/u/17260989?v=3&s=50)](https://github.com/meeber)
 
 ## License
 


### PR DESCRIPTION
I just noticed @meeber's lovely profile pic was missing from our readme. This will not stand, and must be fixed! P1 issue!