### PR TITLE
Un-deprecate `length` and add guard

### DIFF
--- a/lib/chai/core/assertions.js
+++ b/lib/chai/core/assertions.js
@@ -674,14 +674,14 @@ module.exports = function (chai, _) {
    *
    *     expect(10).to.be.above(5);
    *
-   * Can also be used in conjunction with `length` to
+   * Can also be used in conjunction with `lengthOf` to
    * assert a minimum length. The benefit being a
    * more informative error message than if the length
    * was supplied directly. In this case the target must
    * have a length property.
    *
-   *     expect('foo').to.have.length.above(2);
-   *     expect([ 1, 2, 3 ]).to.have.length.above(2);
+   *     expect('foo').to.have.lengthOf.above(2);
+   *     expect([ 1, 2, 3 ]).to.have.lengthOf.above(2);
    *
    * @name above
    * @alias gt
@@ -736,14 +736,14 @@ module.exports = function (chai, _) {
    *
    *     expect(10).to.be.at.least(10);
    *
-   * Can also be used in conjunction with `length` to
+   * Can also be used in conjunction with `lengthOf` to
    * assert a minimum length. The benefit being a
    * more informative error message than if the length
    * was supplied directly. In this case the target must
    * have a length property.
    *
-   *     expect('foo').to.have.length.of.at.least(2);
-   *     expect([ 1, 2, 3 ]).to.have.length.of.at.least(3);
+   *     expect('foo').to.have.lengthOf.at.least(2);
+   *     expect([ 1, 2, 3 ]).to.have.lengthOf.at.least(3);
    *
    * @name least
    * @alias gte
@@ -796,14 +796,14 @@ module.exports = function (chai, _) {
    *
    *     expect(5).to.be.below(10);
    *
-   * Can also be used in conjunction with `length` to
+   * Can also be used in conjunction with `lengthOf` to
    * assert a maximum length. The benefit being a
    * more informative error message than if the length
    * was supplied directly. In this case the target must
    * have a length property.
    *
-   *     expect('foo').to.have.length.below(4);
-   *     expect([ 1, 2, 3 ]).to.have.length.below(4);
+   *     expect('foo').to.have.lengthOf.below(4);
+   *     expect([ 1, 2, 3 ]).to.have.lengthOf.below(4);
    *
    * @name below
    * @alias lt
@@ -858,14 +858,14 @@ module.exports = function (chai, _) {
    *
    *     expect(5).to.be.at.most(5);
    *
-   * Can also be used in conjunction with `length` to
+   * Can also be used in conjunction with `lengthOf` to
    * assert a maximum length. The benefit being a
    * more informative error message than if the length
    * was supplied directly. In this case the target must
    * have a length property.
    *
-   *     expect('foo').to.have.length.of.at.most(4);
-   *     expect([ 1, 2, 3 ]).to.have.length.of.at.most(3);
+   *     expect('foo').to.have.lengthOf.at.most(4);
+   *     expect([ 1, 2, 3 ]).to.have.lengthOf.at.most(3);
    *
    * @name most
    * @alias lte
@@ -918,14 +918,14 @@ module.exports = function (chai, _) {
    *
    *     expect(7).to.be.within(5,10);
    *
-   * Can also be used in conjunction with `length` to
+   * Can also be used in conjunction with `lengthOf` to
    * assert a length range. The benefit being a
    * more informative error message than if the length
    * was supplied directly. In this case the target must
    * have a length property.
    *
-   *     expect('foo').to.have.length.within(2,4);
-   *     expect([ 1, 2, 3 ]).to.have.length.within(2,4);
+   *     expect('foo').to.have.lengthOf.within(2,4);
+   *     expect([ 1, 2, 3 ]).to.have.lengthOf.within(2,4);
    *
    * @name within
    * @param {Number} start lowerbound inclusive
@@ -1213,38 +1213,40 @@ module.exports = function (chai, _) {
   Assertion.addMethod('haveOwnPropertyDescriptor', assertOwnPropertyDescriptor);
 
   /**
-   * ### .length
-   *
-   * Sets the `doLength` flag later used as a chain precursor to a value
-   * comparison for the `length` property.
-   *
-   *     expect('foo').to.have.length.above(2);
-   *     expect([ 1, 2, 3 ]).to.have.length.above(2);
-   *     expect('foo').to.have.length.below(4);
-   *     expect([ 1, 2, 3 ]).to.have.length.below(4);
-   *     expect('foo').to.have.length.within(2,4);
-   *     expect([ 1, 2, 3 ]).to.have.length.within(2,4);
-   *
-   * *Deprecation notice:* Using `length` as an assertion will be deprecated
-   * in version 2.4.0 and removed in 3.0.0. Code using the old style of
-   * asserting for `length` property value using `length(value)` should be
-   * switched to use `lengthOf(value)` instead.
-   *
-   * @name length
-   * @namespace BDD
-   * @api public
-   */
-
-  /**
    * ### .lengthOf(value[, message])
    *
-   * Asserts that the target's `length` property has
+   * When invoked as a function, asserts that the target's `length` property has
    * the expected value.
    *
    *     expect([ 1, 2, 3]).to.have.lengthOf(3);
    *     expect('foobar').to.have.lengthOf(6);
    *
+   * When used as a language chain, sets the `doLength` flag which is later used
+   * by the `above`, `below`, `least`, `most`, and `within` assertions for
+   * asserting that the target's `length` property falls within the expected
+   * range of values.
+   *
+   *     expect('foo').to.have.lengthOf.above(2);
+   *     expect([ 1, 2, 3 ]).to.have.lengthOf.above(2);
+   *     expect('foo').to.have.lengthOf.below(4);
+   *     expect([ 1, 2, 3 ]).to.have.lengthOf.below(4);
+   *     expect('foo').to.have.lengthOf.at.least(3);
+   *     expect([ 1, 2, 3 ]).to.have.lengthOf.at.least(3);
+   *     expect('foo').to.have.lengthOf.at.most(3);
+   *     expect([ 1, 2, 3 ]).to.have.lengthOf.at.most(3);
+   *     expect('foo').to.have.lengthOf.within(2,4);
+   *     expect([ 1, 2, 3 ]).to.have.lengthOf.within(2,4);
+   *
+   * Warning: It's recommended to use `lengthOf` instead of its alias `length`,
+   * even though `length` is shorter. This is due to a compatibility issue that
+   * prevents `length` (but not `lengthOf`) from being chained directly off of
+   * an uninvoked method such as `a`. For example:
+   *
+   *     expect('foo').to.have.a.lengthOf(3);  // passes as expected
+   *     expect('foo').to.have.a.length(3);    // throws error
+   *
    * @name lengthOf
+   * @alias length
    * @param {Number} length
    * @param {String} message _optional_
    * @namespace BDD
@@ -1271,7 +1273,7 @@ module.exports = function (chai, _) {
   }
 
   Assertion.addChainableMethod('length', assertLength, assertLengthChain);
-  Assertion.addMethod('lengthOf', assertLength);
+  Assertion.addChainableMethod('lengthOf', assertLength, assertLengthChain);
 
   /**
    * ### .match(regexp)

--- a/lib/chai/interface/assert.js
+++ b/lib/chai/interface/assert.js
@@ -1456,7 +1456,7 @@ module.exports = function (chai, util) {
    */
 
   assert.lengthOf = function (exp, len, msg) {
-    new Assertion(exp, msg).to.have.length(len);
+    new Assertion(exp, msg).to.have.lengthOf(len);
   };
 
   /**

--- a/lib/chai/utils/addChainableMethod.js
+++ b/lib/chai/utils/addChainableMethod.js
@@ -8,6 +8,7 @@
  * Module dependencies
  */
 
+var addLengthGuard = require('./addLengthGuard');
 var chai = require('../../chai');
 var flag = require('./flag');
 var proxify = require('./proxify');
@@ -92,6 +93,8 @@ module.exports = function (ctx, name, method, chainingBehavior) {
           transferFlags(this, newAssertion);
           return newAssertion;
         };
+
+        addLengthGuard(assert, name, true);
 
         // Use `__proto__` if available
         if (hasProtoSupport) {

--- a/lib/chai/utils/addLengthGuard.js
+++ b/lib/chai/utils/addLengthGuard.js
@@ -1,0 +1,62 @@
+var config = require('../config');
+
+var fnLengthDesc = Object.getOwnPropertyDescriptor(function () {}, 'length');
+
+/*!
+ * Chai - addLengthGuard utility
+ * Copyright(c) 2012-2014 Jake Luer <jake@alogicalparadox.com>
+ * MIT Licensed
+ */
+
+/**
+ * # addLengthGuard(fn, assertionName, isChainable)
+ *
+ * Define `length` as a getter on the given uninvoked method assertion. The
+ * getter acts as a guard against chaining `length` directly off of an uninvoked
+ * method assertion, which is a problem because it references `function`'s
+ * built-in `length` property instead of Chai's `length` assertion. When the
+ * getter catches the user making this mistake, it throws an error with a
+ * helpful message.
+ *
+ * There are two ways in which this mistake can be made. The first way is by
+ * chaining the `length` assertion directly off of an uninvoked chainable
+ * method. In this case, Chai suggests that the user use `lengthOf` instead. The
+ * second way is by chaining the `length` assertion directly off of an uninvoked
+ * non-chainable method. Non-chainable methods must be invoked prior to
+ * chaining. In this case, Chai suggests that the user consult the docs for the
+ * given assertion.
+ *
+ * If the `length` property of functions is unconfigurable, then return `fn`
+ * without modification.
+ *
+ * Note that in ES6, the function's `length` property is configurable, so once
+ * support for legacy environments is dropped, Chai's `length` property can
+ * replace the built-in function's `length` property, and this length guard will
+ * no longer be necessary. In the mean time, maintaining consistency across all
+ * environments is the priority.
+ *
+ * @param {Function} fn
+ * @param {String} assertionName
+ * @param {Boolean} isChainable
+ * @namespace Utils
+ * @name addLengthGuard
+ */
+
+module.exports = function addLengthGuard (fn, assertionName, isChainable) {
+  if (!fnLengthDesc.configurable) return fn;
+
+  Object.defineProperty(fn, 'length', {
+    get: function () {
+      if (isChainable) {
+        throw Error('Invalid Chai property: ' + assertionName + '.length. Due' +
+          ' to a compatibility issue, "length" cannot directly follow "' +
+          assertionName + '". Use "' + assertionName + '.lengthOf" instead.');
+      }
+
+      throw Error('Invalid Chai property: ' + assertionName + '.length. See' +
+        ' docs for proper usage of "' + assertionName + '".');
+    }
+  });
+
+  return fn;
+};

--- a/lib/chai/utils/addMethod.js
+++ b/lib/chai/utils/addMethod.js
@@ -4,6 +4,7 @@
  * MIT Licensed
  */
 
+var addLengthGuard = require('./addLengthGuard');
 var chai = require('../../chai');
 var flag = require('./flag');
 var proxify = require('./proxify');
@@ -51,5 +52,6 @@ module.exports = function (ctx, name, method) {
     return newAssertion;
   };
 
+  addLengthGuard(fn, name, false);
   ctx[name] = proxify(fn, name);
 };

--- a/lib/chai/utils/index.js
+++ b/lib/chai/utils/index.js
@@ -154,6 +154,12 @@ exports.checkError = require('check-error');
 exports.proxify = require('./proxify');
 
 /*!
+ * Proxify util
+ */
+
+exports.addLengthGuard = require('./addLengthGuard');
+
+/*!
  * isNaN method
  */
 

--- a/lib/chai/utils/overwriteChainableMethod.js
+++ b/lib/chai/utils/overwriteChainableMethod.js
@@ -15,7 +15,7 @@ var transferFlags = require('./transferFlags');
  * property.  Must return functions to be used for
  * name.
  *
- *     utils.overwriteChainableMethod(chai.Assertion.prototype, 'length',
+ *     utils.overwriteChainableMethod(chai.Assertion.prototype, 'lengthOf',
  *       function (_super) {
  *       }
  *     , function (_super) {
@@ -28,8 +28,8 @@ var transferFlags = require('./transferFlags');
  *
  * Then can be used as any other assertion.
  *
- *     expect(myFoo).to.have.length(3);
- *     expect(myFoo).to.have.length.above(3);
+ *     expect(myFoo).to.have.lengthOf(3);
+ *     expect(myFoo).to.have.lengthOf.above(3);
  *
  * @param {Object} ctx object whose method / property is to be overwritten
  * @param {String} name of method / property to overwrite

--- a/lib/chai/utils/overwriteMethod.js
+++ b/lib/chai/utils/overwriteMethod.js
@@ -4,6 +4,7 @@
  * MIT Licensed
  */
 
+var addLengthGuard = require('./addLengthGuard');
 var chai = require('../../chai');
 var flag = require('./flag');
 var proxify = require('./proxify');
@@ -71,5 +72,6 @@ module.exports = function (ctx, name, method) {
     return newAssertion;
   }
 
+  addLengthGuard(fn, name, false);
   ctx[name] = proxify(fn, name);
 };

--- a/test/expect.js
+++ b/test/expect.js
@@ -298,7 +298,9 @@ describe('expect', function () {
     expect(5).to.be.within(3,5);
     expect(5).to.not.be.within(1,3);
     expect('foo').to.have.length.within(2,4);
+    expect('foo').to.have.lengthOf.within(2,4);
     expect([ 1, 2, 3 ]).to.have.length.within(2,4);
+    expect([ 1, 2, 3 ]).to.have.lengthOf.within(2,4);
 
     err(function(){
       expect(5).to.not.be.within(4,6, 'blah');
@@ -313,7 +315,15 @@ describe('expect', function () {
     }, "blah: expected \'foo\' to have a length within 5..7");
 
     err(function () {
+      expect('foo').to.have.lengthOf.within(5,7, 'blah');
+    }, "blah: expected \'foo\' to have a length within 5..7");
+
+    err(function () {
       expect([ 1, 2, 3 ]).to.have.length.within(5,7, 'blah');
+    }, "blah: expected [ 1, 2, 3 ] to have a length within 5..7");
+
+    err(function () {
+      expect([ 1, 2, 3 ]).to.have.lengthOf.within(5,7, 'blah');
     }, "blah: expected [ 1, 2, 3 ] to have a length within 5..7");
 
     err(function () {
@@ -343,6 +353,10 @@ describe('expect', function () {
     err(function () {
       expect(1).to.have.length.within(5,7, 'blah');
     }, "blah: expected 1 to have property 'length'");
+
+    err(function () {
+      expect(1).to.have.lengthOf.within(5,7, 'blah');
+    }, "blah: expected 1 to have property 'length'");
   });
 
   it('above(n)', function(){
@@ -351,7 +365,9 @@ describe('expect', function () {
     expect(5).to.not.be.above(5);
     expect(5).to.not.be.above(6);
     expect('foo').to.have.length.above(2);
+    expect('foo').to.have.lengthOf.above(2);
     expect([ 1, 2, 3 ]).to.have.length.above(2);
+    expect([ 1, 2, 3 ]).to.have.lengthOf.above(2);
 
     err(function(){
       expect(5).to.be.above(6, 'blah');
@@ -366,7 +382,15 @@ describe('expect', function () {
     }, "blah: expected \'foo\' to have a length above 4 but got 3");
 
     err(function () {
+      expect('foo').to.have.lengthOf.above(4, 'blah');
+    }, "blah: expected \'foo\' to have a length above 4 but got 3");
+
+    err(function () {
       expect([ 1, 2, 3 ]).to.have.length.above(4, 'blah');
+    }, "blah: expected [ 1, 2, 3 ] to have a length above 4 but got 3");
+
+    err(function () {
+      expect([ 1, 2, 3 ]).to.have.lengthOf.above(4, 'blah');
     }, "blah: expected [ 1, 2, 3 ] to have a length above 4 but got 3");
 
     err(function () {
@@ -388,6 +412,10 @@ describe('expect', function () {
     err(function () {
       expect(1).to.have.length.above(0, 'blah');
     }, "blah: expected 1 to have property 'length'");
+
+    err(function () {
+      expect(1).to.have.lengthOf.above(0, 'blah');
+    }, "blah: expected 1 to have property 'length'");
   });
 
   it('least(n)', function(){
@@ -395,7 +423,9 @@ describe('expect', function () {
     expect(5).to.be.at.least(5);
     expect(5).to.not.be.at.least(6);
     expect('foo').to.have.length.of.at.least(2);
+    expect('foo').to.have.lengthOf.at.least(2);
     expect([ 1, 2, 3 ]).to.have.length.of.at.least(2);
+    expect([ 1, 2, 3 ]).to.have.lengthOf.at.least(2);
 
     err(function(){
       expect(5).to.be.at.least(6, 'blah');
@@ -410,11 +440,23 @@ describe('expect', function () {
     }, "blah: expected \'foo\' to have a length at least 4 but got 3");
 
     err(function () {
+      expect('foo').to.have.lengthOf.at.least(4, 'blah');
+    }, "blah: expected \'foo\' to have a length at least 4 but got 3");
+
+    err(function () {
       expect([ 1, 2, 3 ]).to.have.length.of.at.least(4, 'blah');
     }, "blah: expected [ 1, 2, 3 ] to have a length at least 4 but got 3");
 
     err(function () {
+      expect([ 1, 2, 3 ]).to.have.lengthOf.at.least(4, 'blah');
+    }, "blah: expected [ 1, 2, 3 ] to have a length at least 4 but got 3");
+
+    err(function () {
       expect([ 1, 2, 3, 4 ]).to.not.have.length.of.at.least(4, 'blah');
+    }, "blah: expected [ 1, 2, 3, 4 ] to have a length below 4");
+
+    err(function () {
+      expect([ 1, 2, 3, 4 ]).to.not.have.lengthOf.at.least(4, 'blah');
     }, "blah: expected [ 1, 2, 3, 4 ] to have a length below 4");
 
     err(function () {
@@ -436,6 +478,10 @@ describe('expect', function () {
     err(function () {
       expect(1).to.have.length.at.least(0, 'blah');
     }, "blah: expected 1 to have property 'length'");
+
+    err(function () {
+      expect(1).to.have.lengthOf.at.least(0, 'blah');
+    }, "blah: expected 1 to have property 'length'");
   });
 
   it('below(n)', function(){
@@ -444,7 +490,9 @@ describe('expect', function () {
     expect(2).to.not.be.below(2);
     expect(2).to.not.be.below(1);
     expect('foo').to.have.length.below(4);
+    expect('foo').to.have.lengthOf.below(4);
     expect([ 1, 2, 3 ]).to.have.length.below(4);
+    expect([ 1, 2, 3 ]).to.have.lengthOf.below(4);
 
     err(function(){
       expect(6).to.be.below(5, 'blah');
@@ -459,7 +507,15 @@ describe('expect', function () {
     }, "blah: expected \'foo\' to have a length below 2 but got 3");
 
     err(function () {
+      expect('foo').to.have.lengthOf.below(2, 'blah');
+    }, "blah: expected \'foo\' to have a length below 2 but got 3");
+
+    err(function () {
       expect([ 1, 2, 3 ]).to.have.length.below(2, 'blah');
+    }, "blah: expected [ 1, 2, 3 ] to have a length below 2 but got 3");
+
+    err(function () {
+      expect([ 1, 2, 3 ]).to.have.lengthOf.below(2, 'blah');
     }, "blah: expected [ 1, 2, 3 ] to have a length below 2 but got 3");
 
     err(function () {
@@ -481,6 +537,10 @@ describe('expect', function () {
     err(function () {
       expect(1).to.have.length.below(0, 'blah');
     }, "blah: expected 1 to have property 'length'");
+
+    err(function () {
+      expect(1).to.have.lengthOf.below(0, 'blah');
+    }, "blah: expected 1 to have property 'length'");
   });
 
   it('most(n)', function(){
@@ -489,7 +549,9 @@ describe('expect', function () {
     expect(2).to.not.be.at.most(1);
     expect(2).to.not.be.at.most(1);
     expect('foo').to.have.length.of.at.most(4);
+    expect('foo').to.have.lengthOf.at.most(4);
     expect([ 1, 2, 3 ]).to.have.length.of.at.most(4);
+    expect([ 1, 2, 3 ]).to.have.lengthOf.at.most(4);
 
     err(function(){
       expect(6).to.be.at.most(5, 'blah');
@@ -504,11 +566,23 @@ describe('expect', function () {
     }, "blah: expected \'foo\' to have a length at most 2 but got 3");
 
     err(function () {
+      expect('foo').to.have.lengthOf.at.most(2, 'blah');
+    }, "blah: expected \'foo\' to have a length at most 2 but got 3");
+
+    err(function () {
       expect([ 1, 2, 3 ]).to.have.length.of.at.most(2, 'blah');
     }, "blah: expected [ 1, 2, 3 ] to have a length at most 2 but got 3");
 
     err(function () {
+      expect([ 1, 2, 3 ]).to.have.lengthOf.at.most(2, 'blah');
+    }, "blah: expected [ 1, 2, 3 ] to have a length at most 2 but got 3");
+
+    err(function () {
       expect([ 1, 2 ]).to.not.have.length.of.at.most(2, 'blah');
+    }, "blah: expected [ 1, 2 ] to have a length above 2");
+
+    err(function () {
+      expect([ 1, 2 ]).to.not.have.lengthOf.at.most(2, 'blah');
     }, "blah: expected [ 1, 2 ] to have a length above 2");
 
     err(function () {
@@ -530,6 +604,10 @@ describe('expect', function () {
     err(function () {
       expect(1).to.have.length.of.at.most(0, 'blah');
     }, "blah: expected 1 to have property 'length'");
+
+    err(function () {
+      expect(1).to.have.lengthOf.at.most(0, 'blah');
+    }, "blah: expected 1 to have property 'length'");
   });
 
   it('match(regexp)', function(){
@@ -550,17 +628,28 @@ describe('expect', function () {
     }, "blah: expected 'foobar' not to match /^foo/i");
   });
 
-  it('length(n)', function(){
+  it('lengthOf(n)', function(){
     expect('test').to.have.length(4);
+    expect('test').to.have.lengthOf(4);
     expect('test').to.not.have.length(3);
+    expect('test').to.not.have.lengthOf(3);
     expect([1,2,3]).to.have.length(3);
+    expect([1,2,3]).to.have.lengthOf(3);
 
     err(function(){
       expect(4).to.have.length(3, 'blah');
     }, 'blah: expected 4 to have property \'length\'');
 
     err(function(){
+      expect(4).to.have.lengthOf(3, 'blah');
+    }, 'blah: expected 4 to have property \'length\'');
+
+    err(function(){
       expect('asd').to.not.have.length(3, 'blah');
+    }, "blah: expected 'asd' to not have a length of 3");
+
+    err(function(){
+      expect('asd').to.not.have.lengthOf(3, 'blah');
     }, "blah: expected 'asd' to not have a length of 3");
   });
 

--- a/test/should.js
+++ b/test/should.js
@@ -7,9 +7,7 @@ describe('should', function() {
     should.not.equal('foo', 'bar');
   });
 
-  describe('invalid property', function () {
-    if (typeof Proxy === 'undefined' || typeof Reflect === 'undefined') return;
-
+  describe('safeguards', function () {
     before(function () {
       chai.util.addProperty(chai.Assertion.prototype, 'tmpProperty', function () {
         new chai.Assertion(42).equal(42);
@@ -51,82 +49,163 @@ describe('should', function() {
       delete chai.Assertion.prototype.tmpChainableMethod;
     });
 
-    it('throws when invalid property follows should', function () {
-      err(function () {
-        (42).should.pizza;
-      }, 'Invalid Chai property: pizza');
+    describe('proxify', function () {
+      if (typeof Proxy === 'undefined' || typeof Reflect === 'undefined') return;
+  
+      it('throws when invalid property follows should', function () {
+        err(function () {
+          (42).should.pizza;
+        }, 'Invalid Chai property: pizza');
+      });
+  
+      it('throws when invalid property follows language chain', function () {
+        err(function () {
+          (42).should.to.pizza;
+        }, 'Invalid Chai property: pizza');
+      });
+  
+      it('throws when invalid property follows property assertion', function () {
+        err(function () {
+          (42).should.ok.pizza;
+        }, 'Invalid Chai property: pizza');
+      });
+  
+      it('throws when invalid property follows overwritten property assertion', function () {
+        err(function () {
+          (42).should.tmpProperty.pizza;
+        }, 'Invalid Chai property: pizza');
+      });
+  
+      it('throws when invalid property follows uncalled method assertion', function () {
+        err(function () {
+          (42).should.equal.pizza;
+        }, 'Invalid Chai property: equal.pizza. See docs for proper usage of "equal".');
+      });
+  
+      it('throws when invalid property follows called method assertion', function () {
+        err(function () {
+          (42).should.equal(42).pizza;
+        }, 'Invalid Chai property: pizza');
+      });
+  
+      it('throws when invalid property follows uncalled overwritten method assertion', function () {
+        err(function () {
+          (42).should.tmpMethod.pizza;
+        }, 'Invalid Chai property: tmpMethod.pizza. See docs for proper usage of "tmpMethod".');
+      });
+  
+      it('throws when invalid property follows called overwritten method assertion', function () {
+        err(function () {
+          (42).should.tmpMethod().pizza;
+        }, 'Invalid Chai property: pizza');
+      });
+  
+      it('throws when invalid property follows uncalled chainable method assertion', function () {
+        err(function () {
+          (42).should.a.pizza;
+        }, 'Invalid Chai property: pizza');
+      });
+  
+      it('throws when invalid property follows called chainable method assertion', function () {
+        err(function () {
+          (42).should.a('number').pizza;
+        }, 'Invalid Chai property: pizza');
+      });
+  
+      it('throws when invalid property follows uncalled overwritten chainable method assertion', function () {
+        err(function () {
+          (42).should.tmpChainableMethod.pizza;
+        }, 'Invalid Chai property: pizza');
+      });
+  
+      it('throws when invalid property follows called overwritten chainable method assertion', function () {
+        err(function () {
+          (42).should.tmpChainableMethod().pizza;
+        }, 'Invalid Chai property: pizza');
+      });
+  
+      it('doesn\'t throw if invalid property is excluded via config', function () {
+        (function () {
+          (42).should.then;
+        }).should.not.throw();
+      });
     });
 
-    it('throws when invalid property follows language chain', function () {
-      err(function () {
-        (42).should.to.pizza;
-      }, 'Invalid Chai property: pizza');
-    });
+    describe('length guard', function () {
+      var fnLengthDesc = Object.getOwnPropertyDescriptor(function () {}, 'length');
+      if (!fnLengthDesc.configurable) return;
 
-    it('throws when invalid property follows property assertion', function () {
-      err(function () {
-        (42).should.ok.pizza;
-      }, 'Invalid Chai property: pizza');
-    });
+      it('doesn\'t throw when `.length` follows `.should`', function () {
+        (function () {
+          ('foo').should.length;
+        }).should.not.throw();
+      });
 
-    it('throws when invalid property follows overwritten property assertion', function () {
-      err(function () {
-        (42).should.tmpProperty.pizza;
-      }, 'Invalid Chai property: pizza');
-    });
+      it('doesn\'t throw when `.length` follows language chain', function () {
+        (function () {
+          ('foo').should.to.length;
+        }).should.not.throw();
+      });
 
-    it('throws when invalid property follows uncalled method assertion', function () {
-      err(function () {
-        (42).should.equal.pizza;
-      }, 'Invalid Chai property: equal.pizza. See docs for proper usage of "equal".');
-    });
+      it('doesn\'t throw when `.length` follows property assertion', function () {
+        (function () {
+          ('foo').should.ok.length;
+        }).should.not.throw();
+      });
 
-    it('throws when invalid property follows called method assertion', function () {
-      err(function () {
-        (42).should.equal(42).pizza;
-      }, 'Invalid Chai property: pizza');
-    });
+      it('doesn\'t throw when `.length` follows overwritten property assertion', function () {
+        (function () {
+          ('foo').should.tmpProperty.length;
+        }).should.not.throw();
+      });
 
-    it('throws when invalid property follows uncalled overwritten method assertion', function () {
-      err(function () {
-        (42).should.tmpMethod.pizza;
-      }, 'Invalid Chai property: tmpMethod.pizza. See docs for proper usage of "tmpMethod".');
-    });
+      it('throws when `.length` follows uncalled method assertion', function () {
+        err(function () {
+          ('foo').should.equal.length;
+        }, 'Invalid Chai property: equal.length. See docs for proper usage of "equal".');
+      });
 
-    it('throws when invalid property follows called overwritten method assertion', function () {
-      err(function () {
-        (42).should.tmpMethod().pizza;
-      }, 'Invalid Chai property: pizza');
-    });
+      it('doesn\'t throw when `.length` follows called method assertion', function () {
+        (function () {
+          ('foo').should.equal('foo').length;
+        }).should.not.throw();
+      });
 
-    it('throws when invalid property follows uncalled chainable method assertion', function () {
-      err(function () {
-        (42).should.a.pizza;
-      }, 'Invalid Chai property: pizza');
-    });
+      it('throws when `.length` follows uncalled overwritten method assertion', function () {
+        err(function () {
+          ('foo').should.tmpMethod.length;
+        }, 'Invalid Chai property: tmpMethod.length. See docs for proper usage of "tmpMethod".');
+      });
 
-    it('throws when invalid property follows called chainable method assertion', function () {
-      err(function () {
-        (42).should.a('number').pizza;
-      }, 'Invalid Chai property: pizza');
-    });
+      it('doesn\'t throw when `.length` follows called overwritten method assertion', function () {
+        (function () {
+          ('foo').should.tmpMethod().length;
+        }).should.not.throw();
+      });
 
-    it('throws when invalid property follows uncalled overwritten chainable method assertion', function () {
-      err(function () {
-        (42).should.tmpChainableMethod.pizza;
-      }, 'Invalid Chai property: pizza');
-    });
+      it('throws when `.length` follows uncalled chainable method assertion', function () {
+        err(function () {
+          ('foo').should.a.length;
+        }, 'Invalid Chai property: a.length. Due to a compatibility issue, "length" cannot directly follow "a". Use "a.lengthOf" instead.');
+      });
 
-    it('throws when invalid property follows called overwritten chainable method assertion', function () {
-      err(function () {
-        (42).should.tmpChainableMethod().pizza;
-      }, 'Invalid Chai property: pizza');
-    });
+      it('doesn\'t throw when `.length` follows called chainable method assertion', function () {
+        (function () {
+          ('foo').should.a('string').length;
+        }).should.not.throw();
+      });
 
-    it('doesn\'t throw if invalid property is excluded via config', function () {
-      (function () {
-        (42).should.then;
-      }).should.not.throw();
+      it('throws when `.length` follows uncalled overwritten chainable method assertion', function () {
+        err(function () {
+          ('foo').should.tmpChainableMethod.length;
+        }, 'Invalid Chai property: tmpChainableMethod.length. Due to a compatibility issue, "length" cannot directly follow "tmpChainableMethod". Use "tmpChainableMethod.lengthOf" instead.');
+      });
+
+      it('doesn\'t throw when `.length` follows called overwritten chainable method assertion', function () {
+        (function () {
+          ('foo').should.tmpChainableMethod().length;
+        }).should.not.throw();
+      });
     });
   });
 

--- a/test/should.js
+++ b/test/should.js
@@ -360,6 +360,10 @@ describe('should', function() {
       ({ foo: 1 }).should.have.length.within(50,100, 'blah');
     }, "blah: expected { foo: 1 } to have property 'length'");
 
+    err(function(){
+      ({ foo: 1 }).should.have.lengthOf.within(50,100, 'blah');
+    }, "blah: expected { foo: 1 } to have property 'length'");
+
     err(function () {
       ('string').should.be.within(0, 1, 'blah');
     }, "blah: expected 'string' to be a number");
@@ -387,6 +391,10 @@ describe('should', function() {
     err(function () {
       (1).should.have.length.within(5,7, 'blah');
     }, "blah: expected 1 to have property 'length'");
+
+    err(function () {
+      (1).should.have.lengthOf.within(5,7, 'blah');
+    }, "blah: expected 1 to have property 'length'");
   });
 
   it('above(n)', function(){
@@ -405,6 +413,10 @@ describe('should', function() {
 
     err(function(){
       ({foo: 1}).should.have.length.above(3, 'blah');
+    }, "blah: expected { foo: 1 } to have property 'length'");
+
+    err(function(){
+      ({foo: 1}).should.have.lengthOf.above(3, 'blah');
     }, "blah: expected { foo: 1 } to have property 'length'");
 
     err(function () {
@@ -426,6 +438,10 @@ describe('should', function() {
     err(function () {
       (1).should.have.length.above(0, 'blah');
     }, "blah: expected 1 to have property 'length'");
+
+    err(function () {
+      (1).should.have.lengthOf.above(0, 'blah');
+    }, "blah: expected 1 to have property 'length'");
   });
 
   it('least(n)', function(){
@@ -442,6 +458,10 @@ describe('should', function() {
 
     err(function(){
       ({foo: 1}).should.have.length.of.at.least(3, 'blah');
+    }, "blah: expected { foo: 1 } to have property 'length'");
+
+    err(function(){
+      ({foo: 1}).should.have.lengthOf.at.least(3, 'blah');
     }, "blah: expected { foo: 1 } to have property 'length'");
 
     err(function () {
@@ -479,6 +499,10 @@ describe('should', function() {
       ({foo: 1}).should.have.length.below(3, 'blah');
     }, "blah: expected { foo: 1 } to have property 'length'");
 
+    err(function(){
+      ({foo: 1}).should.have.lengthOf.below(3, 'blah');
+    }, "blah: expected { foo: 1 } to have property 'length'");
+
     err(function () {
       ('string').should.be.below(0, 'blah');
     }, "blah: expected 'string' to be a number");
@@ -498,6 +522,10 @@ describe('should', function() {
     err(function () {
       (1).should.have.length.below(0, 'blah');
     }, "blah: expected 1 to have property 'length'");
+
+    err(function () {
+      (1).should.have.lengthOf.below(0, 'blah');
+    }, "blah: expected 1 to have property 'length'");
   });
 
   it('most(n)', function(){
@@ -514,6 +542,10 @@ describe('should', function() {
 
     err(function(){
       ({foo: 1}).should.have.length.of.at.most(3, 'blah');
+    }, "blah: expected { foo: 1 } to have property 'length'");
+
+    err(function(){
+      ({foo: 1}).should.have.lengthOf.at.most(3, 'blah');
     }, "blah: expected { foo: 1 } to have property 'length'");
 
     err(function () {
@@ -535,6 +567,10 @@ describe('should', function() {
     err(function () {
       (1).should.have.length.of.at.most(0, 'blah');
     }, "blah: expected 1 to have property 'length'");
+
+    err(function () {
+      (1).should.have.lengthOf.at.most(0, 'blah');
+    }, "blah: expected 1 to have property 'length'");
   });
 
   it('match(regexp)', function(){
@@ -550,17 +586,28 @@ describe('should', function() {
     }, "blah: expected 'foobar' not to match /^foo/i");
   });
 
-  it('length(n)', function(){
+  it('lengthOf(n)', function(){
     'test'.should.have.length(4);
+    'test'.should.have.lengthOf(4);
     'test'.should.not.have.length(3);
+    'test'.should.not.have.lengthOf(3);
     [1,2,3].should.have.length(3);
+    [1,2,3].should.have.lengthOf(3);
 
     err(function(){
       (4).should.have.length(3, 'blah');
     }, 'blah: expected 4 to have property \'length\'');
 
     err(function(){
+      (4).should.have.lengthOf(3, 'blah');
+    }, 'blah: expected 4 to have property \'length\'');
+
+    err(function(){
       'asd'.should.not.have.length(3, 'blah');
+    }, "blah: expected 'asd' to not have a length of 3");
+
+    err(function(){
+      'asd'.should.not.have.lengthOf(3, 'blah');
     }, "blah: expected 'asd' to not have a length of 3");
   });
 

--- a/test/utilities.js
+++ b/test/utilities.js
@@ -1089,4 +1089,33 @@ describe('utilities', function () {
       }).to.not.throw();
     });
   });
+
+  describe('addLengthGuard', function () {
+    var fnLengthDesc = Object.getOwnPropertyDescriptor(function () {}, 'length');
+    if (!fnLengthDesc.configurable) return;
+
+    var addLengthGuard;
+
+    beforeEach(function () {
+      chai.use(function (_chai, _) {
+        addLengthGuard = _.addLengthGuard;
+      });
+    });
+
+    it('throws invalid use error if `.length` is read when `methodName` is defined and `isChainable` is false', function () {
+      var hoagie = addLengthGuard({}, 'hoagie', false);
+  
+      expect(function () {
+        hoagie.length;
+      }).to.throw('Invalid Chai property: hoagie.length. See docs for proper usage of "hoagie".');
+    });
+ 
+    it('throws incompatible `.length` error if `.length` is read when `methodName` is defined and `isChainable` is true', function () {
+      var hoagie = addLengthGuard({}, 'hoagie', true);
+  
+      expect(function () {
+        hoagie.length;
+      }).to.throw('Invalid Chai property: hoagie.length. Due to a compatibility issue, "length" cannot directly follow "hoagie". Use "hoagie.lengthOf" instead.');
+    });
+  });
 });


### PR DESCRIPTION
This PR is broken into two commits. The first commit makes `length` and `lengthOf` true aliases, with documentation updated to remove the deprecation notice and favor `lengthOf` over `length`. The second commit adds a guard against chaining `length` directly off of an uninvoked method assertion.

- Closes #684
- Closes #841