### PR TITLE
(WIP) Implement .{include,contain}.{all,any}.strings

### DIFF
--- a/lib/chai/core/assertions.js
+++ b/lib/chai/core/assertions.js
@@ -1516,7 +1516,9 @@ module.exports = function (chai, _) {
       , mixedArgsMsg = 'when testing strings against strings you must give a single Array|String argument or multiple String arguments';
 
     if (stringsType === 'Array') {
-      if (arguments.length > 1) throw new Error(mixedArgsMsg);
+      if (arguments.length > 1) {
+        throw new Error(mixedArgsMsg);
+      }
     } else {
       strings = Array.prototype.slice.call(arguments)
     }
@@ -1525,7 +1527,9 @@ module.exports = function (chai, _) {
       return this.string(strings[0])
     }
 
-    if (!strings.length) throw new Error('strings required');
+    if (!strings.length) {
+      throw new Error('strings required');
+    }
 
     var len = strings.length
       , any = flag(this, 'any')
@@ -1537,18 +1541,19 @@ module.exports = function (chai, _) {
     }
 
     function containsStr (expectedStr) {
-      return ~obj.indexOf(expectedStr)
+      return obj.indexOf(expectedStr) !== -1;
     }
 
+    var reducer
     // Has any
     if (any) {
-      var reducer = negate ? 'every' : 'some'
-      ok = expected[reducer](containsStr)
+      reducer = negate ? 'every' : 'some';
+      ok = expected[reducer](containsStr);
     }
 
     // Has all
     if (all) {
-      var reducer = negate ? 'some' : 'every'
+      reducer = negate ? 'some' : 'every';
       ok = expected[reducer](containsStr)
     }
 
@@ -1572,7 +1577,7 @@ module.exports = function (chai, _) {
     str = (len > 1 ? 'strings ' : 'string ') + str;
 
     // Have / include
-    str = 'contain ' + str
+    str = 'contain ' + str;
 
     // Assertion
     this.assert(

--- a/lib/chai/core/assertions.js
+++ b/lib/chai/core/assertions.js
@@ -1505,106 +1505,84 @@ module.exports = function (chai, _) {
   Assertion.addMethod('keys', assertKeys);
   Assertion.addMethod('key', assertKeys);
 
-  function assertStrings (keys) {
+  function assertStrings (strings) {
+    _.expectTypes(this, ['string']);
     var obj = flag(this, 'object')
-      , keysType = _.type(keys)
-      , isDeep = flag(this, 'deep')
+      , negate = flag(this, 'negate')
+      , stringsType = _.type(strings)
       , str
       , deepStr = ''
       , ok = true
-      , mixedArgsMsg = 'when testing keys against an object or an array you must give a single Array|Object|String argument or multiple String arguments';
+      , mixedArgsMsg = 'when testing strings against strings you must give a single Array|String argument or multiple String arguments';
 
-    actual = _.getOwnEnumerableProperties(obj);
-
-    switch (keysType) {
-      case 'Array':
-        if (arguments.length > 1) throw new Error(mixedArgsMsg);
-        break;
-      default:
-        keys = Array.prototype.slice.call(arguments);
+    if (stringsType === 'Array') {
+      if (arguments.length > 1) throw new Error(mixedArgsMsg);
+    } else {
+      strings = Array.prototype.slice.call(arguments)
     }
 
-    // Only stringify non-Symbols because Symbols would become "Symbol()"
-    keys = keys.map(function (val) {
-      return typeof val === 'symbol' ? val : String(val);
-    });
+    if (strings.length === 1) {
+      return this.string(strings[0])
+    }
 
-    if (!keys.length) throw new Error('keys required');
+    if (!strings.length) throw new Error('strings required');
 
-    var len = keys.length
+    var len = strings.length
       , any = flag(this, 'any')
       , all = flag(this, 'all')
-      , expected = keys
-      , actual;
+      , expected = strings;
 
     if (!any && !all) {
       all = true;
     }
 
+    function containsStr (expectedStr) {
+      return ~obj.indexOf(expectedStr)
+    }
+
     // Has any
     if (any) {
-      ok = expected.some(function(expectedKey) {
-        return actual.some(function(actualKey) {
-          if (isDeep) {
-            return _.eql(expectedKey, actualKey);
-          } else {
-            return expectedKey === actualKey;
-          }
-        });
-      });
+      var reducer = negate ? 'every' : 'some'
+      ok = expected[reducer](containsStr)
     }
 
     // Has all
     if (all) {
-      ok = expected.every(function(expectedKey) {
-        return actual.some(function(actualKey) {
-          if (isDeep) {
-            return _.eql(expectedKey, actualKey);
-          } else {
-            return expectedKey === actualKey;
-          }
-        });
-      });
-
-      if (!flag(this, 'negate') && !flag(this, 'contains')) {
-        ok = ok && keys.length == actual.length;
-      }
+      var reducer = negate ? 'some' : 'every'
+      ok = expected[reducer](containsStr)
     }
 
     // Key string
     if (len > 1) {
-      keys = keys.map(function(key) {
-        return _.inspect(key);
+      strings = strings.map(function(string) {
+        return _.inspect(string);
       });
-      var last = keys.pop();
+      var last = strings.pop();
       if (all) {
-        str = keys.join(', ') + ', and ' + last;
+        str = strings.join(', ') + ', and ' + last;
       }
       if (any) {
-        str = keys.join(', ') + ', or ' + last;
+        str = strings.join(', ') + ', or ' + last;
       }
     } else {
-      str = _.inspect(keys[0]);
+      str = _.inspect(strings[0]);
     }
 
     // Form
-    str = (len > 1 ? 'keys ' : 'key ') + str;
+    str = (len > 1 ? 'strings ' : 'string ') + str;
 
     // Have / include
-    str = (flag(this, 'contains') ? 'contain ' : 'have ') + str;
+    str = 'contain ' + str
 
     // Assertion
     this.assert(
         ok
       , 'expected #{this} to ' + deepStr + str
       , 'expected #{this} to not ' + deepStr + str
-      , expected.slice(0).sort(_.compareByInspect)
-      , actual.sort(_.compareByInspect)
-      , true
     );
   }
 
-  Assertion.addMethod('strings', assertKeys);
+  Assertion.addMethod('strings', assertStrings);
 
   /**
    * ### .throw([errorLike], [errMsgMatcher])

--- a/lib/chai/core/assertions.js
+++ b/lib/chai/core/assertions.js
@@ -154,9 +154,10 @@ module.exports = function (chai, _) {
    * ### .any
    *
    * Sets the `any` flag, (opposite of the `all` flag)
-   * later used in the `keys` assertion.
+   * later used in the `keys` and `strings` assertions.
    *
    *     expect(foo).to.have.any.keys('bar', 'baz');
+   *     expect(foo).to.contain.any.strings('bar', 'baz');
    *
    * @name any
    * @namespace BDD
@@ -173,9 +174,10 @@ module.exports = function (chai, _) {
    * ### .all
    *
    * Sets the `all` flag (opposite of the `any` flag)
-   * later used by the `keys` assertion.
+   * later used by the `keys` and `strings` assertions.
    *
    *     expect(foo).to.have.all.keys('bar', 'baz');
+   *     expect(foo).to.contain.all.strings('bar', 'baz');
    *
    * @name all
    * @namespace BDD
@@ -270,9 +272,11 @@ module.exports = function (chai, _) {
    *     expect({foo: obj1, bar: obj2}).to.deep.include({foo: {a: 1}, bar: {b: 2}});
    *
    * These assertions can also be used as property based language chains,
-   * enabling the `contains` flag for the `keys` assertion. For instance:
+   * enabling the `contains` flag for the `keys` and `strings` assertions.
+   * For instance:
    *
    *     expect({ foo: 'bar', hello: 'universe' }).to.include.keys('foo');
+   *     expect('foobar').to.include.all.strings('foo');
    *
    * @name include
    * @alias contain
@@ -290,6 +294,7 @@ module.exports = function (chai, _) {
 
   function includeChainingBehavior () {
     flag(this, 'contains', true);
+    flag(this, 'includes', true);
   }
 
   function isDeepIncluded (arr, val) {
@@ -1500,6 +1505,107 @@ module.exports = function (chai, _) {
   Assertion.addMethod('keys', assertKeys);
   Assertion.addMethod('key', assertKeys);
 
+  function assertStrings (keys) {
+    var obj = flag(this, 'object')
+      , keysType = _.type(keys)
+      , isDeep = flag(this, 'deep')
+      , str
+      , deepStr = ''
+      , ok = true
+      , mixedArgsMsg = 'when testing keys against an object or an array you must give a single Array|Object|String argument or multiple String arguments';
+
+    actual = _.getOwnEnumerableProperties(obj);
+
+    switch (keysType) {
+      case 'Array':
+        if (arguments.length > 1) throw new Error(mixedArgsMsg);
+        break;
+      default:
+        keys = Array.prototype.slice.call(arguments);
+    }
+
+    // Only stringify non-Symbols because Symbols would become "Symbol()"
+    keys = keys.map(function (val) {
+      return typeof val === 'symbol' ? val : String(val);
+    });
+
+    if (!keys.length) throw new Error('keys required');
+
+    var len = keys.length
+      , any = flag(this, 'any')
+      , all = flag(this, 'all')
+      , expected = keys
+      , actual;
+
+    if (!any && !all) {
+      all = true;
+    }
+
+    // Has any
+    if (any) {
+      ok = expected.some(function(expectedKey) {
+        return actual.some(function(actualKey) {
+          if (isDeep) {
+            return _.eql(expectedKey, actualKey);
+          } else {
+            return expectedKey === actualKey;
+          }
+        });
+      });
+    }
+
+    // Has all
+    if (all) {
+      ok = expected.every(function(expectedKey) {
+        return actual.some(function(actualKey) {
+          if (isDeep) {
+            return _.eql(expectedKey, actualKey);
+          } else {
+            return expectedKey === actualKey;
+          }
+        });
+      });
+
+      if (!flag(this, 'negate') && !flag(this, 'contains')) {
+        ok = ok && keys.length == actual.length;
+      }
+    }
+
+    // Key string
+    if (len > 1) {
+      keys = keys.map(function(key) {
+        return _.inspect(key);
+      });
+      var last = keys.pop();
+      if (all) {
+        str = keys.join(', ') + ', and ' + last;
+      }
+      if (any) {
+        str = keys.join(', ') + ', or ' + last;
+      }
+    } else {
+      str = _.inspect(keys[0]);
+    }
+
+    // Form
+    str = (len > 1 ? 'keys ' : 'key ') + str;
+
+    // Have / include
+    str = (flag(this, 'contains') ? 'contain ' : 'have ') + str;
+
+    // Assertion
+    this.assert(
+        ok
+      , 'expected #{this} to ' + deepStr + str
+      , 'expected #{this} to not ' + deepStr + str
+      , expected.slice(0).sort(_.compareByInspect)
+      , actual.sort(_.compareByInspect)
+      , true
+    );
+  }
+
+  Assertion.addMethod('strings', assertKeys);
+
   /**
    * ### .throw([errorLike], [errMsgMatcher])
    *
@@ -1574,7 +1680,7 @@ module.exports = function (chai, _) {
    *     err.code = 42;
    *     var badFn = function () { throw err; };
    *     expect(badFn).to.throw(TypeError).and.have.property('code', 42);
-   * 
+   *
    * Beware of some common mistakes when using the `throw` assertion. One common
    * mistake is to accidentally invoke the function yourself instead of letting
    * the `throw` assertion invoke the function for you. For example, when

--- a/test/expect.js
+++ b/test/expect.js
@@ -1409,11 +1409,11 @@ describe('expect', function () {
     expect('hello world').to.include.any.strings(['cat', 'hello']);
 
     expect('hello planet').to.not.include.all.strings('hello world');
-    expect('hello planet').to.not.include.all.strings('hello');
+    expect('hello planet').to.not.include.all.strings('goodbye');
     expect('hello planet').to.not.include.all.strings('goodbye', 'world');
 
     expect('hello planet').to.not.include.strings('hello world');
-    expect('hello planet').to.not.include.strings('hello');
+    expect('hello planet').to.not.include.strings('goodbye');
     expect('hello planet').to.not.include.strings('goodbye', 'world');
 
     expect('hello planet').to.not.include.any.strings('hello world');
@@ -1421,11 +1421,11 @@ describe('expect', function () {
     expect('hello planet').to.not.include.any.strings('cat', 'hello');
 
     expect('hello planet').to.not.include.all.strings(['hello world']);
-    expect('hello planet').to.not.include.all.strings(['hello']);
+    expect('hello planet').to.not.include.all.strings(['goodbye']);
     expect('hello planet').to.not.include.all.strings(['goodbye', 'world']);
 
     expect('hello planet').to.not.include.strings(['hello world']);
-    expect('hello planet').to.not.include.strings(['hello']);
+    expect('hello planet').to.not.include.strings(['goodbye']);
     expect('hello planet').to.not.include.strings(['goodbye', 'world']);
 
     expect('hello planet').to.not.include.any.strings(['hello world']);
@@ -1459,11 +1459,11 @@ describe('expect', function () {
     expect('hello world').to.contain.any.strings(['cat', 'hello']);
 
     expect('hello planet').to.not.contain.all.strings('hello world');
-    expect('hello planet').to.not.contain.all.strings('hello');
+    expect('hello planet').to.not.contain.all.strings('goodbye');
     expect('hello planet').to.not.contain.all.strings('goodbye', 'world');
 
     expect('hello planet').to.not.contain.strings('hello world');
-    expect('hello planet').to.not.contain.strings('hello');
+    expect('hello planet').to.not.contain.strings('goodbye');
     expect('hello planet').to.not.contain.strings('goodbye', 'world');
 
     expect('hello planet').to.not.contain.any.strings('hello world');
@@ -1471,11 +1471,11 @@ describe('expect', function () {
     expect('hello planet').to.not.contain.any.strings('cat', 'hello');
 
     expect('hello planet').to.not.contain.all.strings(['hello world']);
-    expect('hello planet').to.not.contain.all.strings(['hello']);
+    expect('hello planet').to.not.contain.all.strings(['goodbye']);
     expect('hello planet').to.not.contain.all.strings(['goodbye', 'world']);
 
     expect('hello planet').to.not.contain.strings(['hello world']);
-    expect('hello planet').to.not.contain.strings(['hello']);
+    expect('hello planet').to.not.contain.strings(['goodbye']);
     expect('hello planet').to.not.contain.strings(['goodbye', 'world']);
 
     expect('hello planet').to.not.contain.any.strings(['hello world']);
@@ -1483,100 +1483,108 @@ describe('expect', function () {
     expect('hello planet').to.not.contain.any.strings(['cat', 'hello']);
 
     err(function() {
+      expect('hello world').to.include.all.strings('cat');
+    }, "expected 'hello world' to contain 'cat'");
+
+    err(function() {
+      expect('hello world').to.include.all.strings(['cat']);
+    }, "expected 'hello world' to contain 'cat'");
+
+    err(function() {
       expect('hello world').to.include.all.strings('hello', 'cat');
-    }, "expected 'hello world' to include 'hello', and 'cat'");
+    }, "expected 'hello world' to contain strings 'hello', and 'cat'");
 
     err(function() {
       expect('hello world').to.include.strings('hello', 'cat');
-    }, "expected 'hello world' to include 'hello', and 'cat'");
+    }, "expected 'hello world' to contain strings 'hello', and 'cat'");
 
     err(function() {
       expect('hello world').to.include.any.strings('goodbye', 'cat');
-    }, "expected 'hello world' to include 'goodbye', or 'cat'");
+    }, "expected 'hello world' to contain strings 'goodbye', or 'cat'");
 
     err(function() {
       expect('hello world').to.not.include.all.strings('hello', 'world');
-    }, "expected 'hello world' to not include 'hello', and 'world'");
+    }, "expected 'hello world' to not contain strings 'hello', and 'world'");
 
     err(function() {
       expect('hello world').to.not.include.strings('hello', 'world');
-    }, "expected 'hello world' to not include 'hello', and 'world'");
+    }, "expected 'hello world' to not contain strings 'hello', and 'world'");
 
     err(function() {
       expect('hello world').to.not.include.any.strings('hello', 'world');
-    }, "expected 'hello world' to not include 'hello', or 'world'");
+    }, "expected 'hello world' to not contain strings 'hello', or 'world'");
 
     err(function() {
       expect('hello world').to.include.all.strings(['hello', 'cat']);
-    }, "expected 'hello world' to include 'hello', and 'cat'");
+    }, "expected 'hello world' to contain strings 'hello', and 'cat'");
 
     err(function() {
       expect('hello world').to.include.strings(['hello', 'cat']);
-    }, "expected 'hello world' to include 'hello', and 'cat'");
+    }, "expected 'hello world' to contain strings 'hello', and 'cat'");
 
     err(function() {
       expect('hello world').to.include.any.strings(['goodbye', 'cat']);
-    }, "expected 'hello world' to include 'goodbye', or 'cat'");
+    }, "expected 'hello world' to contain strings 'goodbye', or 'cat'");
 
     err(function() {
       expect('hello world').to.not.include.all.strings(['hello', 'world']);
-    }, "expected 'hello world' to not include 'hello', and 'world'");
+    }, "expected 'hello world' to not contain strings 'hello', and 'world'");
 
     err(function() {
       expect('hello world').to.not.include.strings(['hello', 'world']);
-    }, "expected 'hello world' to not include 'hello', and 'world'");
+    }, "expected 'hello world' to not contain strings 'hello', and 'world'");
 
     err(function() {
       expect('hello world').to.not.include.any.strings(['hello', 'world']);
-    }, "expected 'hello world' to not include 'hello', or 'world'");
+    }, "expected 'hello world' to not contain strings 'hello', or 'world'");
 
     err(function() {
       expect('hello world').to.contain.all.strings('hello', 'cat');
-    }, "expected 'hello world' to contain 'hello', and 'cat'");
+    }, "expected 'hello world' to contain strings 'hello', and 'cat'");
 
     err(function() {
       expect('hello world').to.contain.strings('hello', 'cat');
-    }, "expected 'hello world' to contain 'hello', and 'cat'");
+    }, "expected 'hello world' to contain strings 'hello', and 'cat'");
 
     err(function() {
       expect('hello world').to.contain.any.strings('goodbye', 'cat');
-    }, "expected 'hello world' to contain 'goodbye', or 'cat'");
+    }, "expected 'hello world' to contain strings 'goodbye', or 'cat'");
 
     err(function() {
       expect('hello world').to.not.contain.all.strings('hello', 'world');
-    }, "expected 'hello world' to not contain 'hello', and 'world'");
+    }, "expected 'hello world' to not contain strings 'hello', and 'world'");
 
     err(function() {
       expect('hello world').to.not.contain.strings('hello', 'world');
-    }, "expected 'hello world' to not contain 'hello', and 'world'");
+    }, "expected 'hello world' to not contain strings 'hello', and 'world'");
 
     err(function() {
       expect('hello world').to.not.contain.any.strings('hello', 'world');
-    }, "expected 'hello world' to not contain 'hello', or 'world'");
+    }, "expected 'hello world' to not contain strings 'hello', or 'world'");
 
     err(function() {
       expect('hello world').to.contain.all.strings(['hello', 'cat']);
-    }, "expected 'hello world' to contain 'hello', and 'cat'");
+    }, "expected 'hello world' to contain strings 'hello', and 'cat'");
 
     err(function() {
       expect('hello world').to.contain.strings(['hello', 'cat']);
-    }, "expected 'hello world' to contain 'hello', and 'cat'");
+    }, "expected 'hello world' to contain strings 'hello', and 'cat'");
 
     err(function() {
       expect('hello world').to.contain.any.strings(['goodbye', 'cat']);
-    }, "expected 'hello world' to contain 'goodbye', or 'cat'");
+    }, "expected 'hello world' to contain strings 'goodbye', or 'cat'");
 
     err(function() {
       expect('hello world').to.not.contain.all.strings(['hello', 'world']);
-    }, "expected 'hello world' to not contain 'hello', and 'world'");
+    }, "expected 'hello world' to not contain strings 'hello', and 'world'");
 
     err(function() {
       expect('hello world').to.not.contain.strings(['hello', 'world']);
-    }, "expected 'hello world' to not contain 'hello', and 'world'");
+    }, "expected 'hello world' to not contain strings 'hello', and 'world'");
 
     err(function() {
       expect('hello world').to.not.contain.any.strings(['hello', 'world']);
-    }, "expected 'hello world' to not contain 'hello', or 'world'");
+    }, "expected 'hello world' to not contain strings 'hello', or 'world'");
 
     err(function(){
       expect('hello').to.contain.all.strings();

--- a/test/expect.js
+++ b/test/expect.js
@@ -1381,11 +1381,9 @@ describe('expect', function () {
 
   it('strings(array|arguments)', function() {
     expect('hello world').to.include.all.strings('hello world');
-    expect('hello world').to.include.all.strings('hello world');
     expect('hello world').to.include.all.strings('hello');
     expect('hello world').to.include.all.strings('hello', 'world');
 
-    expect('hello world').to.include.strings('hello world');
     expect('hello world').to.include.strings('hello world');
     expect('hello world').to.include.strings('hello');
     expect('hello world').to.include.strings('hello', 'world');

--- a/test/expect.js
+++ b/test/expect.js
@@ -1381,8 +1381,15 @@ describe('expect', function () {
 
   it('strings(array|arguments)', function() {
     expect('hello world').to.include.all.strings('hello world');
+    expect('hello world').to.include.all.strings('hello world');
     expect('hello world').to.include.all.strings('hello');
     expect('hello world').to.include.all.strings('hello', 'world');
+
+    expect('hello world').to.include.strings('hello world');
+    expect('hello world').to.include.strings('hello world');
+    expect('hello world').to.include.strings('hello');
+    expect('hello world').to.include.strings('hello', 'world');
+
     expect('hello world').to.include.any.strings('hello');
     expect('hello world').to.include.any.strings('hello world');
     expect('hello world').to.include.any.strings('hello', 'world');
@@ -1391,6 +1398,11 @@ describe('expect', function () {
     expect('hello world').to.include.all.strings(['hello world']);
     expect('hello world').to.include.all.strings(['hello']);
     expect('hello world').to.include.all.strings(['hello', 'world']);
+
+    expect('hello world').to.include.strings(['hello world']);
+    expect('hello world').to.include.strings(['hello']);
+    expect('hello world').to.include.strings(['hello', 'world']);
+
     expect('hello world').to.include.any.strings(['hello']);
     expect('hello world').to.include.any.strings(['hello world']);
     expect('hello world').to.include.any.strings(['hello', 'world']);
@@ -1399,6 +1411,11 @@ describe('expect', function () {
     expect('hello planet').to.not.include.all.strings('hello world');
     expect('hello planet').to.not.include.all.strings('hello');
     expect('hello planet').to.not.include.all.strings('goodbye', 'world');
+
+    expect('hello planet').to.not.include.strings('hello world');
+    expect('hello planet').to.not.include.strings('hello');
+    expect('hello planet').to.not.include.strings('goodbye', 'world');
+
     expect('hello planet').to.not.include.any.strings('hello world');
     expect('hello planet').to.not.include.any.strings('hello', 'world');
     expect('hello planet').to.not.include.any.strings('cat', 'hello');
@@ -1406,6 +1423,11 @@ describe('expect', function () {
     expect('hello planet').to.not.include.all.strings(['hello world']);
     expect('hello planet').to.not.include.all.strings(['hello']);
     expect('hello planet').to.not.include.all.strings(['goodbye', 'world']);
+
+    expect('hello planet').to.not.include.strings(['hello world']);
+    expect('hello planet').to.not.include.strings(['hello']);
+    expect('hello planet').to.not.include.strings(['goodbye', 'world']);
+
     expect('hello planet').to.not.include.any.strings(['hello world']);
     expect('hello planet').to.not.include.any.strings(['hello', 'world']);
     expect('hello planet').to.not.include.any.strings(['cat', 'hello']);
@@ -1413,6 +1435,11 @@ describe('expect', function () {
     expect('hello world').to.contain.all.strings('hello world');
     expect('hello world').to.contain.all.strings('hello');
     expect('hello world').to.contain.all.strings('hello', 'world');
+
+    expect('hello world').to.contain.strings('hello world');
+    expect('hello world').to.contain.strings('hello');
+    expect('hello world').to.contain.strings('hello', 'world');
+
     expect('hello world').to.contain.any.strings('hello');
     expect('hello world').to.contain.any.strings('hello world');
     expect('hello world').to.contain.any.strings('hello', 'world');
@@ -1421,6 +1448,11 @@ describe('expect', function () {
     expect('hello world').to.contain.all.strings(['hello world']);
     expect('hello world').to.contain.all.strings(['hello']);
     expect('hello world').to.contain.all.strings(['hello', 'world']);
+
+    expect('hello world').to.contain.strings(['hello world']);
+    expect('hello world').to.contain.strings(['hello']);
+    expect('hello world').to.contain.strings(['hello', 'world']);
+
     expect('hello world').to.contain.any.strings(['hello']);
     expect('hello world').to.contain.any.strings(['hello world']);
     expect('hello world').to.contain.any.strings(['hello', 'world']);
@@ -1429,6 +1461,11 @@ describe('expect', function () {
     expect('hello planet').to.not.contain.all.strings('hello world');
     expect('hello planet').to.not.contain.all.strings('hello');
     expect('hello planet').to.not.contain.all.strings('goodbye', 'world');
+
+    expect('hello planet').to.not.contain.strings('hello world');
+    expect('hello planet').to.not.contain.strings('hello');
+    expect('hello planet').to.not.contain.strings('goodbye', 'world');
+
     expect('hello planet').to.not.contain.any.strings('hello world');
     expect('hello planet').to.not.contain.any.strings('hello', 'world');
     expect('hello planet').to.not.contain.any.strings('cat', 'hello');
@@ -1436,12 +1473,21 @@ describe('expect', function () {
     expect('hello planet').to.not.contain.all.strings(['hello world']);
     expect('hello planet').to.not.contain.all.strings(['hello']);
     expect('hello planet').to.not.contain.all.strings(['goodbye', 'world']);
+
+    expect('hello planet').to.not.contain.strings(['hello world']);
+    expect('hello planet').to.not.contain.strings(['hello']);
+    expect('hello planet').to.not.contain.strings(['goodbye', 'world']);
+
     expect('hello planet').to.not.contain.any.strings(['hello world']);
     expect('hello planet').to.not.contain.any.strings(['hello', 'world']);
     expect('hello planet').to.not.contain.any.strings(['cat', 'hello']);
 
     err(function() {
       expect('hello world').to.include.all.strings('hello', 'cat');
+    }, "expected 'hello world' to include 'hello', and 'cat'");
+
+    err(function() {
+      expect('hello world').to.include.strings('hello', 'cat');
     }, "expected 'hello world' to include 'hello', and 'cat'");
 
     err(function() {
@@ -1453,11 +1499,19 @@ describe('expect', function () {
     }, "expected 'hello world' to not include 'hello', and 'world'");
 
     err(function() {
+      expect('hello world').to.not.include.strings('hello', 'world');
+    }, "expected 'hello world' to not include 'hello', and 'world'");
+
+    err(function() {
       expect('hello world').to.not.include.any.strings('hello', 'world');
     }, "expected 'hello world' to not include 'hello', or 'world'");
 
     err(function() {
       expect('hello world').to.include.all.strings(['hello', 'cat']);
+    }, "expected 'hello world' to include 'hello', and 'cat'");
+
+    err(function() {
+      expect('hello world').to.include.strings(['hello', 'cat']);
     }, "expected 'hello world' to include 'hello', and 'cat'");
 
     err(function() {
@@ -1469,11 +1523,19 @@ describe('expect', function () {
     }, "expected 'hello world' to not include 'hello', and 'world'");
 
     err(function() {
+      expect('hello world').to.not.include.strings(['hello', 'world']);
+    }, "expected 'hello world' to not include 'hello', and 'world'");
+
+    err(function() {
       expect('hello world').to.not.include.any.strings(['hello', 'world']);
     }, "expected 'hello world' to not include 'hello', or 'world'");
 
     err(function() {
       expect('hello world').to.contain.all.strings('hello', 'cat');
+    }, "expected 'hello world' to contain 'hello', and 'cat'");
+
+    err(function() {
+      expect('hello world').to.contain.strings('hello', 'cat');
     }, "expected 'hello world' to contain 'hello', and 'cat'");
 
     err(function() {
@@ -1485,6 +1547,10 @@ describe('expect', function () {
     }, "expected 'hello world' to not contain 'hello', and 'world'");
 
     err(function() {
+      expect('hello world').to.not.contain.strings('hello', 'world');
+    }, "expected 'hello world' to not contain 'hello', and 'world'");
+
+    err(function() {
       expect('hello world').to.not.contain.any.strings('hello', 'world');
     }, "expected 'hello world' to not contain 'hello', or 'world'");
 
@@ -1493,11 +1559,19 @@ describe('expect', function () {
     }, "expected 'hello world' to contain 'hello', and 'cat'");
 
     err(function() {
+      expect('hello world').to.contain.strings(['hello', 'cat']);
+    }, "expected 'hello world' to contain 'hello', and 'cat'");
+
+    err(function() {
       expect('hello world').to.contain.any.strings(['goodbye', 'cat']);
     }, "expected 'hello world' to contain 'goodbye', or 'cat'");
 
     err(function() {
       expect('hello world').to.not.contain.all.strings(['hello', 'world']);
+    }, "expected 'hello world' to not contain 'hello', and 'world'");
+
+    err(function() {
+      expect('hello world').to.not.contain.strings(['hello', 'world']);
     }, "expected 'hello world' to not contain 'hello', and 'world'");
 
     err(function() {
@@ -1510,6 +1584,14 @@ describe('expect', function () {
 
     err(function(){
      expect('hello').to.contain.all.strings([]);
+    }, "strings required");
+
+    err(function(){
+      expect('hello').to.contain.strings();
+    }, "strings required");
+
+    err(function(){
+     expect('hello').to.contain.strings([]);
     }, "strings required");
 
     err(function(){
@@ -1529,6 +1611,14 @@ describe('expect', function () {
     }, "strings required");
 
     err(function(){
+      expect('hello').to.include.strings();
+    }, "strings required");
+
+    err(function(){
+     expect('hello').to.include.strings([]);
+    }, "strings required");
+
+    err(function(){
       expect('hello').to.include.any.strings();
     }, "strings required");
 
@@ -1543,11 +1633,19 @@ describe('expect', function () {
     }, mixedArgsMsg);
 
     err(function(){
+      expect('hello').to.contain.strings(['e'], "o");
+    }, mixedArgsMsg);
+
+    err(function(){
       expect('hello').to.contain.any.strings(['e'], "o");
     }, mixedArgsMsg);
 
     err(function(){
       expect('hello').to.include.all.strings(['e'], "o");
+    }, mixedArgsMsg);
+
+    err(function(){
+      expect('hello').to.include.strings(['e'], "o");
     }, mixedArgsMsg);
 
     err(function(){

--- a/test/expect.js
+++ b/test/expect.js
@@ -1379,6 +1379,182 @@ describe('expect', function () {
     }, "expected { foo: { a: 1 }, bar: { b: 2 } } to not have deep property 'foo' of { a: 1 }");
   });
 
+  it('strings(array|arguments)', function() {
+    expect('hello world').to.include.all.strings('hello world');
+    expect('hello world').to.include.all.strings('hello');
+    expect('hello world').to.include.all.strings('hello', 'world');
+    expect('hello world').to.include.any.strings('hello');
+    expect('hello world').to.include.any.strings('hello world');
+    expect('hello world').to.include.any.strings('hello', 'world');
+    expect('hello world').to.include.any.strings('cat', 'hello');
+
+    expect('hello world').to.include.all.strings(['hello world']);
+    expect('hello world').to.include.all.strings(['hello']);
+    expect('hello world').to.include.all.strings(['hello', 'world']);
+    expect('hello world').to.include.any.strings(['hello']);
+    expect('hello world').to.include.any.strings(['hello world']);
+    expect('hello world').to.include.any.strings(['hello', 'world']);
+    expect('hello world').to.include.any.strings(['cat', 'hello']);
+
+    expect('hello planet').to.not.include.all.strings('hello world');
+    expect('hello planet').to.not.include.all.strings('hello');
+    expect('hello planet').to.not.include.all.strings('goodbye', 'world');
+    expect('hello planet').to.not.include.any.strings('hello world');
+    expect('hello planet').to.not.include.any.strings('hello', 'world');
+    expect('hello planet').to.not.include.any.strings('cat', 'hello');
+
+    expect('hello planet').to.not.include.all.strings(['hello world']);
+    expect('hello planet').to.not.include.all.strings(['hello']);
+    expect('hello planet').to.not.include.all.strings(['goodbye', 'world']);
+    expect('hello planet').to.not.include.any.strings(['hello world']);
+    expect('hello planet').to.not.include.any.strings(['hello', 'world']);
+    expect('hello planet').to.not.include.any.strings(['cat', 'hello']);
+
+    expect('hello world').to.contain.all.strings('hello world');
+    expect('hello world').to.contain.all.strings('hello');
+    expect('hello world').to.contain.all.strings('hello', 'world');
+    expect('hello world').to.contain.any.strings('hello');
+    expect('hello world').to.contain.any.strings('hello world');
+    expect('hello world').to.contain.any.strings('hello', 'world');
+    expect('hello world').to.contain.any.strings('cat', 'hello');
+
+    expect('hello world').to.contain.all.strings(['hello world']);
+    expect('hello world').to.contain.all.strings(['hello']);
+    expect('hello world').to.contain.all.strings(['hello', 'world']);
+    expect('hello world').to.contain.any.strings(['hello']);
+    expect('hello world').to.contain.any.strings(['hello world']);
+    expect('hello world').to.contain.any.strings(['hello', 'world']);
+    expect('hello world').to.contain.any.strings(['cat', 'hello']);
+
+    expect('hello planet').to.not.contain.all.strings('hello world');
+    expect('hello planet').to.not.contain.all.strings('hello');
+    expect('hello planet').to.not.contain.all.strings('goodbye', 'world');
+    expect('hello planet').to.not.contain.any.strings('hello world');
+    expect('hello planet').to.not.contain.any.strings('hello', 'world');
+    expect('hello planet').to.not.contain.any.strings('cat', 'hello');
+
+    expect('hello planet').to.not.contain.all.strings(['hello world']);
+    expect('hello planet').to.not.contain.all.strings(['hello']);
+    expect('hello planet').to.not.contain.all.strings(['goodbye', 'world']);
+    expect('hello planet').to.not.contain.any.strings(['hello world']);
+    expect('hello planet').to.not.contain.any.strings(['hello', 'world']);
+    expect('hello planet').to.not.contain.any.strings(['cat', 'hello']);
+
+    err(function() {
+      expect('hello world').to.include.all.strings('hello', 'cat');
+    }, "expected 'hello world' to include 'hello', and 'cat'");
+
+    err(function() {
+      expect('hello world').to.include.any.strings('goodbye', 'cat');
+    }, "expected 'hello world' to include 'goodbye', or 'cat'");
+
+    err(function() {
+      expect('hello world').to.not.include.all.strings('hello', 'world');
+    }, "expected 'hello world' to not include 'hello', and 'world'");
+
+    err(function() {
+      expect('hello world').to.not.include.any.strings('hello', 'world');
+    }, "expected 'hello world' to not include 'hello', or 'world'");
+
+    err(function() {
+      expect('hello world').to.include.all.strings(['hello', 'cat']);
+    }, "expected 'hello world' to include 'hello', and 'cat'");
+
+    err(function() {
+      expect('hello world').to.include.any.strings(['goodbye', 'cat']);
+    }, "expected 'hello world' to include 'goodbye', or 'cat'");
+
+    err(function() {
+      expect('hello world').to.not.include.all.strings(['hello', 'world']);
+    }, "expected 'hello world' to not include 'hello', and 'world'");
+
+    err(function() {
+      expect('hello world').to.not.include.any.strings(['hello', 'world']);
+    }, "expected 'hello world' to not include 'hello', or 'world'");
+
+    err(function() {
+      expect('hello world').to.contain.all.strings('hello', 'cat');
+    }, "expected 'hello world' to contain 'hello', and 'cat'");
+
+    err(function() {
+      expect('hello world').to.contain.any.strings('goodbye', 'cat');
+    }, "expected 'hello world' to contain 'goodbye', or 'cat'");
+
+    err(function() {
+      expect('hello world').to.not.contain.all.strings('hello', 'world');
+    }, "expected 'hello world' to not contain 'hello', and 'world'");
+
+    err(function() {
+      expect('hello world').to.not.contain.any.strings('hello', 'world');
+    }, "expected 'hello world' to not contain 'hello', or 'world'");
+
+    err(function() {
+      expect('hello world').to.contain.all.strings(['hello', 'cat']);
+    }, "expected 'hello world' to contain 'hello', and 'cat'");
+
+    err(function() {
+      expect('hello world').to.contain.any.strings(['goodbye', 'cat']);
+    }, "expected 'hello world' to contain 'goodbye', or 'cat'");
+
+    err(function() {
+      expect('hello world').to.not.contain.all.strings(['hello', 'world']);
+    }, "expected 'hello world' to not contain 'hello', and 'world'");
+
+    err(function() {
+      expect('hello world').to.not.contain.any.strings(['hello', 'world']);
+    }, "expected 'hello world' to not contain 'hello', or 'world'");
+
+    err(function(){
+      expect('hello').to.contain.all.strings();
+    }, "strings required");
+
+    err(function(){
+     expect('hello').to.contain.all.strings([]);
+    }, "strings required");
+
+    err(function(){
+      expect('hello').to.contain.any.strings();
+    }, "strings required");
+
+    err(function(){
+     expect('hello').to.contain.any.strings([]);
+    }, "strings required");
+
+    err(function(){
+      expect('hello').to.include.all.strings();
+    }, "strings required");
+
+    err(function(){
+     expect('hello').to.include.all.strings([]);
+    }, "strings required");
+
+    err(function(){
+      expect('hello').to.include.any.strings();
+    }, "strings required");
+
+    err(function(){
+     expect('hello').to.include.any.strings([]);
+    }, "strings required");
+
+    var mixedArgsMsg = 'when testing strings against strings you must give a single Array|String argument or multiple String arguments'
+
+    err(function(){
+      expect('hello').to.contain.all.strings(['e'], "o");
+    }, mixedArgsMsg);
+
+    err(function(){
+      expect('hello').to.contain.any.strings(['e'], "o");
+    }, mixedArgsMsg);
+
+    err(function(){
+      expect('hello').to.include.all.strings(['e'], "o");
+    }, mixedArgsMsg);
+
+    err(function(){
+      expect('hello').to.include.any.strings(['e'], "o");
+    }, mixedArgsMsg);
+  });
+
   it('keys(array|Object|arguments)', function(){
     expect({ foo: 1 }).to.have.keys(['foo']);
     expect({ foo: 1 }).have.keys({ 'foo': 6 });
@@ -1658,7 +1834,7 @@ describe('expect', function () {
       expect(testSet).to.not.have.any.deep.keys([{13: 37}, 'thisDoesNotExist', 'thisToo']);
       expect(testSet).to.not.have.any.deep.keys([20, 1, {13: 37}]);
       expect(testSet).to.not.have.all.deep.keys([{thisIs: 'anExampleObject'}, {'iDoNot': 'exist'}]);
- 
+
       var weirdSetKey1 = Object.create(null)
         , weirdSetKey2 = {toString: NaN}
         , weirdSetKey3 = []


### PR DESCRIPTION
Hello dear chai team :)

This is a WIP PR (as suggested by @vieiralucas) that should implement https://github.com/chaijs/chai/issues/858.

This is an initial version just to get your feedback on style, corner cases, tests, etc. Maybe something else needs to be changed to make new assertion work properly.
One thing I know is missing - docstrings for a new method and I also need to check with chai coding style guidelines.
Will be happy to hear your thoughts on this.

Have a good day!