### PR TITLE
Improve exist assertion (Triple equals and addition to assert interface)

### DIFF
--- a/lib/chai/core/assertions.js
+++ b/lib/chai/core/assertions.js
@@ -481,8 +481,9 @@ module.exports = function (chai, _) {
    */
 
   Assertion.addProperty('exist', function () {
+    var val = flag(this, 'object');
     this.assert(
-        null != flag(this, 'object')
+        val !== null && val !== undefined
       , 'expected #{this} to exist'
       , 'expected #{this} to not exist'
     );

--- a/lib/chai/interface/assert.js
+++ b/lib/chai/interface/assert.js
@@ -461,6 +461,48 @@ module.exports = function (chai, util) {
   };
 
   /**
+   * ### .exists
+   *
+   * Asserts that the target is neither `null` nor `undefined`.
+   *
+   *     var foo = 'hi';
+   *
+   *     assert.exists(foo, 'foo is neither `null` nor `undefined`');
+   *
+   * @name exists
+   * @param {Mixed} value
+   * @param {String} message
+   * @namespace Assert
+   * @api public
+   */
+
+  assert.exists = function (val, msg) {
+    new Assertion(val, msg).to.exist;
+  };
+
+  /**
+   * ### .notExists
+   *
+   * Asserts that the target is either `null` or `undefined`.
+   *
+   *     var bar = null
+   *       , baz;
+   *
+   *     assert.notExists(bar);
+   *     assert.notExists(baz, 'baz is either null or undefined');
+   *
+   * @name notExists
+   * @param {Mixed} value
+   * @param {String} message
+   * @namespace Assert
+   * @api public
+   */
+
+  assert.notExists = function (val, msg) {
+    new Assertion(val, msg).to.not.exist;
+  };
+
+  /**
    * ### .isUndefined(value, [message])
    *
    * Asserts that `value` is `undefined`.

--- a/test/assert.js
+++ b/test/assert.js
@@ -344,6 +344,31 @@ describe('assert', function () {
     }, "expected 'hello' not to be NaN");
   });
 
+  it('exists', function() {
+    var meeber = 'awesome';
+    var iDoNotExist;
+       
+    assert.exists(meeber);
+    assert.exists(0);
+    assert.exists(false);
+    assert.exists('');
+
+    err(function (){
+      assert.exists(iDoNotExist);
+    }, "expected undefined to exist");
+  });
+
+  it('notExists', function() {
+    var meeber = 'awesome';
+    var iDoNotExist;
+       
+    assert.notExists(iDoNotExist);
+
+    err(function (){
+      assert.notExists(meeber);
+    }, "expected 'awesome' to not exist");
+  });
+
   it('isUndefined', function() {
     assert.isUndefined(undefined);
 

--- a/test/expect.js
+++ b/test/expect.js
@@ -124,6 +124,17 @@ describe('expect', function () {
       , bar;
     expect(foo).to.exist;
     expect(bar).to.not.exist;
+    expect(0).to.exist;
+    expect(false).to.exist;
+    expect('').to.exist;
+
+    err(function () {
+      expect(bar).to.exist;
+    }, "expected undefined to exist");
+
+    err(function () {
+      expect(foo).to.not.exist(foo);
+    }, "expected 'bar' to not exist");
   });
 
   it('arguments', function(){

--- a/test/should.js
+++ b/test/should.js
@@ -67,6 +67,9 @@ describe('should', function() {
       , bar = undefined;
     should.exist(foo);
     should.not.exist(bar);
+    should.exist(0);
+    should.exist(false);
+    should.exist('');
 
     err(function () {
       should.exist(bar, 'blah');
@@ -74,7 +77,7 @@ describe('should', function() {
 
     err(function () {
       should.not.exist(foo, 'blah');
-    }, "blah: expected 'foo' to not exist")
+    }, "blah: expected 'foo' to not exist");
   });
 
   it('root equal', function () {


### PR DESCRIPTION
After reading #777 I noticed we were using `null != flag(this, 'object')` on our `exist` assertion. That is correct indeed (given our main goal with this assertion), but I feel more comfortable using `!==` to check if the value is neither `null` or `undefined`, which makes thinks more explicit.

I also added some tests just to make sure `falsy` values or anything "strange" would work.

And at last, but not least, the `exist` assertion was added to the `assert` interface as `assert.exists` and `assert.notExists`.

------------------------------------

For bonus style points on this commit, here goes a picture of me and @vieiralucas with Jake Archibald:

![Jake Archibald Being Awesome with Us](https://cloud.githubusercontent.com/assets/6868147/18023638/f03074c2-6bd1-11e6-9552-d195e9cf607f.jpg)
