### PR TITLE
Fix broken tests in Node v6.5 and update supported node versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,12 @@ language: node_js
 addons:
   sauce_connect: true
 node_js:
-- 0.1
+ - 0.10 # to be removed 2016-10-01
+ - 0.12 # to be removed 2016-12-31
+ - 4 # to be removed 2018-04-01
+ - 6 # to be removed 2019-04-01
+ - lts/* # safety net; don't remove
+ - node # safety net; don't remove
 
 script:
 - make test-travisci

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "test": "make test"
   },
   "engines": {
-    "node": ">= 0.4.0"
+    "node": ">=0.10"
   },
   "dependencies": {
     "assertion-error": "^1.0.1",

--- a/test/expect.js
+++ b/test/expect.js
@@ -1546,87 +1546,87 @@ describe('expect', function () {
 
     err(function(){
       expect(goodFn).to.throw();
-    }, "expected [Function] to throw an error");
+    }, /^expected \[Function(: goodFn)*\] to throw an error$/);
 
     err(function(){
       expect(goodFn).to.throw(ReferenceError);
-    }, "expected [Function] to throw ReferenceError");
+    }, /^expected \[Function(: goodFn)*\] to throw ReferenceError$/);
 
     err(function(){
       expect(goodFn).to.throw(specificError);
-    }, "expected [Function] to throw 'RangeError: boo'");
+    }, /^expected \[Function(: goodFn)*\] to throw 'RangeError: boo'$/);
 
     err(function(){
       expect(badFn).to.not.throw();
-    }, "expected [Function] to not throw an error but 'Error: testing' was thrown");
+    }, /^expected \[Function(: badFn)*\] to not throw an error but 'Error: testing' was thrown$/);
 
     err(function(){
       expect(badFn).to.throw(ReferenceError);
-    }, "expected [Function] to throw 'ReferenceError' but 'Error: testing' was thrown");
+    }, /^expected \[Function(: badFn)*\] to throw 'ReferenceError' but 'Error: testing' was thrown$/);
 
     err(function(){
       expect(badFn).to.throw(specificError);
-    }, "expected [Function] to throw 'RangeError: boo' but 'Error: testing' was thrown");
+    }, /^expected \[Function(: badFn)*\] to throw 'RangeError: boo' but 'Error: testing' was thrown$/);
 
     err(function(){
       expect(badFn).to.not.throw(Error);
-    }, "expected [Function] to not throw 'Error' but 'Error: testing' was thrown");
+    }, /^expected \[Function(: badFn)*\] to not throw 'Error' but 'Error: testing' was thrown$/);
 
     err(function(){
       expect(refErrFn).to.not.throw(ReferenceError);
-    }, "expected [Function] to not throw 'ReferenceError' but 'ReferenceError: hello' was thrown");
+    }, /^expected \[Function(: refErrFn)*\] to not throw 'ReferenceError' but 'ReferenceError: hello' was thrown$/);
 
     err(function(){
       expect(badFn).to.throw(PoorlyConstructedError);
-    }, "expected [Function] to throw 'PoorlyConstructedError' but 'Error: testing' was thrown");
+    }, /^expected \[Function(: badFn)*\] to throw 'PoorlyConstructedError' but 'Error: testing' was thrown$/);
 
     err(function(){
       expect(ickyErrFn).to.not.throw(PoorlyConstructedError);
-    }, /^(expected \[Function\] to not throw 'PoorlyConstructedError' but)(.*)(PoorlyConstructedError|\{ Object \()(.*)(was thrown)$/);
+    }, /^(expected \[Function(: ickyErrFn)*\] to not throw 'PoorlyConstructedError' but)(.*)(PoorlyConstructedError|\{ Object \()(.*)(was thrown)$/);
 
     err(function(){
       expect(ickyErrFn).to.throw(ReferenceError);
-    }, /^(expected \[Function\] to throw 'ReferenceError' but)(.*)(PoorlyConstructedError|\{ Object \()(.*)(was thrown)$/);
+    }, /^(expected \[Function(: ickyErrFn)*\] to throw 'ReferenceError' but)(.*)(PoorlyConstructedError|\{ Object \()(.*)(was thrown)$/);
 
     err(function(){
       expect(specificErrFn).to.throw(new ReferenceError('eek'));
-    }, "expected [Function] to throw 'ReferenceError: eek' but 'RangeError: boo' was thrown");
+    }, /^expected \[Function(: specificErrFn)*\] to throw 'ReferenceError: eek' but 'RangeError: boo' was thrown$/);
 
     err(function(){
       expect(specificErrFn).to.not.throw(specificError);
-    }, "expected [Function] to not throw 'RangeError: boo'");
+    }, /^expected \[Function(: specificErrFn)*\] to not throw 'RangeError: boo'$/);
 
     err(function (){
       expect(badFn).to.not.throw(/testing/);
-    }, "expected [Function] to throw error not matching /testing/");
+    }, /^expected \[Function(: badFn)*\] to throw error not matching \/testing\/$/);
 
     err(function () {
       expect(badFn).to.throw(/hello/);
-    }, "expected [Function] to throw error matching /hello/ but got 'testing'");
+    }, /^expected \[Function(: badFn)*\] to throw error matching \/hello\/ but got 'testing'$/);
 
     err(function () {
       expect(badFn).to.throw(Error, /hello/, 'blah');
-    }, "blah: expected [Function] to throw error matching /hello/ but got 'testing'");
+    }, /^blah: expected \[Function(: badFn)*\] to throw error matching \/hello\/ but got 'testing'$/);
 
     err(function () {
       expect(badFn).to.throw(Error, 'hello', 'blah');
-    }, "blah: expected [Function] to throw error including 'hello' but got 'testing'");
+    }, /^blah: expected \[Function(: badFn)*\] to throw error including 'hello' but got 'testing'$/);
 
     err(function () {
       (customErrFn).should.not.throw();
-    }, "expected [Function] to not throw an error but 'CustomError: foo' was thrown");
+    }, /^expected \[Function(: customErrFn)*\] to not throw an error but 'CustomError: foo' was thrown$/);
 
     err(function(){
       expect(badFn).to.not.throw(Error, 'testing');
-    }, "expected [Function] to not throw 'Error' but 'Error: testing' was thrown");
+    }, /^expected \[Function(: badFn)*\] to not throw 'Error' but 'Error: testing' was thrown$/);
 
     err(function(){
       expect(emptyStringErrFn).to.not.throw(Error, '');
-    }, "expected [Function] to not throw 'Error' but 'Error' was thrown");
+    }, /^expected \[Function(: emptyStringErrFn)*\] to not throw 'Error' but 'Error' was thrown$/);
 
     err(function(){
       expect(emptyStringErrFn).to.not.throw('');
-    }, "expected [Function] to throw error not including ''");
+    }, /^expected \[Function(: emptyStringErrFn)*\] to throw error not including ''$/);
   });
 
   it('respondTo', function(){
@@ -1662,7 +1662,7 @@ describe('expect', function () {
 
     err(function(){
       expect(2).to.satisfy(matcher, 'blah');
-    }, "blah: expected 2 to satisfy [Function]");
+    }, /^blah: expected 2 to satisfy \[Function(: matcher)*\]$/);
   });
 
   it('closeTo', function(){

--- a/test/should.js
+++ b/test/should.js
@@ -1393,103 +1393,103 @@ describe('should', function() {
 
     err(function(){
       (goodFn).should.throw();
-    }, "expected [Function] to throw an error");
+    }, /^expected \[Function(: goodFn)*\] to throw an error$/);
 
     err(function(){
       (goodFn).should.throw(ReferenceError);
-    }, "expected [Function] to throw ReferenceError");
+    }, /^expected \[Function(: goodFn)*\] to throw ReferenceError$/);
 
     err(function(){
       (goodFn).should.throw(specificError);
-    }, "expected [Function] to throw 'RangeError: boo'");
+    }, /^expected \[Function(: goodFn)*\] to throw 'RangeError: boo'$/);
 
     err(function(){
       (badFn).should.not.throw();
-    }, "expected [Function] to not throw an error but 'Error: testing' was thrown");
+    }, /^expected \[Function(: badFn)*\] to not throw an error but 'Error: testing' was thrown$/);
 
     err(function(){
       (badFn).should.throw(ReferenceError);
-    }, "expected [Function] to throw 'ReferenceError' but 'Error: testing' was thrown");
+    }, /^expected \[Function(: badFn)*\] to throw 'ReferenceError' but 'Error: testing' was thrown$/);
 
     err(function(){
       (badFn).should.throw(specificError);
-    }, "expected [Function] to throw 'RangeError: boo' but 'Error: testing' was thrown");
+    }, /^expected \[Function(: badFn)*\] to throw 'RangeError: boo' but 'Error: testing' was thrown$/);
 
     err(function(){
       (badFn).should.not.throw(Error);
-    }, "expected [Function] to not throw 'Error' but 'Error: testing' was thrown");
+    }, /^expected \[Function(: badFn)*\] to not throw 'Error' but 'Error: testing' was thrown$/);
 
     err(function(){
       (stringErrFn).should.not.throw();
-    }, "expected [Function] to not throw an error but 'testing' was thrown");
+    }, /^expected \[Function(: stringErrFn)*\] to not throw an error but 'testing' was thrown$/);
 
     err(function(){
       (stringErrFn).should.throw(ReferenceError);
-    }, "expected [Function] to throw 'ReferenceError' but 'testing' was thrown");
+    }, /^expected \[Function(: stringErrFn)*\] to throw 'ReferenceError' but 'testing' was thrown$/);
 
     err(function(){
       (stringErrFn).should.throw(specificError);
-    }, "expected [Function] to throw 'RangeError: boo' but 'testing' was thrown");
+    }, /^expected \[Function(: stringErrFn)*\] to throw 'RangeError: boo' but 'testing' was thrown$/);
 
     err(function(){
       (stringErrFn).should.not.throw('testing');
-    }, "expected [Function] to throw error not including 'testing'");
+    }, /^expected \[Function(: stringErrFn)*\] to throw error not including 'testing'$/);
 
     err(function(){
       (refErrFn).should.not.throw(ReferenceError);
-    }, "expected [Function] to not throw 'ReferenceError' but 'ReferenceError: hello' was thrown");
+    }, /^expected \[Function(: refErrFn)*\] to not throw 'ReferenceError' but 'ReferenceError: hello' was thrown$/);
 
     err(function(){
       (badFn).should.throw(PoorlyConstructedError);
-    }, "expected [Function] to throw 'PoorlyConstructedError' but 'Error: testing' was thrown")
+    }, /^expected \[Function(: badFn)*\] to throw 'PoorlyConstructedError' but 'Error: testing' was thrown$/);
 
     err(function(){
       (ickyErrFn).should.not.throw(PoorlyConstructedError);
-    }, /^(expected \[Function\] to not throw 'PoorlyConstructedError' but)(.*)(PoorlyConstructedError|\{ Object \()(.*)(was thrown)$/);
+    }, /^(expected \[Function(: ickyErrFn)*\] to not throw 'PoorlyConstructedError' but)(.*)(PoorlyConstructedError|\{ Object \()(.*)(was thrown)$/);
 
     err(function(){
       (ickyErrFn).should.throw(ReferenceError);
-    }, /^(expected \[Function\] to throw 'ReferenceError' but)(.*)(PoorlyConstructedError|\{ Object \()(.*)(was thrown)$/);
+    }, /^(expected \[Function(: ickyErrFn)*\] to throw 'ReferenceError' but)(.*)(PoorlyConstructedError|\{ Object \()(.*)(was thrown)$/);
 
     err(function(){
       (specificErrFn).should.throw(new ReferenceError('eek'));
-    }, "expected [Function] to throw 'ReferenceError: eek' but 'RangeError: boo' was thrown");
+    }, /^expected \[Function(: specificErrFn)*\] to throw 'ReferenceError: eek' but 'RangeError: boo' was thrown$/);
 
     err(function(){
       (specificErrFn).should.not.throw(specificError);
-    }, "expected [Function] to not throw 'RangeError: boo'");
+    }, /^expected \[Function(: specificErrFn)*\] to not throw 'RangeError: boo'$/);
 
     err(function (){
       (badFn).should.not.throw(/testing/);
-    }, "expected [Function] to throw error not matching /testing/");
+    }, /^expected \[Function(: badFn)*\] to throw error not matching \/testing\/$/);
 
     err(function () {
       (badFn).should.throw(/hello/);
-    }, "expected [Function] to throw error matching /hello/ but got \'testing\'");
+    }, /^expected \[Function(: badFn)*\] to throw error matching \/hello\/ but got \'testing\'$/);
 
     err(function () {
       (badFn).should.throw(Error, /hello/, 'blah');
-    }, "blah: expected [Function] to throw error matching /hello/ but got 'testing'");
+    }, /^blah: expected \[Function(: badFn)*\] to throw error matching \/hello\/ but got 'testing'$/);
 
     err(function () {
       (badFn).should.throw(Error, 'hello', 'blah');
-    }, "blah: expected [Function] to throw error including 'hello' but got 'testing'");
+    }, /^blah: expected \[Function(: badFn)*\] to throw error including 'hello' but got 'testing'$/);
 
     err(function () {
       (customErrFn).should.not.throw();
-    }, "expected [Function] to not throw an error but 'CustomError: foo' was thrown");
+    }, /^expected \[Function(: customErrFn)*\] to not throw an error but 'CustomError: foo' was thrown$/);
 
     err(function(){
       (badFn).should.not.throw(Error, 'testing');
-    }, "expected [Function] to not throw 'Error' but 'Error: testing' was thrown");
+    }, /^expected \[Function(: badFn)*\] to not throw 'Error' but 'Error: testing' was thrown$/);
 
     err(function(){
       (emptyStringErrFn).should.not.throw(Error, '');
-    }, "expected [Function] to not throw 'Error' but 'Error' was thrown");
+    }, /^expected \[Function(: emptyStringErrFn)*\] to not throw 'Error' but 'Error' was thrown$/);
 
     err(function(){
       (emptyStringErrFn).should.not.throw('');
-    }, "expected [Function] to throw error not including ''");
+    }, /^expected \[Function(: emptyStringErrFn)*\] to throw error not including ''$/);
   });
 
   it('respondTo', function(){
@@ -1525,7 +1525,7 @@ describe('should', function() {
 
     err(function(){
       (2).should.satisfy(matcher, 'blah');
-    }, "blah: expected 2 to satisfy [Function]");
+    }, /^blah: expected 2 to satisfy \[Function(: matcher)*\]$/);
   });
 
   it('closeTo', function(){


### PR DESCRIPTION
- #783 is a prerequisite to this PR
- The first commit fixes a number of tests that were broken in Node v6.5 due to a change in how anonymous functions that are assigned to variables appear in failed assertion messages (from "[Function]" to "[Function: _var_name_]". 
- The second commit updates Travis Node versions (adds all versions of node that are officially maintained: 0.10, 0.12, 4, 6; also adds safety net aliases: lts/*, node).
- The third commit updates package.json's engines field to node v0.10 since it's the minimum version that we officially support.

Notes on Travis node versions:
- If there was only ever a total of two versions actively supported at the same time, one LTS and one Current, then the lts/* and node aliases would alone be sufficient. The challenge comes from the planned overlaps that are built into the Node release schedule, causing there to periodically be two LTS or two Current versions actively supported at once. The only way to prevent an actively supported version from being prematurely dropped from automated testing during these periods of overlap is to manually list all actively supported versions. The aliases lts/* and node should still be included as safety nets, ensuring that there's still good (but not perfect) coverage if package maintainers fail to keep on top of manually updating the version list. A downside of providing this safety net is that during periods of non-overlap, the test suite will run twice for the same release.

- Whether or not to use numeric versions like 4 or aliased versions like lts/argon is merely preference. I prefer the former because I think it more accurately reflects how most people discuss and interact with different Node versions.

- Including expiration date comments for each version in .travis.yml is good.