### PR TITLE
Fix `hasProperty` called on symbols and booleans

### DIFF
--- a/lib/chai/utils/hasProperty.js
+++ b/lib/chai/utils/hasProperty.js
@@ -4,17 +4,15 @@
  * MIT Licensed
  */
 
-var type = require('type-detect');
-
 /**
- * ### .hasProperty(object, name)
+ * ### .hasProperty(name, object)
  *
- * This allows checking whether an object has
- * named property or numeric array index.
+ * This allows checking whether an object has own
+ * or inherited from prototype chain named property.
  *
  * Basically does the same thing as the `in`
- * operator but works properly with natives
- * and null/undefined values.
+ * operator but works properly with null/undefined values
+ * and other primitives.
  *
  *     var obj = {
  *         arr: ['a', 'b', 'c']
@@ -35,18 +33,13 @@ var type = require('type-detect');
  *     hasProperty(2, obj.arr);  // true
  *     hasProperty(3, obj.arr);  // false
  *
+ * @param {String|Symbol} name
  * @param {Object} object
- * @param {String|Number} name
  * @returns {Boolean} whether it exists
  * @namespace Utils
- * @name getPathInfo
+ * @name hasProperty
  * @api public
  */
-
-var literals = {
-    'number': Number
-  , 'string': String
-};
 
 module.exports = function hasProperty(name, obj) {
   if (obj === undefined || obj === null) {

--- a/lib/chai/utils/hasProperty.js
+++ b/lib/chai/utils/hasProperty.js
@@ -49,16 +49,10 @@ var literals = {
 };
 
 module.exports = function hasProperty(name, obj) {
-  var ot = type(obj);
-
-  // Bad Object, obviously no props at all
-  if(ot === 'null' || ot === 'undefined')
+  if (obj === undefined || obj === null) {
     return false;
+  }
 
-  // The `in` operator does not work with certain literals
-  // box these before the check
-  if(literals[ot] && typeof obj !== 'object')
-    obj = new literals[ot](obj);
-
-  return name in obj;
+  // The `in` operator does not work with primitives.
+  return name in Object(obj);
 };

--- a/test/utilities.js
+++ b/test/utilities.js
@@ -195,16 +195,23 @@ describe('utilities', function () {
       hp(3, arr).should.be.false;
     });
 
-    it('should handle literal types', function() {
+    it('should handle primitives', function() {
       var s = 'string literal';
       hp('length', s).should.be.true;
       hp(3, s).should.be.true;
       hp(14, s).should.be.false;
 
       hp('foo', 1).should.be.false;
+      hp('bar', false).should.be.false;
+      hp('valueOf', true).should.be.true;
+
+      if (typeof Symbol === 'function') {
+        hp(1, Symbol()).should.be.false;
+        hp('toString', Symbol.iterator).should.be.true;
+      }
     });
 
-    it('should handle undefined', function() {
+    it('should handle objects', function() {
       var o = {
         foo: 'bar'
       };


### PR DESCRIPTION
Greatly simplifies the code and makes consistent with behavior of other primitive types.