### PR TITLE
Add script that registers expect as a side-effect

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,28 @@ var expect = chai.expect;
 var should = chai.should();
 ```
 
+## Usage for ES6+
+
+```js
+// Using Assert style
+import assert from 'chai/assert'
+// Using Expect style
+import expect from 'chai/expect'
+// Using Should style
+import should from 'chai/should'
+```
+
+## Usage with Mocha
+
+```bash
+# Using Assert style
+mocha spec.js -r chai/assert # OR:
+# Using Expect style
+mocha spec.js -r chai/expect # OR:
+# Using Should style
+mocha spec.js -r chai/should
+```
+
 [Read more about these styles in our docs](http://chaijs.com/guide/styles/).
 
 ## Plugins

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ var expect = chai.expect;
 var should = chai.should();
 ```
 
-## Usage for ES6+
+## Native Modules Usage
 
 ```js
 import assert from 'chai/assert'

--- a/README.md
+++ b/README.md
@@ -119,23 +119,23 @@ var should = chai.should();
 ## Usage for ES6+
 
 ```js
-// Using Assert style
 import assert from 'chai/assert'
-// Using Expect style
+// Using Assert style
 import expect from 'chai/expect'
-// Using Should style
+// Using Expect style
 import should from 'chai/should'
+// Using Should style
 ```
 
 ## Usage with Mocha
 
 ```bash
-# Using Assert style
 mocha spec.js -r chai/assert # OR:
-# Using Expect style
+# Using Assert style
 mocha spec.js -r chai/expect # OR:
-# Using Should style
+# Using Expect style
 mocha spec.js -r chai/should
+# Using Should style
 ```
 
 [Read more about these styles in our docs](http://chaijs.com/guide/styles/).

--- a/assert.js
+++ b/assert.js
@@ -1,0 +1,1 @@
+global.assert = module.exports = require('./').assert;

--- a/expect.js
+++ b/expect.js
@@ -1,0 +1,1 @@
+global.expect = module.exports = require('./').expect;

--- a/should.js
+++ b/should.js
@@ -1,1 +1,1 @@
-module.exports = require('./').should();
+global.should = module.exports = require('./').should();


### PR DESCRIPTION
I've added expect and assert as side-effects to make mocha auto register expect and assert from CLI automatically and to use them effectively when importing within native modules. 

For more information see: #594 and #604 

## Native Modules Usage

```js
import assert from 'chai/assert'
// Using Assert style
import expect from 'chai/expect'
// Using Expect style
import should from 'chai/should'
// Using Should style
```

## Usage with Mocha

```bash
mocha spec.js -r chai/assert
# Using Assert style
mocha spec.js -r chai/expect
# Using Expect style
mocha spec.js -r chai/should
# Using Should style
```