### PR TITLE
chore: update supported Node versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,9 @@ language: node_js
 addons:
   sauce_connect: true
 node_js:
- - 0.12 # to be removed 2016-12-31
  - 4 # to be removed 2018-04-01
  - 6 # to be removed 2019-04-01
+ - 7 # to be removed 2017-06-30
  - lts/* # safety net; don't remove
  - node # safety net; don't remove
 

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "test": "make test"
   },
   "engines": {
-    "node": ">=0.12"
+    "node": ">=4"
   },
   "dependencies": {
     "assertion-error": "^1.0.1",


### PR DESCRIPTION
- Dropped support for Node v0.12
- Made Node v4 the minimum required version
- Added Node v7 to travis