### PR TITLE
Drop support of node v0.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: node_js
 addons:
   sauce_connect: true
 node_js:
- - 0.10 # to be removed 2016-10-01
  - 0.12 # to be removed 2016-12-31
  - 4 # to be removed 2018-04-01
  - 6 # to be removed 2019-04-01

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "test": "make test"
   },
   "engines": {
-    "node": ">=0.10"
+    "node": ">=0.12"
   },
   "dependencies": {
     "assertion-error": "^1.0.1",


### PR DESCRIPTION
As @keithamus suggested [here](https://github.com/chaijs/chai/issues/124#issuecomment-244967570), Chai should no longer support node v0.10 since Oct 1st
