### PR TITLE
docs: fix link to OpenCollective

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 [![Slack Status](https://chai-slack.herokuapp.com/badge.svg)]( https://chai-slack.herokuapp.com/)
 [![Join the chat at https://gitter.im/chaijs/chai](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/chaijs/chai)
-[![OpenCollective](https://opencollective.com/chaijs/backers/badge.svg)](#backers) 
+[![OpenCollective](https://opencollective.com/chaijs/backers/badge.svg)](https://opencollective.com/chaijs) 
 
 
 Chai is a BDD / TDD assertion library for [node](http://nodejs.org) and the browser that


### PR DESCRIPTION
I think we were... okay I was... a bit hasty on merging this. The link went no where. This one goes to our Open Collective page. #732 