### PR TITLE
Refactor `utils.addChainableMethod` helper

### DIFF
--- a/lib/chai/utils/addChainableMethod.js
+++ b/lib/chai/utils/addChainableMethod.js
@@ -18,13 +18,13 @@ var transferFlags = require('./transferFlags');
  * Module variables
  */
 
-// Check whether `__proto__` is supported
-var hasProtoSupport = '__proto__' in Object;
 
 // Without `__proto__` support, this module will need to add properties to a function.
 // However, some Function.prototype methods cannot be overwritten,
 // and there seems no easy cross-platform way to detect them (@see chaijs/chai/issues/69).
 var excludeNames = /^(?:length|name|arguments|caller)$/;
+// Check whether `Object.setPrototypeOf` is supported
+var canSetPrototype = typeof Object.setPrototypeOf === 'function';
 
 // Cache `Function` properties
 var call  = Function.prototype.call,
@@ -101,13 +101,14 @@ module.exports = function addChainableMethod(ctx, name, method, chainingBehavior
 
         addLengthGuard(chainableMethodWrapper, name, true);
 
-        // Use `__proto__` if available
-        if (hasProtoSupport) {
+        // Use `Object.setPrototypeOf` if available
+        if (canSetPrototype) {
           // Inherit all properties from the object by replacing the `Function` prototype
-          var prototype = chainableMethodWrapper.__proto__ = Object.create(this);
+          var prototype = Object.create(this);
           // Restore the `call` and `apply` methods from `Function`
           prototype.call = call;
           prototype.apply = apply;
+          Object.setPrototypeOf(chainableMethodWrapper, prototype);
         }
         // Otherwise, redefine all properties (slow!)
         else {

--- a/lib/chai/utils/addChainableMethod.js
+++ b/lib/chai/utils/addChainableMethod.js
@@ -18,11 +18,6 @@ var transferFlags = require('./transferFlags');
  * Module variables
  */
 
-
-// Without `__proto__` support, this module will need to add properties to a function.
-// However, some Function.prototype methods cannot be overwritten,
-// and there seems no easy cross-platform way to detect them (@see chaijs/chai/issues/69).
-var excludeNames = /^(?:length|name|arguments|caller)$/;
 // Check whether `Object.setPrototypeOf` is supported
 var canSetPrototype = typeof Object.setPrototypeOf === 'function';
 
@@ -89,7 +84,6 @@ module.exports = function addChainableMethod(ctx, name, method, chainingBehavior
           flag(this, 'ssfi', chainableMethodWrapper);
 
           var result = chainableBehavior.method.apply(this, arguments);
-
           if (result !== undefined) {
             return result;
           }
@@ -114,10 +108,11 @@ module.exports = function addChainableMethod(ctx, name, method, chainingBehavior
         else {
           var asserterNames = Object.getOwnPropertyNames(ctx);
           asserterNames.forEach(function (asserterName) {
-            if (!excludeNames.test(asserterName)) {
-              var pd = Object.getOwnPropertyDescriptor(ctx, asserterName);
-              Object.defineProperty(chainableMethodWrapper, asserterName, pd);
-            }
+            var fnDesc = Object.getOwnPropertyDescriptor(chainableMethodWrapper, asserterName);
+            if (fnDesc && !fnDesc.configurable) return;
+
+            var pd = Object.getOwnPropertyDescriptor(ctx, asserterName);
+            Object.defineProperty(chainableMethodWrapper, asserterName, pd);
           });
         }
 

--- a/lib/chai/utils/addChainableMethod.js
+++ b/lib/chai/utils/addChainableMethod.js
@@ -21,6 +21,13 @@ var transferFlags = require('./transferFlags');
 // Check whether `Object.setPrototypeOf` is supported
 var canSetPrototype = typeof Object.setPrototypeOf === 'function';
 
+// Without `Object.setPrototypeOf` support, this module will need to add properties to a function.
+// However, some of functions' own props are not configurable and should be skipped.
+var testFn = function() {};
+var excludeNames = Object.getOwnPropertyNames(testFn).filter(function(name) {
+  return !Object.getOwnPropertyDescriptor(testFn, name).configurable;
+});
+
 // Cache `Function` properties
 var call  = Function.prototype.call,
     apply = Function.prototype.apply;
@@ -108,8 +115,9 @@ module.exports = function addChainableMethod(ctx, name, method, chainingBehavior
         else {
           var asserterNames = Object.getOwnPropertyNames(ctx);
           asserterNames.forEach(function (asserterName) {
-            var fnDesc = Object.getOwnPropertyDescriptor(chainableMethodWrapper, asserterName);
-            if (fnDesc && !fnDesc.configurable) return;
+            if (excludeNames.indexOf(asserterName) !== -1) {
+              return;
+            }
 
             var pd = Object.getOwnPropertyDescriptor(ctx, asserterName);
             Object.defineProperty(chainableMethodWrapper, asserterName, pd);

--- a/test/utilities.js
+++ b/test/utilities.js
@@ -883,8 +883,7 @@ describe('utilities', function () {
       // Ensure that foo returns an Assertion (not a function)
       expect(expect('x').x()).to.be.an.instanceOf(assertionConstructor);
 
-      var hasProtoSupport = '__proto__' in Object;
-      if (hasProtoSupport) {
+      if (typeof Object.setPrototypeOf === 'function') {
         expect(expect('x').x).to.be.an.instanceOf(assertionConstructor);
       }
     });


### PR DESCRIPTION
### Use `Object.setPrototypeOf` instead of `__proto__`

* `Object.setPrototypeOf` is more strict than `__proto__`: it throws on failure instead of being silent.
* `__proto__` is in Annex B of the spec; using it is kinda discouraged.

> This annex describes various legacy features and other characteristics of web browser based ECMAScript implementations. All of the language features and behaviours specified in this annex have one or more undesirable characteristics and in the absence of legacy usage would be removed from this specification. 

* I would avoid relying on early implementations of `__proto__` (before it was defined on `Object.prototype`) .
* `Object.setPrototypeOf` reads better :smile:.
* Every browser we support, has either both `__proto__` and `Object.setPrototypeOf` or neither of them.

When we drop IE < 11, we would simplify `addChainableMethod` even more.

### Remove hardcoded non-configurable function keys

They used to cause troubles in ancient IEs, but work fine in IE.