### PR TITLE
Update getName to fix inspect in Firefox

### DIFF
--- a/lib/chai/utils/getName.js
+++ b/lib/chai/utils/getName.js
@@ -14,9 +14,19 @@
  * @name getName
  */
 
-module.exports = function (func) {
-  if (func.name) return func.name;
+var functionNameMatch = /\s*function(?:\s|\s*\/\*[^(?:*\/)]+\*\/\s*)*([^\(\/]+)/;
 
-  var match = /^\s?function ([^(]*)\(/.exec(func);
-  return match && match[1] ? match[1] : "";
+module.exports = function (func) {
+  var name = '';
+  if (typeof func.name === 'undefined') {
+    // Here we run a polyfill if func.name is not defined
+    var match = String(func).match(functionNameMatch);
+    if (match) {
+      name = match[1];
+    }
+  } else {
+    name = func.name;
+  }
+
+  return name;
 };


### PR DESCRIPTION
[This test](https://github.com/chaijs/chai/blob/36bbf1c49b7dc7eb2c699a203a8bdce4a07d3c47/test/utilities.js#L822-L831) started failing in Firefox after #789 was merged because `Function.prototype.toString` doesn't work on proxified functions per [this article](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/toString).  I traced the specific error to [this line](https://github.com/chaijs/chai/blob/36bbf1c49b7dc7eb2c699a203a8bdce4a07d3c47/lib/chai/utils/getName.js#L20), which was being called by Chai's `inspect`.

Replacing the logic in Chai's `getName` with @lucasfcosta's logic from `getConstructorName` in the **check-error** repository fixed the problem without breaking any tests.

Not sure it's worth it to pull that function into a separate module that's required by both Chai and check-error; seems like it might be overkill. An alternative would be for check-error to expose the function for Chai to require, but that doesn't quite feel right either. I'm okay with the duplicate logic across repos here, but if someone feels strongly otherwise I'm easily swayed.