### PR TITLE
Adding `.finite`. Fixes #271

### DIFF
--- a/lib/chai/core/assertions.js
+++ b/lib/chai/core/assertions.js
@@ -2151,16 +2151,15 @@ module.exports = function (chai, _) {
    *
    * Asserts that the target is a finite number. Unlike `.a('number')`, this will fail for `NaN` and `Infinity`.
    *
-   *     expect(4).to.be.finite();
-   *     expect(NaN).to.not.be.finite();
+   *     expect(4).to.be.finite;
+   *     expect(NaN).to.not.be.finite;
    *
    * @name finite
    * @namespace BDD
    * @api public
    */
 
-  Assertion.addMethod('finite', function(msg) {
-    if (msg) flag(this, 'message', msg);
+  Assertion.addProperty('finite', function(msg) {
     var obj = flag(this, 'object');
 
     this.assert(

--- a/lib/chai/core/assertions.js
+++ b/lib/chai/core/assertions.js
@@ -2149,9 +2149,10 @@ module.exports = function (chai, _) {
   /**
    * ### .finite
    *
-   * Asserts that the target is a finite number. Unlike `.a('number')`, this will fail for `NaN` and `Infinity`
+   * Asserts that the target is a finite number. Unlike `.a('number')`, this will fail for `NaN` and `Infinity`.
    *
-   *     expect(foo).to.be.finite();
+   *     expect(4).to.be.finite();
+   *     expect(NaN).to.not.be.finite();
    *
    * @name finite
    * @namespace BDD

--- a/lib/chai/core/assertions.js
+++ b/lib/chai/core/assertions.js
@@ -2145,4 +2145,27 @@ module.exports = function (chai, _) {
       , 'expected #{this} to not be frozen'
     );
   });
+
+  /**
+   * ### .finite
+   *
+   * Asserts that the target is a finite number. Unlike `.a('number')`, this will fail for `NaN` and `Infinity`
+   *
+   *     expect(foo).to.be.finite();
+   *
+   * @name finite
+   * @namespace BDD
+   * @api public
+   */
+
+  Assertion.addMethod('finite', function(msg) {
+    if (msg) flag(this, 'message', msg);
+    var obj = flag(this, 'object');
+
+    this.assert(
+        typeof obj === "number" && isFinite(obj)
+      , 'expected #{this} to be a finite number'
+      , 'expected #{this} to not be a finite number'
+    );
+  });
 };

--- a/lib/chai/interface/assert.js
+++ b/lib/chai/interface/assert.js
@@ -735,7 +735,6 @@ module.exports = function (chai, util) {
    /**
    * ### .isFinite(value, [message])
    *
-   * Asserts that `value` is a finite number. This will fail for NaN, unlike `.isNumber`
    * Asserts that `value` is a finite number. Unlike `.isNumber`, this will fail for `NaN` and `Infinity`
    *
    *     var cups = 2;

--- a/lib/chai/interface/assert.js
+++ b/lib/chai/interface/assert.js
@@ -750,7 +750,7 @@ module.exports = function (chai, util) {
    */
 
   assert.isFinite = function (val, msg) {
-    new Assertion(val, msg).to.be.finite();
+    new Assertion(val, msg).to.be.finite;
   };
 
   /**

--- a/lib/chai/interface/assert.js
+++ b/lib/chai/interface/assert.js
@@ -732,6 +732,26 @@ module.exports = function (chai, util) {
     new Assertion(val, msg).to.not.be.a('number');
   };
 
+   /**
+   * ### .isFinite(value, [message])
+   *
+   * Asserts that `value` is a finite number. This will fail for NaN, unlike `.isNumber`
+   * Asserts that `value` is a finite number. Unlike `.isNumber`, this will fail for `NaN` and `Infinity`
+   *
+   *     var cups = 2;
+   *     assert.isFinite(cups, 'how many cups');
+   *
+   * @name isFinite
+   * @param {Number} value
+   * @param {String} message
+   * @namespace Assert
+   * @api public
+   */
+
+  assert.isFinite = function (val, msg) {
+    new Assertion(val, msg).to.be.finite();
+  };
+
   /**
    * ### .isBoolean(value, [message])
    *

--- a/lib/chai/interface/assert.js
+++ b/lib/chai/interface/assert.js
@@ -740,6 +740,8 @@ module.exports = function (chai, util) {
    *     var cups = 2;
    *     assert.isFinite(cups, 'how many cups');
    *
+   *     assert.isFinite(NaN); // throws
+   *
    * @name isFinite
    * @param {Number} value
    * @param {String} message

--- a/test/assert.js
+++ b/test/assert.js
@@ -460,16 +460,28 @@ describe('assert', function () {
   });
 
   it('isFinite', function() {
-    assert.isFinite(1);
-    assert.isFinite(Number('3'));
+    assert.isFinite(4);
+    assert.isFinite(-10);
 
-    err(function () {
-      assert.isFinite('1');
-    }, "expected \'1\' to be a finite number");
-
-    err(function () {
+    err(function(){
       assert.isFinite(NaN);
     }, "expected NaN to be a finite number");
+
+    err(function(){
+      assert.isFinite(Infinity);
+    }, "expected Infinity to be a finite number");
+
+    err(function(){
+      assert.isFinite('foo');
+    }, "expected \'foo\' to be a finite number");
+
+    err(function(){
+      assert.isFinite([]);
+    }, "expected [] to be a finite number");
+
+    err(function(){
+      assert.isFinite({});
+    }, "expected {} to be a finite number");
   })
 
   it('isBoolean', function() {

--- a/test/assert.js
+++ b/test/assert.js
@@ -459,6 +459,19 @@ describe('assert', function () {
     }, "expected 4 not to be a number");
   });
 
+  it('isFinite', function() {
+    assert.isFinite(1);
+    assert.isFinite(Number('3'));
+
+    err(function () {
+      assert.isFinite('1');
+    }, "expected \'1\' to be a finite number");
+
+    err(function () {
+      assert.isFinite(NaN);
+    }, "expected NaN to be a finite number");
+  })
+
   it('isBoolean', function() {
     assert.isBoolean(true);
     assert.isBoolean(false);

--- a/test/expect.js
+++ b/test/expect.js
@@ -493,6 +493,31 @@ describe('expect', function () {
     }, "expected 'foo' not to be NaN");
   });
 
+  it('finite', function() {
+    expect(4).to.be.finite();
+    expect(-10).to.be.finite();
+
+    err(function(){
+      expect(NaN).to.be.finite();
+    }, "expected NaN to be a finite number");
+
+    err(function(){
+      expect(Infinity).to.be.finite();
+    }, "expected Infinity to be a finite number");
+
+    err(function(){
+      expect('foo').to.be.finite();
+    }, "expected \'foo\' to be a finite number");
+
+    err(function(){
+      expect([]).to.be.finite();
+    }, "expected [] to be a finite number");
+
+    err(function(){
+      expect({}).to.be.finite();
+    }, "expected {} to be a finite number");
+  });
+
   it('property(name)', function(){
     expect('test').to.have.property('length');
     expect(4).to.not.have.property('length');

--- a/test/expect.js
+++ b/test/expect.js
@@ -494,27 +494,27 @@ describe('expect', function () {
   });
 
   it('finite', function() {
-    expect(4).to.be.finite();
-    expect(-10).to.be.finite();
+    expect(4).to.be.finite;
+    expect(-10).to.be.finite;
 
     err(function(){
-      expect(NaN).to.be.finite();
+      expect(NaN).to.be.finite;
     }, "expected NaN to be a finite number");
 
     err(function(){
-      expect(Infinity).to.be.finite();
+      expect(Infinity).to.be.finite;
     }, "expected Infinity to be a finite number");
 
     err(function(){
-      expect('foo').to.be.finite();
+      expect('foo').to.be.finite;
     }, "expected \'foo\' to be a finite number");
 
     err(function(){
-      expect([]).to.be.finite();
+      expect([]).to.be.finite;
     }, "expected [] to be a finite number");
 
     err(function(){
-      expect({}).to.be.finite();
+      expect({}).to.be.finite;
     }, "expected {} to be a finite number");
   });
 

--- a/test/should.js
+++ b/test/should.js
@@ -432,27 +432,27 @@ describe('should', function() {
   });
 
   it('finite(value)', function() {
-    (4).should.be.finite();
-    (-10).should.be.finite();
+    (4).should.be.finite;
+    (-10).should.be.finite;
 
     err(function(){
-      (NaN).should.be.finite();
+      (NaN).should.be.finite;
     }, "expected NaN to be a finite number");
 
     err(function(){
-      (Infinity).should.be.finite();
+      (Infinity).should.be.finite;
     }, "expected Infinity to be a finite number");
 
     err(function(){
-      ('foo').should.be.finite();
+      ('foo').should.be.finite;
     }, "expected \'foo\' to be a finite number");
 
     err(function(){
-      ([]).should.be.finite();
+      ([]).should.be.finite;
     }, "expected [] to be a finite number");
 
     err(function(){
-      ({}).should.be.finite();
+      ({}).should.be.finite;
     }, "expected {} to be a finite number");
   });
 

--- a/test/should.js
+++ b/test/should.js
@@ -431,6 +431,31 @@ describe('should', function() {
     }, "expected { foo: \'bar\' } to be empty");
   });
 
+  it('finite(value)', function() {
+    (4).should.be.finite();
+    (-10).should.be.finite();
+
+    err(function(){
+      (NaN).should.be.finite();
+    }, "expected NaN to be a finite number");
+
+    err(function(){
+      (Infinity).should.be.finite();
+    }, "expected Infinity to be a finite number");
+
+    err(function(){
+      ('foo').should.be.finite();
+    }, "expected \'foo\' to be a finite number");
+
+    err(function(){
+      ([]).should.be.finite();
+    }, "expected [] to be a finite number");
+
+    err(function(){
+      ({}).should.be.finite();
+    }, "expected {} to be a finite number");
+  });
+
   it('property(name)', function(){
     'test'.should.have.property('length');
     (4).should.not.have.property('length');


### PR DESCRIPTION
As discussed in #271, `.isNumber` currently passes for `NaN`. This issue recently bit our team and so we wanted to move forward on the proposal in that issue. 

The implementation is the polyfill from https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/isFinite.