### PR TITLE
Fix breaking test on IE10

### DIFF
--- a/test/utilities.js
+++ b/test/utilities.js
@@ -1026,7 +1026,11 @@ describe('utilities', function () {
 
       // Ensure that foo returns an Assertion (not a function)
       expect(expect('x').x()).to.be.an.instanceOf(assertionConstructor);
-      expect(expect('x').x).to.be.an.instanceOf(assertionConstructor);
+
+      var hasProtoSupport = '__proto__' in Object;
+      if (hasProtoSupport) {
+        expect(expect('x').x).to.be.an.instanceOf(assertionConstructor);
+      }
     });
   });
 


### PR DESCRIPTION
As @meeber said [here](https://github.com/chaijs/chai/pull/799#issuecomment-248042985)
Since IE10 does not support `__proto__`, [this](https://github.com/chaijs/chai/blob/7683356fff853b0f661ec1fbdd69979c6f31aab2/test/utilities.js#L1029) test was failing.