### PR TITLE
Fix #792: Rephrase old docs

### DIFF
--- a/lib/chai/core/assertions.js
+++ b/lib/chai/core/assertions.js
@@ -622,7 +622,7 @@ module.exports = function (chai, _) {
   /**
    * ### .above(value)
    *
-   * Asserts that the number target is greater than `value`.
+   * Asserts that the target number is greater than `value`.
    *
    *     expect(10).to.be.above(5);
    *
@@ -684,7 +684,7 @@ module.exports = function (chai, _) {
   /**
    * ### .least(value)
    *
-   * Asserts that the number target is greater than or equal to `value`.
+   * Asserts that the target number is greater than or equal to `value`.
    *
    *     expect(10).to.be.at.least(10);
    *
@@ -744,7 +744,7 @@ module.exports = function (chai, _) {
   /**
    * ### .below(value)
    *
-   * Asserts that the number target is less than `value`.
+   * Asserts that the target number is less than `value`.
    *
    *     expect(5).to.be.below(10);
    *
@@ -806,7 +806,7 @@ module.exports = function (chai, _) {
   /**
    * ### .most(value)
    *
-   * Asserts that the number target is less than or equal to `value`.
+   * Asserts that the target number is less than or equal to `value`.
    *
    *     expect(5).to.be.at.most(5);
    *
@@ -866,7 +866,7 @@ module.exports = function (chai, _) {
   /**
    * ### .within(start, finish)
    *
-   * Asserts that the number target is within a range of numbers.
+   * Asserts that the target number is within a range of numbers.
    *
    *     expect(7).to.be.within(5,10);
    *
@@ -1280,7 +1280,7 @@ module.exports = function (chai, _) {
   /**
    * ### .string(string)
    *
-   * Asserts that the string target contains another string.
+   * Asserts that the target string contains another string.
    *
    *     expect('foobar').to.have.string('bar');
    *
@@ -1459,7 +1459,7 @@ module.exports = function (chai, _) {
   /**
    * ### .throw(constructor)
    *
-   * Asserts that the function target will throw a specific error, or specific type of error
+   * Asserts that the target function will throw a specific error, or specific type of error
    * (as determined using `instanceof`), optionally with a RegExp or String inclusion test
    * for the error's message.
    * If an Error instance is provided, it asserts that the error thrown and the instance
@@ -1626,7 +1626,7 @@ module.exports = function (chai, _) {
   /**
    * ### .respondTo(method)
    *
-   * Asserts that the object or class target will respond to a method.
+   * Asserts that the target object or class will respond to a method.
    *
    *     Klass.prototype.bar = function(){};
    *     expect(Klass).to.respondTo('bar');


### PR DESCRIPTION
fixes #792 Rephrase old docs and use `target <type>` instead of `<type> target`