### PR TITLE
Fix plugin utilities documentation

### DIFF
--- a/lib/chai/utils/addChainableMethod.js
+++ b/lib/chai/utils/addChainableMethod.js
@@ -33,7 +33,7 @@ var call  = Function.prototype.call,
     apply = Function.prototype.apply;
 
 /**
- * ### .addChainableMethod (ctx, name, method, chainingBehavior)
+ * ### .addChainableMethod(ctx, name, method, chainingBehavior)
  *
  * Adds a method to an object, such that the method can also be chained.
  *

--- a/lib/chai/utils/addChainableMethod.js
+++ b/lib/chai/utils/addChainableMethod.js
@@ -33,7 +33,7 @@ var call  = Function.prototype.call,
     apply = Function.prototype.apply;
 
 /**
- * ### addChainableMethod (ctx, name, method, chainingBehavior)
+ * ### .addChainableMethod (ctx, name, method, chainingBehavior)
  *
  * Adds a method to an object, such that the method can also be chained.
  *

--- a/lib/chai/utils/addLengthGuard.js
+++ b/lib/chai/utils/addLengthGuard.js
@@ -9,7 +9,7 @@ var fnLengthDesc = Object.getOwnPropertyDescriptor(function () {}, 'length');
  */
 
 /**
- * ### addLengthGuard(fn, assertionName, isChainable)
+ * ### .addLengthGuard(fn, assertionName, isChainable)
  *
  * Define `length` as a getter on the given uninvoked method assertion. The
  * getter acts as a guard against chaining `length` directly off of an uninvoked

--- a/lib/chai/utils/addLengthGuard.js
+++ b/lib/chai/utils/addLengthGuard.js
@@ -9,7 +9,7 @@ var fnLengthDesc = Object.getOwnPropertyDescriptor(function () {}, 'length');
  */
 
 /**
- * # addLengthGuard(fn, assertionName, isChainable)
+ * ### addLengthGuard(fn, assertionName, isChainable)
  *
  * Define `length` as a getter on the given uninvoked method assertion. The
  * getter acts as a guard against chaining `length` directly off of an uninvoked

--- a/lib/chai/utils/addMethod.js
+++ b/lib/chai/utils/addMethod.js
@@ -11,7 +11,7 @@ var proxify = require('./proxify');
 var transferFlags = require('./transferFlags');
 
 /**
- * ### .addMethod (ctx, name, method)
+ * ### .addMethod(ctx, name, method)
  *
  * Adds a method to the prototype of an object.
  *

--- a/lib/chai/utils/addProperty.js
+++ b/lib/chai/utils/addProperty.js
@@ -10,7 +10,7 @@ var isProxyEnabled = require('./isProxyEnabled');
 var transferFlags = require('./transferFlags');
 
 /**
- * ### addProperty (ctx, name, getter)
+ * ### .addProperty (ctx, name, getter)
  *
  * Adds a property to the prototype of an object.
  *

--- a/lib/chai/utils/addProperty.js
+++ b/lib/chai/utils/addProperty.js
@@ -10,7 +10,7 @@ var isProxyEnabled = require('./isProxyEnabled');
 var transferFlags = require('./transferFlags');
 
 /**
- * ### .addProperty (ctx, name, getter)
+ * ### .addProperty(ctx, name, getter)
  *
  * Adds a property to the prototype of an object.
  *

--- a/lib/chai/utils/compareByInspect.js
+++ b/lib/chai/utils/compareByInspect.js
@@ -11,7 +11,7 @@
 var inspect = require('./inspect');
 
 /**
- * ### .compareByInspect (mixed, mixed)
+ * ### .compareByInspect(mixed, mixed)
  *
  * To be used as a compareFunction with Array.prototype.sort. Compares elements
  * using inspect instead of default behavior of using toString so that Symbols

--- a/lib/chai/utils/expectTypes.js
+++ b/lib/chai/utils/expectTypes.js
@@ -5,7 +5,7 @@
  */
 
 /**
- * ### expectTypes(obj, types)
+ * ### .expectTypes(obj, types)
  *
  * Ensures that the object being tested against is of a valid type.
  *

--- a/lib/chai/utils/flag.js
+++ b/lib/chai/utils/flag.js
@@ -5,7 +5,7 @@
  */
 
 /**
- * ### flag(object, key, [value])
+ * ### .flag(object, key, [value])
  *
  * Get or set a flag value on an object. If a
  * value is provided it will be set, else it will

--- a/lib/chai/utils/getActual.js
+++ b/lib/chai/utils/getActual.js
@@ -5,7 +5,7 @@
  */
 
 /**
- * ### getActual(object, [actual])
+ * ### .getActual(object, [actual])
  *
  * Returns the `actual` value for an Assertion.
  *

--- a/lib/chai/utils/getActual.js
+++ b/lib/chai/utils/getActual.js
@@ -5,7 +5,7 @@
  */
 
 /**
- * # getActual(object, [actual])
+ * ### getActual(object, [actual])
  *
  * Returns the `actual` value for an Assertion.
  *

--- a/lib/chai/utils/inspect.js
+++ b/lib/chai/utils/inspect.js
@@ -9,12 +9,14 @@ var config = require('../config');
 module.exports = inspect;
 
 /**
+ * ### .inspect(obj, [showHidden], [depth], [colors])
+ *
  * Echoes the value of a value. Tries to print the value out
  * in the best way possible given the different types.
  *
  * @param {Object} obj The object to print out.
  * @param {Boolean} showHidden Flag that shows hidden (not enumerable)
- *    properties of objects.
+ *    properties of objects. Default is false.
  * @param {Number} depth Depth in which to descend in object. Default is 2.
  * @param {Boolean} colors Flag to turn on ANSI escape codes to color the
  *    output. Default is false (no coloring).

--- a/lib/chai/utils/isNaN.js
+++ b/lib/chai/utils/isNaN.js
@@ -5,7 +5,7 @@
  */
 
 /**
- * ### isNaN(value)
+ * ### .isNaN(value)
  *
  * Checks if the given value is NaN or not.
  *

--- a/lib/chai/utils/isProxyEnabled.js
+++ b/lib/chai/utils/isProxyEnabled.js
@@ -7,7 +7,7 @@ var config = require('../config');
  */
 
 /**
- * ### isProxyEnabled()
+ * ### .isProxyEnabled()
  *
  * Helper function to check if Chai's proxy protection feature is enabled. If
  * proxies are unsupported or disabled via the user's Chai config, then return

--- a/lib/chai/utils/isProxyEnabled.js
+++ b/lib/chai/utils/isProxyEnabled.js
@@ -7,7 +7,7 @@ var config = require('../config');
  */
 
 /**
- * # isProxyEnabled()
+ * ### isProxyEnabled()
  *
  * Helper function to check if Chai's proxy protection feature is enabled. If
  * proxies are unsupported or disabled via the user's Chai config, then return

--- a/lib/chai/utils/objDisplay.js
+++ b/lib/chai/utils/objDisplay.js
@@ -12,7 +12,7 @@ var inspect = require('./inspect');
 var config = require('../config');
 
 /**
- * ### .objDisplay (object)
+ * ### .objDisplay(object)
  *
  * Determines if an object or an array matches
  * criteria to be inspected in-line for error

--- a/lib/chai/utils/overwriteChainableMethod.js
+++ b/lib/chai/utils/overwriteChainableMethod.js
@@ -8,7 +8,7 @@ var chai = require('../../chai');
 var transferFlags = require('./transferFlags');
 
 /**
- * ### .overwriteChainableMethod (ctx, name, method, chainingBehavior)
+ * ### .overwriteChainableMethod(ctx, name, method, chainingBehavior)
  *
  * Overwites an already existing chainable method
  * and provides access to the previous function or

--- a/lib/chai/utils/overwriteChainableMethod.js
+++ b/lib/chai/utils/overwriteChainableMethod.js
@@ -8,7 +8,7 @@ var chai = require('../../chai');
 var transferFlags = require('./transferFlags');
 
 /**
- * ### overwriteChainableMethod (ctx, name, method, chainingBehavior)
+ * ### .overwriteChainableMethod (ctx, name, method, chainingBehavior)
  *
  * Overwites an already existing chainable method
  * and provides access to the previous function or

--- a/lib/chai/utils/overwriteMethod.js
+++ b/lib/chai/utils/overwriteMethod.js
@@ -11,7 +11,7 @@ var proxify = require('./proxify');
 var transferFlags = require('./transferFlags');
 
 /**
- * ### .overwriteMethod (ctx, name, fn)
+ * ### .overwriteMethod(ctx, name, fn)
  *
  * Overwites an already existing method and provides
  * access to previous function. Must return function

--- a/lib/chai/utils/overwriteMethod.js
+++ b/lib/chai/utils/overwriteMethod.js
@@ -11,7 +11,7 @@ var proxify = require('./proxify');
 var transferFlags = require('./transferFlags');
 
 /**
- * ### overwriteMethod (ctx, name, fn)
+ * ### .overwriteMethod (ctx, name, fn)
  *
  * Overwites an already existing method and provides
  * access to previous function. Must return function

--- a/lib/chai/utils/overwriteProperty.js
+++ b/lib/chai/utils/overwriteProperty.js
@@ -10,7 +10,7 @@ var isProxyEnabled = require('./isProxyEnabled');
 var transferFlags = require('./transferFlags');
 
 /**
- * ### .overwriteProperty (ctx, name, fn)
+ * ### .overwriteProperty(ctx, name, fn)
  *
  * Overwites an already existing property getter and provides
  * access to previous value. Must return function to use as getter.

--- a/lib/chai/utils/overwriteProperty.js
+++ b/lib/chai/utils/overwriteProperty.js
@@ -10,7 +10,7 @@ var isProxyEnabled = require('./isProxyEnabled');
 var transferFlags = require('./transferFlags');
 
 /**
- * ### overwriteProperty (ctx, name, fn)
+ * ### .overwriteProperty (ctx, name, fn)
  *
  * Overwites an already existing property getter and provides
  * access to previous value. Must return function to use as getter.

--- a/lib/chai/utils/proxify.js
+++ b/lib/chai/utils/proxify.js
@@ -10,7 +10,7 @@ var isProxyEnabled = require('./isProxyEnabled');
  */
 
 /**
- * ### proxify(object)
+ * ### .proxify(object)
  *
  * Return a proxy of given object that throws an error when a non-existent
  * property is read. By default, the root cause is assumed to be a misspelled

--- a/lib/chai/utils/proxify.js
+++ b/lib/chai/utils/proxify.js
@@ -10,7 +10,7 @@ var isProxyEnabled = require('./isProxyEnabled');
  */
 
 /**
- * # proxify(object)
+ * ### proxify(object)
  *
  * Return a proxy of given object that throws an error when a non-existent
  * property is read. By default, the root cause is assumed to be a misspelled

--- a/lib/chai/utils/test.js
+++ b/lib/chai/utils/test.js
@@ -11,7 +11,7 @@
 var flag = require('./flag');
 
 /**
- * ### test(object, expression)
+ * ### .test(object, expression)
  *
  * Test and object for expression.
  *

--- a/lib/chai/utils/test.js
+++ b/lib/chai/utils/test.js
@@ -11,7 +11,7 @@
 var flag = require('./flag');
 
 /**
- * # test(object, expression)
+ * ### test(object, expression)
  *
  * Test and object for expression.
  *

--- a/lib/chai/utils/transferFlags.js
+++ b/lib/chai/utils/transferFlags.js
@@ -5,7 +5,7 @@
  */
 
 /**
- * ### transferFlags(assertion, object, includeAll = true)
+ * ### .transferFlags(assertion, object, includeAll = true)
  *
  * Transfer all the flags for `assertion` to `object`. If
  * `includeAll` is set to `false`, then the base Chai


### PR DESCRIPTION
This PR fixes some issues with the plugin utilities documentation. http://chaijs.com/api/plugins/.

This is in reference to [this issue](https://github.com/chaijs/chai-docs/issues/148) on the [chai-docs repo](https://github.com/chaijs/chai-docs).

To summarize these commits:
- [This](https://github.com/chaijs/chai/commit/1a47ff1a5ffd9ca162370fe99a4973f616c048cc) adds a headline for the [.inspect()](http://chaijs.com/api/plugins/#method_inspect) method and adds "Default is false" for the showHidden param
- [This](https://github.com/chaijs/chai/commit/0334f178681957a63cd82901434d1b54ed50e825) updates some of the headlines to use h3's instead of h1's [.getActual()](http://chaijs.com/api/plugins/#method_getactual), and [.test()](http://chaijs.com/api/plugins/#method_test)
- [This](https://github.com/chaijs/chai/commit/251fa57c16b0645b8b4551453eb881a02f00fa6e) adds periods before each method [.addChainableMethod()](http://chaijs.com/api/plugins/#method_addchainablemethod), [.addProperty()](http://chaijs.com/api/plugins/#method_addproperty) [.expectTypes()](http://chaijs.com/api/plugins/#method_expecttypes), [.flag()](http://chaijs.com/api/plugins/#method_flag), [.getActual()](http://chaijs.com/api/plugins/#method_getactual), [.overwriteChainableMethod()](http://chaijs.com/api/plugins/#method_overwritechainablemethod), [.overwriteMethod()](http://chaijs.com/api/plugins/#method_overwritemethod), [.overwriteProperty()](http://chaijs.com/api/plugins/#method_overwriteproperty), [.test()](http://chaijs.com/api/plugins/#method_test), and [.transferFlags()](http://chaijs.com/api/plugins/#method_transferflags)
- [This](https://github.com/chaijs/chai/commit/38d3ccaf0cdfabc45cff31f1b4ede12d5c60d56e) removes the space between the method name and the opening parenthesis [.addChainableMethod()](http://chaijs.com/api/plugins/#method_addchainablemethod), [.addMethod()](http://chaijs.com/api/plugins/#method_addmethod), [.addProperty()](http://chaijs.com/api/plugins/#method_addproperty), [.objDisplay()](http://chaijs.com/api/plugins/#method_objdisplay), [.overwriteChainableMethod()](http://chaijs.com/api/plugins/#method_overwritechainablemethod), [.overwriteMethod()](http://chaijs.com/api/plugins/#method_overwritemethod), and [.overwriteProperty()](http://chaijs.com/api/plugins/#method_overwriteproperty)