### PR TITLE
Fix tests for .throws using getConstructor name instead of .name prop

### DIFF
--- a/lib/chai/core/assertions.js
+++ b/lib/chai/core/assertions.js
@@ -1351,7 +1351,7 @@ module.exports = function (chai, _) {
       if (errorLike instanceof Error) {
         errorLikeString = '#{exp}';
       } else if (errorLike) {
-        errorLikeString = errorLike.name;
+        errorLikeString = _.checkError.getConstructorName(errorLike);
       }
 
       this.assert(
@@ -1360,7 +1360,8 @@ module.exports = function (chai, _) {
         , 'expected #{this} to not throw an error but #{act} was thrown'
         , errorLike && errorLike.toString()
         , (caughtErr instanceof Error ?
-            caughtErr.toString() : (typeof caughtErr === 'string' ? caughtErr : caughtErr && caughtErr.name))
+            caughtErr.toString() : (typeof caughtErr === 'string' ? caughtErr : caughtErr &&
+                                    _.checkError.getConstructorName(caughtErr)))
       );
     }
 


### PR DESCRIPTION
This fixes the failing tests for the `.throws` assertion.
The problem was that I was using `.name` to access the name of an Error instead of calling the `getConstructorName` function, which runs a polyfill for IE.

Sorry for the delay on this one, I had problems with karma and my IE VMs yesterday.