### PR TITLE
Make `utils.getName` more robust & use it in `empty`

### DIFF
--- a/lib/chai/core/assertions.js
+++ b/lib/chai/core/assertions.js
@@ -537,8 +537,8 @@ module.exports = function (chai, _) {
         itemsCount = val.length;
         break;
       case 'function':
-        var name = val.name ? ' ' + val.name : '';
-        throw new TypeError('.empty was passed a function' + name);
+        var msg = '.empty was passed a function ' + _.getName(val);
+        throw new TypeError(msg.trim());
       default:
         if (val !== Object(val)) {
           throw new TypeError('.empty was passed non-string primitive ' + _.inspect(val));

--- a/lib/chai/utils/getName.js
+++ b/lib/chai/utils/getName.js
@@ -14,13 +14,14 @@
  * @name getName
  */
 
+var toString = Function.prototype.toString;
 var functionNameMatch = /\s*function(?:\s|\s*\/\*[^(?:*\/)]+\*\/\s*)*([^\s\(\/]+)/;
 
 module.exports = function (func) {
   var name = '';
   if (typeof func.name === 'undefined') {
     // Here we run a polyfill if func.name is not defined
-    var match = String(func).match(functionNameMatch);
+    var match = toString.call(func).match(functionNameMatch);
     if (match) {
       name = match[1];
     }

--- a/test/should.js
+++ b/test/should.js
@@ -680,7 +680,7 @@ describe('should', function() {
       }, ".empty was passed non-string primitive Symbol()");
 
       err(function(){
-        Symbol.iterator.should.to.be.empty;
+        Symbol.iterator.should.be.empty;
       }, ".empty was passed non-string primitive Symbol(Symbol.iterator)");
     }
 

--- a/test/utilities.js
+++ b/test/utilities.js
@@ -54,6 +54,20 @@ describe('utilities', function () {
     });
   });
 
+  it('getName', function () {
+    chai.use(function (_chai, utils) {
+      var name = utils.getName;
+      expect(name(function () {})).to.equal('');
+      expect(name(function foo() {})).to.equal('foo');
+
+      var bar = function bar() {};
+      bar.toString = function() {
+        return 'function foo() {}';
+      };
+
+      expect(name(bar)).to.equal('bar');
+    });
+  });
 
   it('getPathValue', function () {
     var object = {


### PR DESCRIPTION
Current ponyfill routine does not handle `toString` defined on functions. That is kinda rare, but does not take much effort to support. Beware, proposed "fix" will throw on non-functions (is that desirable?). Also, added basic tests for `getName`.