### PR TITLE
Do not suppress `TypeError`s thrown on integrity checks

### DIFF
--- a/lib/chai/core/assertions.js
+++ b/lib/chai/core/assertions.js
@@ -2186,10 +2186,10 @@ module.exports = function (chai, _) {
   Assertion.addProperty('extensible', function() {
     var obj = flag(this, 'object');
 
-    // In ES5, if the argument to this method is not an object (a primitive), then it will cause a TypeError.
+    // In ES5, if the argument to this method is a primitive, then it will cause a TypeError.
     // In ES6, a non-object argument will be treated as if it was a non-extensible ordinary object, simply return false.
     // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/isExtensible
-    // The following provides ES6 behavior when a TypeError is thrown under ES5.
+    // The following provides ES6 behavior for ES5 environments.
 
     var isExtensible = obj === Object(obj) && Object.isExtensible(obj);
 
@@ -2222,10 +2222,10 @@ module.exports = function (chai, _) {
   Assertion.addProperty('sealed', function() {
     var obj = flag(this, 'object');
 
-    // In ES5, if the argument to this method is not an object (a primitive), then it will cause a TypeError.
+    // In ES5, if the argument to this method is a primitive, then it will cause a TypeError.
     // In ES6, a non-object argument will be treated as if it was a sealed ordinary object, simply return true.
     // See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/isSealed
-    // The following provides ES6 behavior when a TypeError is thrown under ES5.
+    // The following provides ES6 behavior for ES5 environments.
 
     var isSealed = obj === Object(obj) ? Object.isSealed(obj) : true;
 
@@ -2256,10 +2256,10 @@ module.exports = function (chai, _) {
   Assertion.addProperty('frozen', function() {
     var obj = flag(this, 'object');
 
-    // In ES5, if the argument to this method is not an object (a primitive), then it will cause a TypeError.
+    // In ES5, if the argument to this method is a primitive, then it will cause a TypeError.
     // In ES6, a non-object argument will be treated as if it was a frozen ordinary object, simply return true.
     // See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/isFrozen
-    // The following provides ES6 behavior when a TypeError is thrown under ES5.
+    // The following provides ES6 behavior for ES5 environments.
 
     var isFrozen = obj === Object(obj) ? Object.isFrozen(obj) : true;
 

--- a/lib/chai/core/assertions.js
+++ b/lib/chai/core/assertions.js
@@ -2166,7 +2166,7 @@ module.exports = function (chai, _) {
    * ### .extensible
    *
    * Asserts that the target is extensible (can have new properties added to
-   * it).
+   * it). Returns `false` for primitives.
    *
    *     var nonExtensibleObject = Object.preventExtensions({});
    *     var sealedObject = Object.seal({});
@@ -2176,6 +2176,7 @@ module.exports = function (chai, _) {
    *     expect(nonExtensibleObject).to.not.be.extensible;
    *     expect(sealedObject).to.not.be.extensible;
    *     expect(frozenObject).to.not.be.extensible;
+   *     expect("").to.not.be.extensible;
    *
    * @name extensible
    * @namespace BDD
@@ -2210,7 +2211,7 @@ module.exports = function (chai, _) {
    * ### .sealed
    *
    * Asserts that the target is sealed (cannot have new properties added to it
-   * and its existing properties cannot be removed).
+   * and its existing properties cannot be removed). Returns `true` for primitives.
    *
    *     var sealedObject = Object.seal({});
    *     var frozenObject = Object.freeze({});
@@ -2218,6 +2219,7 @@ module.exports = function (chai, _) {
    *     expect(sealedObject).to.be.sealed;
    *     expect(frozenObject).to.be.sealed;
    *     expect({}).to.not.be.sealed;
+   *     expect(false).to.be.sealed;
    *
    * @name sealed
    * @namespace BDD
@@ -2252,12 +2254,13 @@ module.exports = function (chai, _) {
    * ### .frozen
    *
    * Asserts that the target is frozen (cannot have new properties added to it
-   * and its existing properties cannot be modified).
+   * and its existing properties cannot be modified). Returns `true` for primitives.
    *
    *     var frozenObject = Object.freeze({});
    *
    *     expect(frozenObject).to.be.frozen;
    *     expect({}).to.not.be.frozen;
+   *     expect(1).to.be.frozen;
    *
    * @name frozen
    * @namespace BDD

--- a/lib/chai/core/assertions.js
+++ b/lib/chai/core/assertions.js
@@ -2191,14 +2191,7 @@ module.exports = function (chai, _) {
     // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/isExtensible
     // The following provides ES6 behavior when a TypeError is thrown under ES5.
 
-    var isExtensible;
-
-    try {
-      isExtensible = Object.isExtensible(obj);
-    } catch (err) {
-      if (err instanceof TypeError) isExtensible = false;
-      else throw err;
-    }
+    var isExtensible = obj === Object(obj) && Object.isExtensible(obj);
 
     this.assert(
       isExtensible
@@ -2234,14 +2227,7 @@ module.exports = function (chai, _) {
     // See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/isSealed
     // The following provides ES6 behavior when a TypeError is thrown under ES5.
 
-    var isSealed;
-
-    try {
-      isSealed = Object.isSealed(obj);
-    } catch (err) {
-      if (err instanceof TypeError) isSealed = true;
-      else throw err;
-    }
+    var isSealed = obj === Object(obj) ? Object.isSealed(obj) : true;
 
     this.assert(
       isSealed
@@ -2275,14 +2261,7 @@ module.exports = function (chai, _) {
     // See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/isFrozen
     // The following provides ES6 behavior when a TypeError is thrown under ES5.
 
-    var isFrozen;
-
-    try {
-      isFrozen = Object.isFrozen(obj);
-    } catch (err) {
-      if (err instanceof TypeError) isFrozen = true;
-      else throw err;
-    }
+    var isFrozen = obj === Object(obj) ? Object.isFrozen(obj) : true;
 
     this.assert(
       isFrozen

--- a/test/assert.js
+++ b/test/assert.js
@@ -1883,6 +1883,7 @@ describe('assert', function () {
         });
 
         err(function() {
+          // isExtensible should not suppress errors, thrown in proxy traps
           assert[isExtensible](proxy);
         }, { name: 'TypeError' });
       }
@@ -1919,6 +1920,7 @@ describe('assert', function () {
         });
 
         err(function() {
+          // isNotExtensible should not suppress errors, thrown in proxy traps
           assert[isNotExtensible](proxy);
         }, { name: 'TypeError' });
       }
@@ -1954,9 +1956,11 @@ describe('assert', function () {
           }
         });
 
+        // Object.isSealed will call ownKeys trap only if object is not extensible
         Object.preventExtensions(proxy);
 
         err(function() {
+          // isSealed should not suppress errors, thrown in proxy traps
           assert[isSealed](proxy);
         }, { name: 'TypeError' });
       }
@@ -2002,9 +2006,11 @@ describe('assert', function () {
           }
         });
 
+        // Object.isSealed will call ownKeys trap only if object is not extensible
         Object.preventExtensions(proxy);
 
         err(function() {
+          // isNotSealed should not suppress errors, thrown in proxy traps
           assert[isNotSealed](proxy);
         }, { name: 'TypeError' });
       }
@@ -2040,9 +2046,11 @@ describe('assert', function () {
           }
         });
 
+        // Object.isFrozen will call ownKeys trap only if object is not extensible
         Object.preventExtensions(proxy);
 
         err(function() {
+          // isFrozen should not suppress errors, thrown in proxy traps
           assert[isFrozen](proxy);
         }, { name: 'TypeError' });
       }
@@ -2088,9 +2096,11 @@ describe('assert', function () {
           }
         });
 
+        // Object.isFrozen will call ownKeys trap only if object is not extensible
         Object.preventExtensions(proxy);
 
         err(function() {
+          // isNotFrozen should not suppress errors, thrown in proxy traps
           assert[isNotFrozen](proxy);
         }, { name: 'TypeError' });
       }

--- a/test/assert.js
+++ b/test/assert.js
@@ -1874,6 +1874,18 @@ describe('assert', function () {
       err(function() {
         assert[isExtensible](undefined);
       }, 'expected undefined to be extensible');
+
+      if (typeof Proxy === 'function') {
+        var proxy = new Proxy({}, {
+          isExtensible: function() {
+            throw new TypeError();
+          }
+        });
+
+        err(function() {
+          assert[isExtensible](proxy);
+        }, { name: 'TypeError' });
+      }
     });
   });
 
@@ -1898,6 +1910,18 @@ describe('assert', function () {
       if (typeof Symbol === 'function') {
         assert[isNotExtensible](Symbol());
       }
+
+      if (typeof Proxy === 'function') {
+        var proxy = new Proxy({}, {
+          isExtensible: function() {
+            throw new TypeError();
+          }
+        });
+
+        err(function() {
+          assert[isNotExtensible](proxy);
+        }, { name: 'TypeError' });
+      }
     });
   });
 
@@ -1921,6 +1945,18 @@ describe('assert', function () {
 
       if (typeof Symbol === 'function') {
         assert[isSealed](Symbol());
+      }
+
+      if (typeof Proxy === 'function') {
+        var proxy = new Proxy({}, {
+          isExtensible: function() {
+            throw new TypeError();
+          }
+        });
+
+        err(function() {
+          assert[isSealed](proxy);
+        }, { name: 'TypeError' });
       }
     });
   });
@@ -1956,6 +1992,18 @@ describe('assert', function () {
       err(function() {
         assert[isNotSealed](undefined);
       }, 'expected undefined to not be sealed');
+
+      if (typeof Proxy === 'function') {
+        var proxy = new Proxy({}, {
+          isExtensible: function() {
+            throw new TypeError();
+          }
+        });
+
+        err(function() {
+          assert[isNotSealed](proxy);
+        }, { name: 'TypeError' });
+      }
     });
   });
 
