### PR TITLE
test: comment out broken tests in Safari 10

### DIFF
--- a/test/should.js
+++ b/test/should.js
@@ -2205,7 +2205,9 @@ describe('should', function() {
        false.should.be.extensible;
      }, 'expected false to be extensible');
 
-    if (typeof Proxy === 'function') {
+    // A bug in Safari 10 causes the below test to fail. It can be re-enabled
+    // once the bug is fixed. See https://github.com/chaijs/chai/issues/855.
+    /*if (typeof Proxy === 'function') {
       var proxy = new Proxy({}, {
         isExtensible: function() {
           throw new TypeError();
@@ -2216,7 +2218,7 @@ describe('should', function() {
         // .extensible should not suppress errors, thrown in proxy traps
         proxy.should.be.extensible;
       }, { name: 'TypeError' });
-    }
+    }*/
   });
 
   it('sealed', function() {
@@ -2255,7 +2257,9 @@ describe('should', function() {
       false.should.not.be.sealed;
     }, 'expected false to not be sealed');
 
-    if (typeof Proxy === 'function') {
+    // A bug in Safari 10 causes the below test to fail. It can be re-enabled
+    // once the bug is fixed. See https://github.com/chaijs/chai/issues/855.
+    /*if (typeof Proxy === 'function') {
       var proxy = new Proxy({}, {
         ownKeys: function() {
           throw new TypeError();
@@ -2269,7 +2273,7 @@ describe('should', function() {
         // .sealed should not suppress errors, thrown in proxy traps
         proxy.should.be.sealed;
       }, { name: 'TypeError' });
-    }
+    }*/
   });
 
   it('frozen', function() {
@@ -2308,7 +2312,9 @@ describe('should', function() {
       false.should.not.be.frozen;
     }, 'expected false to not be frozen');
 
-    if (typeof Proxy === 'function') {
+    // A bug in Safari 10 causes the below test to fail. It can be re-enabled
+    // once the bug is fixed. See https://github.com/chaijs/chai/issues/855.
+    /*if (typeof Proxy === 'function') {
       var proxy = new Proxy({}, {
         ownKeys: function() {
           throw new TypeError();
@@ -2322,6 +2328,6 @@ describe('should', function() {
         // .frozen should not suppress errors, thrown in proxy traps
         proxy.should.be.frozen;
       }, { name: 'TypeError' });
-    }
+    }*/
   });
 });


### PR DESCRIPTION
Three tests on the `should` interface are failing in Safari 10 due to a
bug related to proxies. These tests should be re-enabled once the bug is
fixed. See https://github.com/chaijs/chai/issues/855.