### PR TITLE
Custom message not always respected 

### DIFF
--- a/lib/chai/core/assertions.js
+++ b/lib/chai/core/assertions.js
@@ -1864,7 +1864,7 @@ module.exports = function (chai, _) {
     if (msg) flag(this, 'message', msg);
     var obj = flag(this, 'object');
 
-    new Assertion(obj, msg).is.a('number');
+    this.is.a('number');
     if (typeof expected !== 'number' || typeof delta !== 'number') {
       throw new Error('the arguments to closeTo or approximately must be numbers');
     }

--- a/test/expect.js
+++ b/test/expect.js
@@ -2328,6 +2328,19 @@ describe('expect', function () {
     err(function() {
       expect(1.5).to.be.closeTo(1.0, true);
     }, "the arguments to closeTo or approximately must be numbers");
+    
+    err(function() {
+      expect('blah', 'custom message').to.be.closeTo(2, 1);
+    },"custom message: expected 'blah' to be a number")
+    
+    err(function() {
+      expect(10, 'custom message').to.be.closeTo(2, 1);
+    },"custom message: expected 10 to be close to 2 +/- 1")
+    
+    err(function() {
+      expect(10, 'custom message').to.be.closeTo(2, 1, 'another message');
+    },"another message: expected 10 to be close to 2 +/- 1")
+    
   });
 
   it('approximately', function(){


### PR DESCRIPTION
Inside "closeTo" function "this" already references an Assertion with "msg" parameter previously being set, so no need to call new Assertion 

Fixes [#923](https://github.com/chaijs/chai/issues/923) 