### PR TITLE
Make 'empty' throw on non-string primitives and functions

### DIFF
--- a/lib/chai/core/assertions.js
+++ b/lib/chai/core/assertions.js
@@ -541,7 +541,7 @@ module.exports = function (chai, _) {
         throw new TypeError('.empty was passed a function' + name);
       default:
         if (val !== Object(val)) {
-          throw new TypeError('.empty was passed non-string primitive ' + String(val));
+          throw new TypeError('.empty was passed non-string primitive ' + (val && val.toString()));
         }
         itemsCount = Object.keys(val).length;
     }

--- a/lib/chai/core/assertions.js
+++ b/lib/chai/core/assertions.js
@@ -528,10 +528,25 @@ module.exports = function (chai, _) {
    */
 
   Assertion.addProperty('empty', function () {
-    var obj = flag(this, 'object');
-    new Assertion(obj).to.exist;
+    var val = flag(this, 'object')
+      , itemsCount;
+
+    switch (_.type(val)) {
+      case 'array':
+      case 'string':
+        itemsCount = val.length;
+        break;
+      case 'function':
+        throw new TypeError('.empty() was passed a function');
+      default:
+        if (val !== Object(val)) {
+          throw new TypeError('.empty() was passed non-string primitive');
+        }
+        itemsCount = Object.keys(val).length;
+    }
+
     this.assert(
-        Object.keys(Object(obj)).length === 0
+        0 === itemsCount
       , 'expected #{this} to be empty'
       , 'expected #{this} not to be empty'
     );

--- a/lib/chai/core/assertions.js
+++ b/lib/chai/core/assertions.js
@@ -537,10 +537,11 @@ module.exports = function (chai, _) {
         itemsCount = val.length;
         break;
       case 'function':
-        throw new TypeError('.empty() was passed a function');
+        var name = val.name ? ' ' + val.name : '';
+        throw new TypeError('.empty was passed a function' + name);
       default:
         if (val !== Object(val)) {
-          throw new TypeError('.empty() was passed non-string primitive');
+          throw new TypeError('.empty was passed non-string primitive ' + String(val));
         }
         itemsCount = Object.keys(val).length;
     }

--- a/lib/chai/core/assertions.js
+++ b/lib/chai/core/assertions.js
@@ -515,8 +515,8 @@ module.exports = function (chai, _) {
    * ### .empty
    *
    * Asserts that the target's length is `0`. For arrays and strings, it checks
-   * the `length` property. For objects, it gets the count of
-   * enumerable keys.
+   * the `length` property. For non-function objects, it gets the count of own
+   * enumerable string keys.
    *
    *     expect([]).to.be.empty;
    *     expect('').to.be.empty;

--- a/lib/chai/core/assertions.js
+++ b/lib/chai/core/assertions.js
@@ -541,7 +541,7 @@ module.exports = function (chai, _) {
         throw new TypeError('.empty was passed a function' + name);
       default:
         if (val !== Object(val)) {
-          throw new TypeError('.empty was passed non-string primitive ' + (val && val.toString()));
+          throw new TypeError('.empty was passed non-string primitive ' + _.inspect(val));
         }
         itemsCount = Object.keys(val).length;
     }

--- a/test/expect.js
+++ b/test/expect.js
@@ -680,28 +680,53 @@ describe('expect', function () {
 
     err(function(){
       expect(null).to.be.empty;
-    }, "expected null to exist");
+    }, ".empty() was passed non-string primitive");
 
     err(function(){
       expect(undefined).to.be.empty;
-    }, "expected undefined to exist");
+    }, ".empty() was passed non-string primitive");
 
     err(function(){
       expect().to.be.empty;
-    }, "expected undefined to exist");
+    }, ".empty() was passed non-string primitive");
 
     err(function(){
       expect(null).to.not.be.empty;
-    }, "expected null to exist");
+    }, ".empty() was passed non-string primitive");
 
     err(function(){
       expect(undefined).to.not.be.empty;
-    }, "expected undefined to exist");
+    }, ".empty() was passed non-string primitive");
 
     err(function(){
       expect().to.not.be.empty;
-    }, "expected undefined to exist");
+    }, ".empty() was passed non-string primitive");
 
