### PR TITLE
fix: wrong assertion types

### DIFF
--- a/lib/chai/core/assertions.js
+++ b/lib/chai/core/assertions.js
@@ -2083,8 +2083,8 @@ module.exports = function (chai, _) {
     );
   }
 
-  Assertion.addChainableMethod('change', assertChanges);
-  Assertion.addChainableMethod('changes', assertChanges);
+  Assertion.addMethod('change', assertChanges);
+  Assertion.addMethod('changes', assertChanges);
 
   /**
    * ### .increase(target[, property[, message]])
@@ -2147,8 +2147,8 @@ module.exports = function (chai, _) {
     );
   }
 
-  Assertion.addChainableMethod('increase', assertIncreases);
-  Assertion.addChainableMethod('increases', assertIncreases);
+  Assertion.addMethod('increase', assertIncreases);
+  Assertion.addMethod('increases', assertIncreases);
 
   /**
    * ### .decrease(target[, property[, message]])
@@ -2211,8 +2211,8 @@ module.exports = function (chai, _) {
     );
   }
 
-  Assertion.addChainableMethod('decrease', assertDecreases);
-  Assertion.addChainableMethod('decreases', assertDecreases);
+  Assertion.addMethod('decrease', assertDecreases);
+  Assertion.addMethod('decreases', assertDecreases);
 
   /**
    * ### .by


### PR DESCRIPTION
BREAKING CHANGE: `.change`, `.increase`, and `.decrease` changed from
Chainable Method Assertions to Method Assertions. They don't have any
chaining behavior, and there's no generic semantic benefit to chaining
them.

Fixes #917 

Note: If this is merged, #920 needs to be updated in order to remove verbiage about chaining behavior.