### PR TITLE
Fix typo in JSDoc param documentation

### DIFF
--- a/lib/chai/interface/assert.js
+++ b/lib/chai/interface/assert.js
@@ -1736,8 +1736,8 @@ module.exports = function (chai, util) {
    * @alias throw
    * @alias Throw
    * @param {Function} fn
-   * @param {ErrorConstructor/Error} errorLike
-   * @param {RegExp/String} errMsgMatcher
+   * @param {ErrorConstructor|Error} errorLike
+   * @param {RegExp|String} errMsgMatcher
    * @param {String} message
    * @see https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Error#Error_types
    * @namespace Assert
@@ -1776,7 +1776,7 @@ module.exports = function (chai, util) {
    * @name doesNotThrow
    * @param {Function} fn
    * @param {ErrorConstructor} errorLike
-   * @param {RegExp/String} errMsgMatcher
+   * @param {RegExp|String} errMsgMatcher
    * @param {String} message
    * @see https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Error#Error_types
    * @namespace Assert


### PR DESCRIPTION
I noticed this typo because I couldn’t generate [chai-docs](https://github.com/chaijs/chai-docs) from chai’s `master` branch.