### PR TITLE
Fix typo in the docstring of isNotExtensible

### DIFF
--- a/chai.js
+++ b/chai.js
@@ -3690,7 +3690,7 @@ module.exports = function (chai, util) {
    *
    *     var nonExtensibleObject = Object.preventExtensions({});
    *     var sealedObject = Object.seal({});
-   *     var frozenObject = Object.freese({});
+   *     var frozenObject = Object.freeze({});
    *
    *     assert.isNotExtensible(nonExtensibleObject);
    *     assert.isNotExtensible(sealedObject);


### PR DESCRIPTION
Fix `Object.freeze` misspelling.

See also https://github.com/chaijs/chai-docs/pull/140