@@ -1979,6 +2027,18 @@ describe('assert', function () {
 
       if (typeof Symbol === 'function') {
         assert[isFrozen](Symbol());
+      }
+
+      if (typeof Proxy === 'function') {
+        var proxy = new Proxy({}, {
+          isExtensible: function() {
+            throw new TypeError();
+          }
+        });
+
+        err(function() {
+          assert[isFrozen](proxy);
+        }, { name: 'TypeError' });
       }
     });
   });
@@ -2014,6 +2074,18 @@ describe('assert', function () {
       err(function() {
         assert[isNotFrozen](undefined);
       }, 'expected undefined to not be frozen');
+
+      if (typeof Proxy === 'function') {
+        var proxy = new Proxy({}, {
+          isExtensible: function() {
+            throw new TypeError();
+          }
+        });
+
+        err(function() {
+          assert[isNotFrozen](proxy);
+        }, { name: 'TypeError' });
+      }
     });
   });
 

--- a/test/assert.js
+++ b/test/assert.js
@@ -1949,10 +1949,12 @@ describe('assert', function () {
 
       if (typeof Proxy === 'function') {
         var proxy = new Proxy({}, {
-          isExtensible: function() {
+          ownKeys: function() {
             throw new TypeError();
           }
         });
+
+        Object.preventExtensions(proxy);
 
         err(function() {
           assert[isSealed](proxy);
@@ -1995,10 +1997,12 @@ describe('assert', function () {
 
       if (typeof Proxy === 'function') {
         var proxy = new Proxy({}, {
-          isExtensible: function() {
+          ownKeys: function() {
             throw new TypeError();
           }
         });
+
+        Object.preventExtensions(proxy);
 
         err(function() {
           assert[isNotSealed](proxy);
@@ -2031,10 +2035,12 @@ describe('assert', function () {
 
       if (typeof Proxy === 'function') {
         var proxy = new Proxy({}, {
-          isExtensible: function() {
+          ownKeys: function() {
             throw new TypeError();
           }
         });
+
+        Object.preventExtensions(proxy);
 
         err(function() {
           assert[isFrozen](proxy);
@@ -2077,10 +2083,12 @@ describe('assert', function () {
 
       if (typeof Proxy === 'function') {
         var proxy = new Proxy({}, {
-          isExtensible: function() {
+          ownKeys: function() {
             throw new TypeError();
           }
         });
+
+        Object.preventExtensions(proxy);
 
         err(function() {
           assert[isNotFrozen](proxy);

--- a/test/expect.js
+++ b/test/expect.js
@@ -2369,6 +2369,18 @@ describe('expect', function () {
     err(function() {
       expect(undefined).to.be.extensible;
     }, 'expected undefined to be extensible');
+
+    if (typeof Proxy === 'function') {
+      var proxy = new Proxy({}, {
+        isExtensible: function() {
+          throw new TypeError();
+        }
+      });
+
+      err(function() {
+        expect(proxy).to.be.extensible;
+      }, { name: 'TypeError' });
+    }
   });
 
   it('sealed', function() {
@@ -2416,6 +2428,18 @@ describe('expect', function () {
     err(function() {
       expect(undefined).to.not.be.sealed;
     }, 'expected undefined to not be sealed');
+
+    if (typeof Proxy === 'function') {
+      var proxy = new Proxy({}, {
+        isExtensible: function() {
+          throw new TypeError();
+        }
+      });
+
+      err(function() {
+        expect(proxy).to.be.sealed;
+      }, { name: 'TypeError' });
+    }
   });
 
   it('frozen', function() {
@@ -2463,5 +2487,17 @@ describe('expect', function () {
     err(function() {
       expect(undefined).to.not.be.frozen;
     }, 'expected undefined to not be frozen');
+
+    if (typeof Proxy === 'function') {
+      var proxy = new Proxy({}, {
+        isExtensible: function() {
+          throw new TypeError();
+        }
+      });
+
+      err(function() {
+        expect(proxy).to.be.frozen;
+      }, { name: 'TypeError' });
+    }
   });
 });

--- a/test/expect.js
+++ b/test/expect.js
@@ -2378,6 +2378,7 @@ describe('expect', function () {
       });
 
       err(function() {
+        // .extensible should not suppress errors, thrown in proxy traps
         expect(proxy).to.be.extensible;
       }, { name: 'TypeError' });
     }
@@ -2436,9 +2437,11 @@ describe('expect', function () {
         }
       });
 
+      // Object.isSealed will call ownKeys trap only if object is not extensible
       Object.preventExtensions(proxy);
 
       err(function() {
+        // .sealed should not suppress errors, thrown in proxy traps
         expect(proxy).to.be.sealed;
       }, { name: 'TypeError' });
     }
@@ -2497,9 +2500,11 @@ describe('expect', function () {
         }
       });
 
+      // Object.isFrozen will call ownKeys trap only if object is not extensible
       Object.preventExtensions(proxy);
 
       err(function() {
+        // .frozen should not suppress errors, thrown in proxy traps
         expect(proxy).to.be.frozen;
       }, { name: 'TypeError' });
     }

--- a/test/expect.js
+++ b/test/expect.js
@@ -2431,10 +2431,12 @@ describe('expect', function () {
 
     if (typeof Proxy === 'function') {
       var proxy = new Proxy({}, {
-        isExtensible: function() {
+        ownKeys: function() {
           throw new TypeError();
         }
       });
+
+      Object.preventExtensions(proxy);
 
       err(function() {
         expect(proxy).to.be.sealed;
@@ -2490,10 +2492,12 @@ describe('expect', function () {
 
     if (typeof Proxy === 'function') {
       var proxy = new Proxy({}, {
-        isExtensible: function() {
+        ownKeys: function() {
           throw new TypeError();
         }
       });
+
+      Object.preventExtensions(proxy);
 
       err(function() {
         expect(proxy).to.be.frozen;

--- a/test/should.js
+++ b/test/should.js
@@ -2204,6 +2204,18 @@ describe('should', function() {
      err(function() {
        false.should.be.extensible;
      }, 'expected false to be extensible');
+
+    if (typeof Proxy === 'function') {
+      var proxy = new Proxy({}, {
+        isExtensible: function() {
+          throw new TypeError();
+        }
+      });
+
+      err(function() {
+        proxy.should.be.extensible;
+      }, { name: 'TypeError' });
+    }
   });
 
   it('sealed', function() {
@@ -2241,6 +2253,18 @@ describe('should', function() {
     err(function() {
       false.should.not.be.sealed;
     }, 'expected false to not be sealed');
+
+    if (typeof Proxy === 'function') {
+      var proxy = new Proxy({}, {
+        isExtensible: function() {
+          throw new TypeError();
+        }
+      });
+
+      err(function() {
+        proxy.should.be.sealed;
+      }, { name: 'TypeError' });
+    }
   });
 
   it('frozen', function() {
@@ -2278,5 +2302,17 @@ describe('should', function() {
     err(function() {
       false.should.not.be.frozen;
     }, 'expected false to not be frozen');
+
+    if (typeof Proxy === 'function') {
+      var proxy = new Proxy({}, {
+        isExtensible: function() {
+          throw new TypeError();
+        }
+      });
+
+      err(function() {
+        proxy.should.be.frozen;
+      }, { name: 'TypeError' });
+    }
   });
 });

--- a/test/should.js
+++ b/test/should.js
@@ -2256,10 +2256,12 @@ describe('should', function() {
 
     if (typeof Proxy === 'function') {
       var proxy = new Proxy({}, {
-        isExtensible: function() {
+        ownKeys: function() {
           throw new TypeError();
         }
       });
+
+      Object.preventExtensions(proxy);
 
       err(function() {
         proxy.should.be.sealed;
@@ -2305,10 +2307,12 @@ describe('should', function() {
 
     if (typeof Proxy === 'function') {
       var proxy = new Proxy({}, {
-        isExtensible: function() {
+        ownKeys: function() {
           throw new TypeError();
         }
       });
+
+      Object.preventExtensions(proxy);
 
       err(function() {
         proxy.should.be.frozen;

--- a/test/should.js
+++ b/test/should.js
@@ -2213,6 +2213,7 @@ describe('should', function() {
       });
 
       err(function() {
+        // .extensible should not suppress errors, thrown in proxy traps
         proxy.should.be.extensible;
       }, { name: 'TypeError' });
     }
@@ -2261,9 +2262,11 @@ describe('should', function() {
         }
       });
 
+      // Object.isSealed will call ownKeys trap only if object is not extensible
       Object.preventExtensions(proxy);
 
       err(function() {
+        // .sealed should not suppress errors, thrown in proxy traps
         proxy.should.be.sealed;
       }, { name: 'TypeError' });
     }
@@ -2312,9 +2315,11 @@ describe('should', function() {
         }
       });
 
+      // Object.isFrozen will call ownKeys trap only if object is not extensible
       Object.preventExtensions(proxy);
 
       err(function() {
+        // .frozen should not suppress errors, thrown in proxy traps
         proxy.should.be.frozen;
       }, { name: 'TypeError' });
     }


### PR DESCRIPTION
Current implementation will report false-positive result if `TypeError` is thrown in some `Proxy` traps (`isExtensible`, `ownKeys`, `getOwnPropertyDescriptor`).