+    err(function(){
+      expect(0).to.be.empty;
+    }, ".empty() was passed non-string primitive");
+
+    err(function(){
+      expect(1).to.be.empty;
+    }, ".empty() was passed non-string primitive");
+
+    err(function(){
+      expect(true).to.be.empty;
+    }, ".empty() was passed non-string primitive");
+
+    err(function(){
+      expect(false).to.be.empty;
+    }, ".empty() was passed non-string primitive");
+
+    if (typeof Symbol !== 'undefined') {
+      err(function(){
+        expect(Symbol()).to.be.empty;
+      }, ".empty() was passed non-string primitive");
+    }
+
+    err(function(){
+      expect(function() {}).to.be.empty;
+    }, ".empty() was passed a function");
   });
 
   it('NaN', function() {

--- a/test/expect.js
+++ b/test/expect.js
@@ -680,53 +680,63 @@ describe('expect', function () {
 
     err(function(){
       expect(null).to.be.empty;
-    }, ".empty() was passed non-string primitive");
+    }, ".empty was passed non-string primitive null");
 
     err(function(){
       expect(undefined).to.be.empty;
-    }, ".empty() was passed non-string primitive");
+    }, ".empty was passed non-string primitive undefined");
 
     err(function(){
       expect().to.be.empty;
-    }, ".empty() was passed non-string primitive");
+    }, ".empty was passed non-string primitive undefined");
 
     err(function(){
       expect(null).to.not.be.empty;
-    }, ".empty() was passed non-string primitive");
+    }, ".empty was passed non-string primitive null");
 
     err(function(){
       expect(undefined).to.not.be.empty;
-    }, ".empty() was passed non-string primitive");
+    }, ".empty was passed non-string primitive undefined");
 
     err(function(){
       expect().to.not.be.empty;
-    }, ".empty() was passed non-string primitive");
+    }, ".empty was passed non-string primitive undefined");
 
     err(function(){
       expect(0).to.be.empty;
-    }, ".empty() was passed non-string primitive");
+    }, ".empty was passed non-string primitive 0");
 
     err(function(){
       expect(1).to.be.empty;
-    }, ".empty() was passed non-string primitive");
+    }, ".empty was passed non-string primitive 1");
 
     err(function(){
       expect(true).to.be.empty;
-    }, ".empty() was passed non-string primitive");
+    }, ".empty was passed non-string primitive true");
 
     err(function(){
       expect(false).to.be.empty;
-    }, ".empty() was passed non-string primitive");
+    }, ".empty was passed non-string primitive false");
 
     if (typeof Symbol !== 'undefined') {
       err(function(){
         expect(Symbol()).to.be.empty;
-      }, ".empty() was passed non-string primitive");
+      }, ".empty was passed non-string primitive Symbol()");
+
+      err(function(){
+        expect(Symbol.iterator).to.be.empty;
+      }, ".empty was passed non-string primitive Symbol(Symbol.iterator)");
     }
 
     err(function(){
       expect(function() {}).to.be.empty;
-    }, ".empty() was passed a function");
+    }, ".empty was passed a function");
+
+    if (FakeArgs.name === 'FakeArgs') {
+      err(function(){
+        expect(FakeArgs).to.be.empty;
+      }, ".empty was passed a function FakeArgs");
+    }
   });
 
   it('NaN', function() {

--- a/test/should.js
+++ b/test/should.js
@@ -657,6 +657,32 @@ describe('should', function() {
     err(function(){
       ({foo: 'bar'}).should.be.empty;
     }, "expected { foo: \'bar\' } to be empty");
+
+    err(function(){
+      (0).should.be.empty;
+    }, ".empty() was passed non-string primitive");
+
+    err(function(){
+      (1).should.be.empty;
+    }, ".empty() was passed non-string primitive");
+
+    err(function(){
+      true.should.be.empty;
+    }, ".empty() was passed non-string primitive");
+
+    err(function(){
+      false.should.be.empty;
+    }, ".empty() was passed non-string primitive");
+
+    if (typeof Symbol !== 'undefined') {
+      err(function(){
+        Symbol().should.be.empty;
+      }, ".empty() was passed non-string primitive");
+    }
+
+    err(function(){
+      (function() {}).should.be.empty;
+    }, ".empty() was passed a function");
   });
 
   it('finite(value)', function() {

--- a/test/should.js
+++ b/test/should.js
@@ -660,29 +660,39 @@ describe('should', function() {
 
     err(function(){
       (0).should.be.empty;
-    }, ".empty() was passed non-string primitive");
+    }, ".empty was passed non-string primitive 0");
 
     err(function(){
       (1).should.be.empty;
-    }, ".empty() was passed non-string primitive");
+    }, ".empty was passed non-string primitive 1");
 
     err(function(){
       true.should.be.empty;
-    }, ".empty() was passed non-string primitive");
+    }, ".empty was passed non-string primitive true");
 
     err(function(){
       false.should.be.empty;
-    }, ".empty() was passed non-string primitive");
+    }, ".empty was passed non-string primitive false");
 
     if (typeof Symbol !== 'undefined') {
       err(function(){
         Symbol().should.be.empty;
-      }, ".empty() was passed non-string primitive");
+      }, ".empty was passed non-string primitive Symbol()");
+
+      err(function(){
+        Symbol.iterator.should.to.be.empty;
+      }, ".empty was passed non-string primitive Symbol(Symbol.iterator)");
     }
 
     err(function(){
       (function() {}).should.be.empty;
-    }, ".empty() was passed a function");
+    }, ".empty was passed a function");
+
+    if (FakeArgs.name === 'FakeArgs') {
+      err(function(){
+        FakeArgs.should.be.empty;
+      }, ".empty was passed a function FakeArgs");
+    }
   });
 
   it('finite(value)', function() {


### PR DESCRIPTION
Follow-up of #763.