### PR TITLE
Improve JSDoc documentation

### DIFF
--- a/lib/chai.js
+++ b/lib/chai.js
@@ -27,7 +27,7 @@ var util = require('./chai/utils');
 /**
  * # .use(function)
  *
- * Provides a way to extend the internals of Chai
+ * Provides a way to extend the internals of Chai.
  *
  * @param {Function}
  * @returns {this} for chaining

--- a/lib/chai/core/assertions.js
+++ b/lib/chai/core/assertions.js
@@ -1945,7 +1945,7 @@ module.exports = function (chai, _) {
   /**
    * ### .change(function)
    *
-   * Asserts that a function changes an object property
+   * Asserts that a function changes an object property.
    *
    *     var obj = { val: 10 };
    *     var fn = function() { obj.val += 3 };
@@ -2002,13 +2002,13 @@ module.exports = function (chai, _) {
   /**
    * ### .increase(target[, property[, message]])
    *
-   * Asserts that a function increases a numeric object property
+   * Asserts that a function increases a numeric object property.
    *
    *     var obj = { val: 10 };
    *     var fn = function() { obj.val = 15 };
    *     expect(fn).to.increase(obj, 'val');
    *
-   * It can also receive a function which returns the property
+   * It can also receive a function which returns the property:
    *
    *     var obj = { val: 10 };
    *     var fn = function() { obj.val = 5 };
@@ -2066,13 +2066,13 @@ module.exports = function (chai, _) {
   /**
    * ### .decrease(target[, property[, message]])
    *
-   * Asserts that a function decreases a numeric object property
+   * Asserts that a function decreases a numeric object property.
    *
    *     var obj = { val: 10 };
    *     var fn = function() { obj.val = 5 };
    *     expect(fn).to.decrease(obj, 'val');
    *
-   * It can also receive a function which returns the property
+   * It can also receive a function which returns the property:
    *
    *     var obj = { val: 10 };
    *     var fn = function() { obj.val = 5 };

--- a/lib/chai/core/assertions.js
+++ b/lib/chai/core/assertions.js
@@ -464,6 +464,7 @@ module.exports = function (chai, _) {
 
   /**
    * ### .NaN
+   *
    * Asserts that the target is `NaN`.
    *
    *     expect(NaN).to.be.NaN;

--- a/lib/chai/interface/assert.js
+++ b/lib/chai/interface/assert.js
@@ -431,6 +431,7 @@ module.exports = function (chai, util) {
 
   /**
    * ### .isNaN
+   *
    * Asserts that value is NaN
    *
    *    assert.isNaN(NaN, 'NaN is NaN');
@@ -448,6 +449,7 @@ module.exports = function (chai, util) {
 
   /**
    * ### .isNotNaN
+   *
    * Asserts that value is not NaN
    *
    *    assert.isNotNaN(4, '4 is not NaN');

--- a/lib/chai/interface/assert.js
+++ b/lib/chai/interface/assert.js
@@ -241,7 +241,7 @@ module.exports = function (chai, util) {
    /**
    * ### .isAbove(valueToCheck, valueToBeAbove, [message])
    *
-   * Asserts `valueToCheck` is strictly greater than (>) `valueToBeAbove`
+   * Asserts `valueToCheck` is strictly greater than (>) `valueToBeAbove`.
    *
    *     assert.isAbove(5, 2, '5 is strictly greater than 2');
    *
@@ -260,7 +260,7 @@ module.exports = function (chai, util) {
    /**
    * ### .isAtLeast(valueToCheck, valueToBeAtLeast, [message])
    *
-   * Asserts `valueToCheck` is greater than or equal to (>=) `valueToBeAtLeast`
+   * Asserts `valueToCheck` is greater than or equal to (>=) `valueToBeAtLeast`.
    *
    *     assert.isAtLeast(5, 2, '5 is greater or equal to 2');
    *     assert.isAtLeast(3, 3, '3 is greater or equal to 3');
@@ -280,7 +280,7 @@ module.exports = function (chai, util) {
    /**
    * ### .isBelow(valueToCheck, valueToBeBelow, [message])
    *
-   * Asserts `valueToCheck` is strictly less than (<) `valueToBeBelow`
+   * Asserts `valueToCheck` is strictly less than (<) `valueToBeBelow`.
    *
    *     assert.isBelow(3, 6, '3 is strictly less than 6');
    *
@@ -299,7 +299,7 @@ module.exports = function (chai, util) {
    /**
    * ### .isAtMost(valueToCheck, valueToBeAtMost, [message])
    *
-   * Asserts `valueToCheck` is less than or equal to (<=) `valueToBeAtMost`
+   * Asserts `valueToCheck` is less than or equal to (<=) `valueToBeAtMost`.
    *
    *     assert.isAtMost(3, 6, '3 is less than or equal to 6');
    *     assert.isAtMost(4, 4, '4 is less than or equal to 4');
@@ -432,7 +432,7 @@ module.exports = function (chai, util) {
   /**
    * ### .isNaN
    *
-   * Asserts that value is NaN
+   * Asserts that value is NaN.
    *
    *     assert.isNaN(NaN, 'NaN is NaN');
    *
@@ -450,7 +450,7 @@ module.exports = function (chai, util) {
   /**
    * ### .isNotNaN
    *
-   * Asserts that value is not NaN
+   * Asserts that value is not NaN.
    *
    *     assert.isNotNaN(4, '4 is not NaN');
    *
@@ -739,7 +739,7 @@ module.exports = function (chai, util) {
    /**
    * ### .isFinite(value, [message])
    *
-   * Asserts that `value` is a finite number. Unlike `.isNumber`, this will fail for `NaN` and `Infinity`
+   * Asserts that `value` is a finite number. Unlike `.isNumber`, this will fail for `NaN` and `Infinity`.
    *
    *     var cups = 2;
    *     assert.isFinite(cups, 'how many cups');
@@ -2238,7 +2238,7 @@ module.exports = function (chai, util) {
   /**
    * ### .changes(function, object, property, [message])
    *
-   * Asserts that a function changes the value of a property
+   * Asserts that a function changes the value of a property.
    *
    *     var obj = { val: 10 };
    *     var fn = function() { obj.val = 22 };
@@ -2265,7 +2265,7 @@ module.exports = function (chai, util) {
    /**
    * ### .changesBy(function, object, property, delta, [message])
    *
-   * Asserts that a function changes the value of a property by an amount (delta)
+   * Asserts that a function changes the value of a property by an amount (delta).
    *
    *     var obj = { val: 10 };
    *     var fn = function() { obj.val += 2 };
@@ -2297,7 +2297,7 @@ module.exports = function (chai, util) {
    /**
    * ### .doesNotChange(function, object, property, [message])
    *
-   * Asserts that a function does not change the value of a property
+   * Asserts that a function does not change the value of a property.
    *
    *     var obj = { val: 10 };
    *     var fn = function() { console.log('foo'); };
@@ -2356,7 +2356,7 @@ module.exports = function (chai, util) {
   /**
    * ### .increases(function, object, property, [message])
    *
-   * Asserts that a function increases a numeric object property
+   * Asserts that a function increases a numeric object property.
    *
    *     var obj = { val: 10 };
    *     var fn = function() { obj.val = 13 };
@@ -2383,7 +2383,7 @@ module.exports = function (chai, util) {
   /**
    * ### .increasesBy(function, object, property, delta, [message])
    *
-   * Asserts that a function increases a numeric object property or a function's return value by an amount (delta)
+   * Asserts that a function increases a numeric object property or a function's return value by an amount (delta).
    *
    *     var obj = { val: 10 };
    *     var fn = function() { obj.val += 10 };
@@ -2415,7 +2415,7 @@ module.exports = function (chai, util) {
   /**
    * ### .doesNotIncrease(function, object, property, [message])
    *
-   * Asserts that a function does not increase a numeric object property
+   * Asserts that a function does not increase a numeric object property.
    *
    *     var obj = { val: 10 };
    *     var fn = function() { obj.val = 8 };
@@ -2442,7 +2442,7 @@ module.exports = function (chai, util) {
   /**
    * ### .increasesButNotBy(function, object, property, [message])
    *
-   * Asserts that a function does not increase a numeric object property or function's return value by an amount (delta)
+   * Asserts that a function does not increase a numeric object property or function's return value by an amount (delta).
    *
    *     var obj = { val: 10 };
    *     var fn = function() { obj.val = 15 };
@@ -2474,7 +2474,7 @@ module.exports = function (chai, util) {
   /**
    * ### .decreases(function, object, property, [message])
    *
-   * Asserts that a function decreases a numeric object property
+   * Asserts that a function decreases a numeric object property.
    *
    *     var obj = { val: 10 };
    *     var fn = function() { obj.val = 5 };
@@ -2533,7 +2533,7 @@ module.exports = function (chai, util) {
   /**
    * ### .doesNotDecrease(function, object, property, [message])
    *
-   * Asserts that a function does not decreases a numeric object property
+   * Asserts that a function does not decreases a numeric object property.
    *
    *     var obj = { val: 10 };
    *     var fn = function() { obj.val = 15 };

--- a/lib/chai/interface/assert.js
+++ b/lib/chai/interface/assert.js
@@ -434,7 +434,7 @@ module.exports = function (chai, util) {
    *
    * Asserts that value is NaN
    *
-   *    assert.isNaN(NaN, 'NaN is NaN');
+   *     assert.isNaN(NaN, 'NaN is NaN');
    *
    * @name isNaN
    * @param {Mixed} value
@@ -452,7 +452,7 @@ module.exports = function (chai, util) {
    *
    * Asserts that value is not NaN
    *
-   *    assert.isNotNaN(4, '4 is not NaN');
+   *     assert.isNotNaN(4, '4 is not NaN');
    *
    * @name isNotNaN
    * @param {Mixed} value

--- a/lib/chai/utils/getActual.js
+++ b/lib/chai/utils/getActual.js
@@ -7,7 +7,7 @@
 /**
  * # getActual(object, [actual])
  *
- * Returns the `actual` value for an Assertion
+ * Returns the `actual` value for an Assertion.
  *
  * @param {Object} object (constructed Assertion)
  * @param {Arguments} chai.Assertion.prototype.assert arguments


### PR DESCRIPTION
- Add blank lines between headers and descriptions

Almost all of Chai’s JSDoc documentation uses a blank line between Markdown headers and descriptions, so I added them to `.NaN`, `.isNaN` and `.isNotNaN`.

- Fix Markdown code blocks

The code examples for `.isNaN` and `.isNotNaN` are not rendered in a code block on [chaijs.com](http://chaijs.com/api/assert/#method_isnan):

![screen shot 2016-10-08 at 19 05 10](https://cloud.githubusercontent.com/assets/652793/19214710/281ee2d6-8d8a-11e6-8503-951d52d60d71.png)

- Punctuate descriptions

Almost all of Chai’s documentation uses punctuation marks, so I added them where they were missing.