### PR TITLE
Fix getName for poorlyConstructed errors

### DIFF
--- a/lib/chai/utils/getName.js
+++ b/lib/chai/utils/getName.js
@@ -19,13 +19,14 @@ var functionNameMatch = /\s*function(?:\s|\s*\/\*[^(?:*\/)]+\*\/\s*)*([^\s\(\/]+
 
 module.exports = function (func) {
   var name = '';
-  if (typeof func.name === 'undefined') {
-    // Here we run a polyfill if func.name is not defined
+  if (typeof Function.prototype.name === 'undefined' && typeof func.name === 'undefined') {
+    // Here we run a polyfill if Function does not support the `name` property and if func.name is not defined
     var match = toString.call(func).match(functionNameMatch);
     if (match) {
       name = match[1];
     }
   } else {
+    // If we've got a `name` property we just use it
     name = func.name;
   }
 


### PR DESCRIPTION
This is the same fix as chaijs/check-error#11.

Now `getName` will continue working with `Poorly Constructed Errors` (#45).

This is related to #813.