### PR TITLE
Add toJSON to proxyExcludedKeys

### DIFF
--- a/lib/chai/config.js
+++ b/lib/chai/config.js
@@ -90,5 +90,5 @@ module.exports = {
    * @api public
    */
 
-  proxyExcludedKeys: ['then', 'inspect']
+  proxyExcludedKeys: ['then', 'inspect', 'toJSON']
 };


### PR DESCRIPTION
Hello there,

While I was working on #799, I discovered that you cannot call `JSON.stringify` on an assertion because o proxify.

```javascript
const { expect } = require('chai');

const equal1 = expect(1).to.equal(1);

JSON.stringify(equal); // Error: Invalid Chai property: toJSON
```