### PR TITLE
Fix 'empty' assertion called on null

### DIFF
--- a/lib/chai/core/assertions.js
+++ b/lib/chai/core/assertions.js
@@ -437,7 +437,7 @@ module.exports = function (chai, _) {
 
     if (Array.isArray(obj) || 'string' === typeof object) {
       expected = obj.length;
-    } else if (typeof obj === 'object') {
+    } else if (obj && 'object' === typeof obj) {
       expected = Object.keys(obj).length;
     }
 

--- a/test/expect.js
+++ b/test/expect.js
@@ -420,6 +420,7 @@ describe('expect', function () {
     function FakeArgs() {};
     FakeArgs.prototype.length = 0;
 
+    expect(null).to.be.empty;
     expect('').to.be.empty;
     expect('foo').not.to.be.empty;
     expect([]).to.be.empty;
@@ -428,6 +429,10 @@ describe('expect', function () {
     expect({arguments: 0}).not.to.be.empty;
     expect({}).to.be.empty;
     expect({foo: 'bar'}).not.to.be.empty;
+
+    err(function(){
+      expect(null).not.to.be.empty;
+    }, "expected null not to be empty");
 
     err(function(){
       expect('').not.to.be.empty;


### PR DESCRIPTION
Because of `typeof null` thing and `ToObject` in `Object.keys`, `TypeError` was thrown.