### PR TITLE
Add common pitfalls warnings to the .throws assertion docs

### DIFF
--- a/lib/chai/core/assertions.js
+++ b/lib/chai/core/assertions.js
@@ -1527,6 +1527,21 @@ module.exports = function (chai, _) {
    *     expect(fn).to.throw(ReferenceError)
    *       .and.have.property('message').equal('This is a bad function.');
    *
+   * Be aware that you should pass a function as the target for this assertion, not its
+   * result. This means that if you want to test a function called `fn`, for example, you
+   * should not do the following:
+   *
+   *     expect(fn()).to.throw(Error);
+   *
+   * You should do this instead:
+   *
+   *     expect(fn).to.throw(Error);
+   *
+   * Also, when passing a function to this assertion, its context will be lost. This means
+   * that when you have a function which relies on `this`, for example, it might not work
+   * since `this` will be undefined because that function will be invoked directly, just
+   * like `fn()`.
+   *
    * @name throw
    * @alias throws
    * @alias Throw


### PR DESCRIPTION
As @meeber suggested on #864, this adds a few warnings about common pitfalls related to the `throws` assertion.

Please let me know if you guys remember anything else or if there are any grammar mistakes.

Thanks everyone 😄 