### PR TITLE
Enabling showDiff for assert's equal and notEqual methods. Closes #790

### DIFF
--- a/lib/chai/interface/assert.js
+++ b/lib/chai/interface/assert.js
@@ -129,6 +129,7 @@ module.exports = function (chai, util) {
       , 'expected #{this} to not equal #{act}'
       , exp
       , act
+      , true
     );
   };
 
@@ -156,6 +157,7 @@ module.exports = function (chai, util) {
       , 'expected #{this} to equal #{act}'
       , exp
       , act
+      , true
     );
   };
 


### PR DESCRIPTION
This aims to close #790.

As explained on [this post](https://github.com/chaijs/chai/issues/790#issuecomment-246078537) the `equal` and `notEqual` methods on the `assert` interface, which called `Assertion.assert` directly, didn't have the `showDiff` flag turned on and that would make their error messages look different because of the way the test runner showed results.

In order to make that behavior consistent with the `equal` related methods on other interfaces, I enabled the `showDiff` flag for these assertions too.

I didn't add any tests since this was a problem related to the test runner and not ours.
Please read the post I linked above for more details.
Thanks everyone 😄 