### PR TITLE
Fix new Promise example

### DIFF
--- a/lib/chai/core/assertions.js
+++ b/lib/chai/core/assertions.js
@@ -159,7 +159,7 @@ module.exports = function (chai, _) {
    *     expect(null).to.be.a('null');
    *     expect(undefined).to.be.an('undefined');
    *     expect(new Error).to.be.an('error');
-   *     expect(new Promise).to.be.a('promise');
+   *     expect(Promise.resolve()).to.be.a('promise');
    *     expect(new Float32Array).to.be.a('float32array');
    *     expect(Symbol()).to.be.a('symbol');
    *


### PR DESCRIPTION
`Promise` will throw unless `executor` is a function. Please, see [25.4.3.1, step 2](https://tc39.github.io/ecma262/#sec-promise-executor) of spec.