### PR TITLE
Fix getName for anon functions in IE

### DIFF
--- a/lib/chai/utils/getName.js
+++ b/lib/chai/utils/getName.js
@@ -14,7 +14,7 @@
  * @name getName
  */
 
-var functionNameMatch = /\s*function(?:\s|\s*\/\*[^(?:*\/)]+\*\/\s*)*([^\(\/]+)/;
+var functionNameMatch = /\s*function(?:\s|\s*\/\*[^(?:*\/)]+\*\/\s*)*([^\s\(\/]+)/;
 
 module.exports = function (func) {
   var name = '';


### PR DESCRIPTION
Since older versions of IE don't support `function.name`, `getName` falls back to a regex check on the function definition. Previously, an anonymous function would return " " as the function name when determined via regex. Since a string with one space isn't technically empty, [this part](https://github.com/chaijs/chai/blob/92b1ff738947bb9cc70b4061f3e29b3bdac4a825/lib/chai/utils/inspect.js#L115) of the `inspect` logic would wrongly add a ": " to the end of the function name, causing some of Chai's error-message-checking tests to fail.

This change makes `getName` return an empty string for anonymous functions determined via regex by not allowing white space to be a part of what's captured by the `match`.