### PR TITLE
Fix bug when trying to call inspect on an Assertion

### DIFF
--- a/lib/chai/utils/inspect.js
+++ b/lib/chai/utils/inspect.js
@@ -37,6 +37,7 @@ var isDOMElement = function (object) {
   } else {
     return object &&
       typeof object === 'object' &&
+      'nodeType' in object &&
       object.nodeType === 1 &&
       typeof object.nodeName === 'string';
   }

--- a/test/utilities.js
+++ b/test/utilities.js
@@ -819,6 +819,17 @@ describe('utilities', function () {
     });
   });
 
+  it('inspect an assertion', function () {
+    chai.use(function (_chai, _) {
+      var assertion = expect(1);
+      var anInspectFn = function() {
+        return _.inspect(assertion);
+      };
+
+      expect(anInspectFn).to.not.throw();
+    });
+  });
+
   it('truncate long TypedArray', function () {
     chai.use(function (_chai, _) {
 


### PR DESCRIPTION
Hello everyone!
As me and @vieiralucas were taking a look at Chai's code yesterday on college, we noticed that there was a bug when an assertion which had other `Assertion` objects as `expected` or `actual` failed.

This was happening because mocha called the `.inspect` method on them and it tried to read the property `nodeType`, which did not exist on the `Assertion` object and ended up throwing an error.

To fix this I simply added a check before accessing that property, calling `hasOwnProperty` and passing the `object` we're inspecting (as `this`) and `'nodeType'`.