### PR TITLE
Provided browser field in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "url": "https://github.com/chaijs/chai/issues"
   },
   "main": "./index",
+  "browser": "./chai.js",
   "scripts": {
     "test": "make test"
   },


### PR DESCRIPTION
Some tools use the browser field in the package.json to use an alternate main file. This is e.g. the case for rollup-plugin-node-resolve (https://github.com/rollup/rollup-plugin-node-resolve).
Specs: https://github.com/defunctzombie/package-browser-field-spec#alternate-main---basic