### PR TITLE
Add toJSON to proxyExcludedKeys

### DIFF
--- a/lib/chai/config.js
+++ b/lib/chai/config.js
@@ -90,5 +90,5 @@ module.exports = {
    * @api public
    */
 
-  proxyExcludedKeys: ['then', 'inspect']
+  proxyExcludedKeys: ['then', 'inspect', 'toJSON']
 };

--- a/test/configuration.js
+++ b/test/configuration.js
@@ -206,8 +206,8 @@ describe('configuration', function () {
       }
     };
 
-    it('should have default value equal to `[\'then\', \'inspect\']`', function() {
-      expect(chai.config.proxyExcludedKeys).to.be.deep.equal(['then', 'inspect']);
+    it('should have default value equal to `[\'then\', \'inspect\', \'toJSON\']`', function() {
+      expect(chai.config.proxyExcludedKeys).to.be.deep.equal(['then', 'inspect', 'toJSON']);
     });
 
     it('should not throw when accessing non-existing `then` and `inspect` in an environment with proxy support', function() {


### PR DESCRIPTION
Hello there,

While I was working on #799, I discovered that you cannot call `JSON.stringify` on an assertion because o proxify.

```javascript
const { expect } = require('chai');

const equal1 = expect(1).to.equal(1);

JSON.stringify(equal); // Error: Invalid Chai property: toJSON
```