### PR TITLE
Bump version for first 4.0.0 canary release

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "Veselin Todorov <hi@vesln.com>",
     "John Firebaugh <john.firebaugh@gmail.com>"
   ],
-  "version": "3.5.0",
+  "version": "4.0.0-canary.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/chaijs/chai"


### PR DESCRIPTION
We need to change the package's version on `package.json` before releasing any version, even if it's a tagged one.

Please merge ASAP so we can release this 😄 

🎉 🎉 🎉 🎉 🎉 🎉 🎉 🎉 🎉 🎉

Also, thanks to our awesome contributors! You are all listed into #457, thanks everyone, you've done a great job!