### PR TITLE
assert: add nestedInclude, deepNestedInclude, ownInclude and deepOwnInclude

### DIFF
--- a/lib/chai/interface/assert.js
+++ b/lib/chai/interface/assert.js
@@ -1013,6 +1013,51 @@ module.exports = function (chai, util) {
   };
 
   /**
+   * ### .nestedInclude
+   * 
+   * Asserts that 'targetObject' includes 'nestedObject'. 
+   * Enables the use of dot- and bracket-notation for referencing nested properties.
+   * '[]' and '.' in property names can be escaped using double backslashes.
+   * 
+   *     assert.nestedInclude({'.a': {'b': 'x'}}, {'\\.a.[b]': 'x'});
+   *     assert.nestedInclude({'a': {'[b]': 'x'}}, {'a.\\[b\\]': 'x'});
+   * 
+   * @name nestedInclude
+   * @param {Object} targetObject
+   * @param {Object} nestedObject
+   * @param {String} message
+   * @namespace Assert
+   * @api public 
+   */ 
+
+  assert.nestedInclude = function (exp, inc, msg) {
+    new Assertion(exp, msg, assert.nestedInclude, true).nested.include(inc);
+  };
+
+  /**
+   * ### .notNestedInclude
+   * 
+   * Asserts that 'targetObject' does not include 'nestedObject'. 
+   * Enables the use of dot- and bracket-notation for referencing nested properties.
+   * '[]' and '.' in property names can be escaped using double backslashes.
+   * 
+   *     assert.notNestedInclude({'.a': {'b': 'x'}}, {'\\.a.[b]': 'y'});
+   *     assert.notNestedInclude({'a': {'[b]': 'x'}}, {'a.\\[b\\]': 'y'});
+   * 
+   * 
+   * @name notNestedInclude
+   * @param {Object} targetObject
+   * @param {Object} nestedObject
+   * @param {String} message
+   * @namespace Assert
+   * @api public 
+   */ 
+
+  assert.notNestedInclude = function (exp, inc, msg) {
+    new Assertion(exp, msg, assert.notNestedInclude, true).not.nested.include(inc);
+  };
+
+  /**
    * ### .match(value, regexp, [message])
    *
    * Asserts that `value` matches the regular expression `regexp`.

--- a/lib/chai/interface/assert.js
+++ b/lib/chai/interface/assert.js
@@ -1013,7 +1013,7 @@ module.exports = function (chai, util) {
   };
 
   /**
-   * ### .nestedInclude
+   * ### .nestedInclude(targetObj, nestedObject, [msg])
    * 
    * Asserts that 'targetObject' includes 'nestedObject'. 
    * Enables the use of dot- and bracket-notation for referencing nested properties.
@@ -1035,7 +1035,7 @@ module.exports = function (chai, util) {
   };
 
   /**
-   * ### .notNestedInclude
+   * ### .notNestedInclude(targetObj, nestedObj, [msg])
    * 
    * Asserts that 'targetObject' does not include 'nestedObject'. 
    * Enables the use of dot- and bracket-notation for referencing nested properties.
@@ -1055,6 +1055,50 @@ module.exports = function (chai, util) {
 
   assert.notNestedInclude = function (exp, inc, msg) {
     new Assertion(exp, msg, assert.notNestedInclude, true).not.nested.include(inc);
+  };
+
+  /**
+   * ### .deepNestedInclude(targetObject, nestedObject, [msg])
+   * 
+   * Asserts that 'targetObj' includes 'nestedObject' while checking for deep equality.
+   * Enables the user of dot- and bracket-notation for referencing nested properties.
+   * '[]' and '.' in property names can be escaped using double backslashes.
+   * 
+   *    assert.deepNestedInclude({a: {b: [{x: 1}]}}, {'a.b[0]': {x: 1}})
+   *    assert.deepNestedInclude({'.a': {'[b]': {x: 1}}}, {'\\.a.\\[b\\]': {x: 1}});
+   *    
+   * @name deepNestedInclude
+   * @param {Object} targetObject
+   * @param {Object} nestedObject
+   * @param {String} message
+   * @namespace Assert
+   * @api public 
+   */
+
+  assert.deepNestedInclude = function(exp, inc, msg) {
+    new Assertion(exp, msg, assert.deepNestedInclude, true).deep.nested.include(inc);
+  };
+
+  /**
+   * ### .notDeepNestedInclude(targetObject, nestedObject, [msg])
+   * 
+   * Asserts that 'targetObj' does not include 'nestedObject' while checking for deep equality.
+   * Enables the user of dot- and bracket-notation for referencing nested properties.
+   * '[]' and '.' in property names can be escaped using double backslashes.
+   * 
+   *    assert.notDeepNestedInclude({a: {b: [{x: 1}]}}, {'a.b[0]': {y: 1}})
+   *    assert.notDeepNestedInclude({'.a': {'[b]': {x: 1}}}, {'\\.a.\\[b\\]': {y: 2}});
+   *    
+   * @name notDeepNestedInclude
+   * @param {Object} targetObject
+   * @param {Object} nestedObject
+   * @param {String} message
+   * @namespace Assert
+   * @api public 
+   */
+
+  assert.notDeepNestedInclude = function(exp, inc, msg) {
+    new Assertion(exp, msg, assert.notDeepNestedInclude, true).not.deep.nested.include(inc);
   };
 
   /**

--- a/lib/chai/interface/assert.js
+++ b/lib/chai/interface/assert.js
@@ -1013,10 +1013,11 @@ module.exports = function (chai, util) {
   };
 
   /**
-   * ### .nestedInclude(targetObj, nestedObject, [msg])
+   * ### .nestedInclude(targetObject, nestedObject, [message])
    * 
    * Asserts that 'targetObject' includes 'nestedObject'. 
-   * Enables the use of dot- and bracket-notation for referencing nested properties.
+   * Enables the use of dot- and bracket-notation for referencing nested 
+   * properties.
    * '[]' and '.' in property names can be escaped using double backslashes.
    * 
    *     assert.nestedInclude({'.a': {'b': 'x'}}, {'\\.a.[b]': 'x'});
@@ -1035,10 +1036,11 @@ module.exports = function (chai, util) {
   };
 
   /**
-   * ### .notNestedInclude(targetObj, nestedObj, [msg])
+   * ### .notNestedInclude(targetObject, nestedObject, [message])
    * 
    * Asserts that 'targetObject' does not include 'nestedObject'. 
-   * Enables the use of dot- and bracket-notation for referencing nested properties.
+   * Enables the use of dot- and bracket-notation for referencing nested 
+   * properties. 
    * '[]' and '.' in property names can be escaped using double backslashes.
    * 
    *     assert.notNestedInclude({'.a': {'b': 'x'}}, {'\\.a.[b]': 'y'});
@@ -1054,18 +1056,21 @@ module.exports = function (chai, util) {
    */ 
 
   assert.notNestedInclude = function (exp, inc, msg) {
-    new Assertion(exp, msg, assert.notNestedInclude, true).not.nested.include(inc);
+    new Assertion(exp, msg, assert.notNestedInclude, true)
+      .not.nested.include(inc);
   };
 
   /**
-   * ### .deepNestedInclude(targetObject, nestedObject, [msg])
+   * ### .deepNestedInclude(targetObject, nestedObject, [message])
    * 
-   * Asserts that 'targetObj' includes 'nestedObject' while checking for deep equality.
-   * Enables the user of dot- and bracket-notation for referencing nested properties.
+   * Asserts that 'targetObject' includes 'nestedObject' while checking for 
+   * deep equality.
+   * Enables the use of dot- and bracket-notation for referencing nested 
+   * properties.
    * '[]' and '.' in property names can be escaped using double backslashes.
    * 
-   *    assert.deepNestedInclude({a: {b: [{x: 1}]}}, {'a.b[0]': {x: 1}})
-   *    assert.deepNestedInclude({'.a': {'[b]': {x: 1}}}, {'\\.a.\\[b\\]': {x: 1}});
+   *     assert.deepNestedInclude({a: {b: [{x: 1}]}}, {'a.b[0]': {x: 1}})
+   *     assert.deepNestedInclude({'.a': {'[b]': {x: 1}}}, {'\\.a.\\[b\\]': {x: 1}});
    *    
    * @name deepNestedInclude
    * @param {Object} targetObject
@@ -1076,18 +1081,21 @@ module.exports = function (chai, util) {
    */
 
   assert.deepNestedInclude = function(exp, inc, msg) {
-    new Assertion(exp, msg, assert.deepNestedInclude, true).deep.nested.include(inc);
+    new Assertion(exp, msg, assert.deepNestedInclude, true)
+      .deep.nested.include(inc);
   };
 
   /**
-   * ### .notDeepNestedInclude(targetObject, nestedObject, [msg])
+   * ### .notDeepNestedInclude(targetObject, nestedObject, [message])
    * 
-   * Asserts that 'targetObj' does not include 'nestedObject' while checking for deep equality.
-   * Enables the user of dot- and bracket-notation for referencing nested properties.
+   * Asserts that 'targetObject' does not include 'nestedObject' while 
+   * checking for deep equality.
+   * Enables the use of dot- and bracket-notation for referencing nested 
+   * properties.
    * '[]' and '.' in property names can be escaped using double backslashes.
    * 
-   *    assert.notDeepNestedInclude({a: {b: [{x: 1}]}}, {'a.b[0]': {y: 1}})
-   *    assert.notDeepNestedInclude({'.a': {'[b]': {x: 1}}}, {'\\.a.\\[b\\]': {y: 2}});
+   *     assert.notDeepNestedInclude({a: {b: [{x: 1}]}}, {'a.b[0]': {y: 1}})
+   *     assert.notDeepNestedInclude({'.a': {'[b]': {x: 1}}}, {'\\.a.\\[b\\]': {y: 2}});
    *    
    * @name notDeepNestedInclude
    * @param {Object} targetObject
@@ -1098,7 +1106,50 @@ module.exports = function (chai, util) {
    */
 
   assert.notDeepNestedInclude = function(exp, inc, msg) {
-    new Assertion(exp, msg, assert.notDeepNestedInclude, true).not.deep.nested.include(inc);
+    new Assertion(exp, msg, assert.notDeepNestedInclude, true)
+      .not.deep.nested.include(inc);
+  };
+
+  /**
+   * ### .ownInclude(targetObject, objectToBeIncluded, [message])
+   * 
+   * Asserts that 'targetObject' includes 'objectToBeIncluded' while 
+   * ignoring inherited properties.
+   * 
+   *     assert.OwnInclude({ a: 1 }, { a: 1 });
+   * 
+   * @name ownInclude
+   * @param {Object} targetObject
+   * @param {Object} objectToBeIncluded
+   * @param {String} message
+   * @namespace Assert
+   * @api public
+   */
+
+  assert.ownInclude = function(exp, inc, msg) {
+    new Assertion(exp, msg, assert.ownInclude, true).own.include(inc);
+  };
+
+  /**
+   * ### .notOwnInclude(targetObject, objectToNotBeIncluded, [message])
+   * 
+   * Asserts that 'targetObject' does not include 'objectToNotBeIncluded' while 
+   * ignoring inherited properties.
+   * 
+   *     Object.prototype.b = 2;
+   * 
+   *     assert.notOwnInclude({ a: 1 }, { b: 2 });
+   * 
+   * @name notOwnInclude
+   * @param {Object} targetObject
+   * @param {Object} objectToNotBeIncluded
+   * @param {String} message
+   * @namespace Assert
+   * @api public
+   */
+
+  assert.notOwnInclude = function(exp, inc, msg) {
+    new Assertion(exp, msg, assert.notOwnInclude, true).not.own.include(inc);
   };
 
   /**

--- a/lib/chai/interface/assert.js
+++ b/lib/chai/interface/assert.js
@@ -1013,9 +1013,9 @@ module.exports = function (chai, util) {
   };
 
   /**
-   * ### .nestedInclude(targetObject, nestedObject, [message])
+   * ### .nestedInclude(object1, object2, [message])
    * 
-   * Asserts that 'targetObject' includes 'nestedObject'. 
+   * Asserts that 'object1' includes 'object2'. 
    * Enables the use of dot- and bracket-notation for referencing nested 
    * properties.
    * '[]' and '.' in property names can be escaped using double backslashes.
@@ -1024,8 +1024,8 @@ module.exports = function (chai, util) {
    *     assert.nestedInclude({'a': {'[b]': 'x'}}, {'a.\\[b\\]': 'x'});
    * 
    * @name nestedInclude
-   * @param {Object} targetObject
-   * @param {Object} nestedObject
+   * @param {Object} object1
+   * @param {Object} object2
    * @param {String} message
    * @namespace Assert
    * @api public 
@@ -1036,20 +1036,19 @@ module.exports = function (chai, util) {
   };
 
   /**
-   * ### .notNestedInclude(targetObject, nestedObject, [message])
+   * ### .notNestedInclude(object1, object2, [message])
    * 
-   * Asserts that 'targetObject' does not include 'nestedObject'. 
+   * Asserts that 'object1' does not include 'object2'. 
    * Enables the use of dot- and bracket-notation for referencing nested 
    * properties. 
    * '[]' and '.' in property names can be escaped using double backslashes.
    * 
-   *     assert.notNestedInclude({'.a': {'b': 'x'}}, {'\\.a.[b]': 'y'});
+   *     assert.notNestedInclude({'.a': {'b': 'x'}}, {'\\.a.b': 'y'});
    *     assert.notNestedInclude({'a': {'[b]': 'x'}}, {'a.\\[b\\]': 'y'});
    * 
-   * 
    * @name notNestedInclude
-   * @param {Object} targetObject
-   * @param {Object} nestedObject
+   * @param {Object} object1
+   * @param {Object} object2
    * @param {String} message
    * @namespace Assert
    * @api public 
@@ -1061,20 +1060,20 @@ module.exports = function (chai, util) {
   };
 
   /**
-   * ### .deepNestedInclude(targetObject, nestedObject, [message])
+   * ### .deepNestedInclude(object1, object2, [message])
    * 
-   * Asserts that 'targetObject' includes 'nestedObject' while checking for 
+   * Asserts that 'object1' includes 'object2' while checking for 
    * deep equality.
    * Enables the use of dot- and bracket-notation for referencing nested 
    * properties.
    * '[]' and '.' in property names can be escaped using double backslashes.
    * 
-   *     assert.deepNestedInclude({a: {b: [{x: 1}]}}, {'a.b[0]': {x: 1}})
+   *     assert.deepNestedInclude({a: {b: [{x: 1}]}}, {'a.b[0]': {x: 1}});
    *     assert.deepNestedInclude({'.a': {'[b]': {x: 1}}}, {'\\.a.\\[b\\]': {x: 1}});
    *    
    * @name deepNestedInclude
-   * @param {Object} targetObject
-   * @param {Object} nestedObject
+   * @param {Object} object1
+   * @param {Object} object2
    * @param {String} message
    * @namespace Assert
    * @api public 
@@ -1086,9 +1085,9 @@ module.exports = function (chai, util) {
   };
 
   /**
-   * ### .notDeepNestedInclude(targetObject, nestedObject, [message])
+   * ### .notDeepNestedInclude(object1, object2, [message])
    * 
-   * Asserts that 'targetObject' does not include 'nestedObject' while 
+   * Asserts that 'object1' does not include 'object2' while 
    * checking for deep equality.
    * Enables the use of dot- and bracket-notation for referencing nested 
    * properties.
@@ -1098,8 +1097,8 @@ module.exports = function (chai, util) {
    *     assert.notDeepNestedInclude({'.a': {'[b]': {x: 1}}}, {'\\.a.\\[b\\]': {y: 2}});
    *    
    * @name notDeepNestedInclude
-   * @param {Object} targetObject
-   * @param {Object} nestedObject
+   * @param {Object} object1
+   * @param {Object} object2
    * @param {String} message
    * @namespace Assert
    * @api public 
@@ -1111,16 +1110,16 @@ module.exports = function (chai, util) {
   };
 
   /**
-   * ### .ownInclude(targetObject, objectToBeIncluded, [message])
+   * ### .ownInclude(object1, object2, [message])
    * 
-   * Asserts that 'targetObject' includes 'objectToBeIncluded' while 
+   * Asserts that 'object1' includes 'object2' while 
    * ignoring inherited properties.
    * 
-   *     assert.OwnInclude({ a: 1 }, { a: 1 });
+   *     assert.ownInclude({ a: 1 }, { a: 1 });
    * 
    * @name ownInclude
-   * @param {Object} targetObject
-   * @param {Object} objectToBeIncluded
+   * @param {Object} object1
+   * @param {Object} object2
    * @param {String} message
    * @namespace Assert
    * @api public
@@ -1131,9 +1130,9 @@ module.exports = function (chai, util) {
   };
 
   /**
-   * ### .notOwnInclude(targetObject, objectToNotBeIncluded, [message])
+   * ### .notOwnInclude(object1, object2, [message])
    * 
-   * Asserts that 'targetObject' does not include 'objectToNotBeIncluded' while 
+   * Asserts that 'object1' does not include 'object2' while 
    * ignoring inherited properties.
    * 
    *     Object.prototype.b = 2;
@@ -1141,8 +1140,8 @@ module.exports = function (chai, util) {
    *     assert.notOwnInclude({ a: 1 }, { b: 2 });
    * 
    * @name notOwnInclude
-   * @param {Object} targetObject
-   * @param {Object} objectToNotBeIncluded
+   * @param {Object} object1
+   * @param {Object} object2
    * @param {String} message
    * @namespace Assert
    * @api public
@@ -1150,6 +1149,50 @@ module.exports = function (chai, util) {
 
   assert.notOwnInclude = function(exp, inc, msg) {
     new Assertion(exp, msg, assert.notOwnInclude, true).not.own.include(inc);
+  };
+
+  /**
+   * ### .deepOwnInclude(object1, object2, [message])
+   * 
+   * Asserts that 'object1' includes 'object2' while 
+   * ignoring inherited properties.
+   * Deep equality is used.
+   * 
+   *      assert.deepOwnInclude({a: {b: 2}}, {a: {b: 2}});
+   *      
+   * @name deepOwnInclude
+   * @param {Object} object1
+   * @param {Object} object2
+   * @param {String} message
+   * @namespace Assert
+   * @api public
+   */
+
+  assert.deepOwnInclude = function(exp, inc, msg) {
+    new Assertion(exp, msg, assert.deepOwnInclude, true)
+      .deep.own.include(inc);
+  };
+
+   /**
+   * ### .notDeepOwnInclude(object1, object2, [message])
+   * 
+   * Asserts that 'object1' does not include 'object2' while 
+   * ignoring inherited properties.
+   * Deep equality is used.
+   * 
+   *      assert.notDeepOwnInclude({a: {b: 2}}, {a: {c: 3}});
+   *      
+   * @name notDeepOwnInclude
+   * @param {Object} object1
+   * @param {Object} object2
+   * @param {String} message
+   * @namespace Assert
+   * @api public
+   */
+
+  assert.notDeepOwnInclude = function(exp, inc, msg) {
+    new Assertion(exp, msg, assert.notDeepOwnInclude, true)
+      .not.deep.own.include(inc);
   };
 
   /**

--- a/lib/chai/interface/assert.js
+++ b/lib/chai/interface/assert.js
@@ -1013,9 +1013,11 @@ module.exports = function (chai, util) {
   };
 
   /**
-   * ### .nestedInclude(object1, object2, [message])
+   * ### .nestedInclude(haystack, needle, [message])
    * 
-   * Asserts that 'object1' includes 'object2'. 
+   * Asserts that 'haystack' includes 'needle'. 
+   * Can be used to assert the inclusion of a subset of properties in an 
+   * object.
    * Enables the use of dot- and bracket-notation for referencing nested 
    * properties.
    * '[]' and '.' in property names can be escaped using double backslashes.
@@ -1024,8 +1026,8 @@ module.exports = function (chai, util) {
    *     assert.nestedInclude({'a': {'[b]': 'x'}}, {'a.\\[b\\]': 'x'});
    * 
    * @name nestedInclude
-   * @param {Object} object1
-   * @param {Object} object2
+   * @param {Object} haystack
+   * @param {Object} needle
    * @param {String} message
    * @namespace Assert
    * @api public 
@@ -1036,9 +1038,11 @@ module.exports = function (chai, util) {
   };
 
   /**
-   * ### .notNestedInclude(object1, object2, [message])
+   * ### .notNestedInclude(haystack, needle, [message])
    * 
-   * Asserts that 'object1' does not include 'object2'. 
+   * Asserts that 'haystack' does not include 'needle'. 
+   * Can be used to assert the absence of a subset of properties in an 
+   * object.
    * Enables the use of dot- and bracket-notation for referencing nested 
    * properties. 
    * '[]' and '.' in property names can be escaped using double backslashes.
@@ -1047,8 +1051,8 @@ module.exports = function (chai, util) {
    *     assert.notNestedInclude({'a': {'[b]': 'x'}}, {'a.\\[b\\]': 'y'});
    * 
    * @name notNestedInclude
-   * @param {Object} object1
-   * @param {Object} object2
+   * @param {Object} haystack
+   * @param {Object} needle
    * @param {String} message
    * @namespace Assert
    * @api public 
@@ -1060,10 +1064,11 @@ module.exports = function (chai, util) {
   };
 
   /**
-   * ### .deepNestedInclude(object1, object2, [message])
+   * ### .deepNestedInclude(haystack, needle, [message])
    * 
-   * Asserts that 'object1' includes 'object2' while checking for 
-   * deep equality.
+   * Asserts that 'haystack' includes 'needle'.
+   * Can be used to assert the inclusion of a subset of properties in an 
+   * object while checking for deep equality.
    * Enables the use of dot- and bracket-notation for referencing nested 
    * properties.
    * '[]' and '.' in property names can be escaped using double backslashes.
@@ -1072,8 +1077,8 @@ module.exports = function (chai, util) {
    *     assert.deepNestedInclude({'.a': {'[b]': {x: 1}}}, {'\\.a.\\[b\\]': {x: 1}});
    *    
    * @name deepNestedInclude
-   * @param {Object} object1
-   * @param {Object} object2
+   * @param {Object} haystack
+   * @param {Object} needle
    * @param {String} message
    * @namespace Assert
    * @api public 
@@ -1085,10 +1090,11 @@ module.exports = function (chai, util) {
   };
 
   /**
-   * ### .notDeepNestedInclude(object1, object2, [message])
+   * ### .notDeepNestedInclude(haystack, needle, [message])
    * 
-   * Asserts that 'object1' does not include 'object2' while 
-   * checking for deep equality.
+   * Asserts that 'haystack' does not include 'needle'.
+   * Can be used to assert the absence of a subset of properties in an 
+   * object while checking for deep equality.
    * Enables the use of dot- and bracket-notation for referencing nested 
    * properties.
    * '[]' and '.' in property names can be escaped using double backslashes.
@@ -1097,8 +1103,8 @@ module.exports = function (chai, util) {
    *     assert.notDeepNestedInclude({'.a': {'[b]': {x: 1}}}, {'\\.a.\\[b\\]': {y: 2}});
    *    
    * @name notDeepNestedInclude
-   * @param {Object} object1
-   * @param {Object} object2
+   * @param {Object} haystack
+   * @param {Object} needle
    * @param {String} message
    * @namespace Assert
    * @api public 
@@ -1110,16 +1116,17 @@ module.exports = function (chai, util) {
   };
 
   /**
-   * ### .ownInclude(object1, object2, [message])
+   * ### .ownInclude(haystack, needle, [message])
    * 
-   * Asserts that 'object1' includes 'object2' while 
-   * ignoring inherited properties.
+   * Asserts that 'haystack' includes 'needle'.
+   * Can be used to assert the inclusion of a subset of properties in an 
+   * object while ignoring inherited properties.
    * 
    *     assert.ownInclude({ a: 1 }, { a: 1 });
    * 
    * @name ownInclude
-   * @param {Object} object1
-   * @param {Object} object2
+   * @param {Object} haystack
+   * @param {Object} needle
    * @param {String} message
    * @namespace Assert
    * @api public
@@ -1130,18 +1137,19 @@ module.exports = function (chai, util) {
   };
 
   /**
-   * ### .notOwnInclude(object1, object2, [message])
+   * ### .notOwnInclude(haystack, needle, [message])
    * 
-   * Asserts that 'object1' does not include 'object2' while 
-   * ignoring inherited properties.
+   * Asserts that 'haystack' includes 'needle'.
+   * Can be used to assert the absence of a subset of properties in an 
+   * object while ignoring inherited properties.
    * 
    *     Object.prototype.b = 2;
    * 
    *     assert.notOwnInclude({ a: 1 }, { b: 2 });
    * 
    * @name notOwnInclude
-   * @param {Object} object1
-   * @param {Object} object2
+   * @param {Object} haystack
+   * @param {Object} needle
    * @param {String} message
    * @namespace Assert
    * @api public
@@ -1152,17 +1160,17 @@ module.exports = function (chai, util) {
   };
 
   /**
-   * ### .deepOwnInclude(object1, object2, [message])
+   * ### .deepOwnInclude(haystack, needle, [message])
    * 
-   * Asserts that 'object1' includes 'object2' while 
-   * ignoring inherited properties.
-   * Deep equality is used.
+   * Asserts that 'haystack' includes 'needle'.
+   * Can be used to assert the inclusion of a subset of properties in an 
+   * object while ignoring inherited properties and checking for deep equality.
    * 
    *      assert.deepOwnInclude({a: {b: 2}}, {a: {b: 2}});
    *      
    * @name deepOwnInclude
-   * @param {Object} object1
-   * @param {Object} object2
+   * @param {Object} haystack
+   * @param {Object} needle
    * @param {String} message
    * @namespace Assert
    * @api public
@@ -1174,17 +1182,17 @@ module.exports = function (chai, util) {
   };
 
    /**
-   * ### .notDeepOwnInclude(object1, object2, [message])
+   * ### .notDeepOwnInclude(haystack, needle, [message])
    * 
-   * Asserts that 'object1' does not include 'object2' while 
-   * ignoring inherited properties.
-   * Deep equality is used.
+   * Asserts that 'haystack' includes 'needle'.
+   * Can be used to assert the absence of a subset of properties in an 
+   * object while ignoring inherited properties and checking for deep equality.
    * 
    *      assert.notDeepOwnInclude({a: {b: 2}}, {a: {c: 3}});
    *      
    * @name notDeepOwnInclude
-   * @param {Object} object1
-   * @param {Object} object2
+   * @param {Object} haystack
+   * @param {Object} needle
    * @param {String} message
    * @namespace Assert
    * @api public

--- a/test/assert.js
+++ b/test/assert.js
@@ -763,7 +763,7 @@ describe('assert', function () {
     }, "blah: expected { a: { b: [ 'x', 'y' ] } } to have nested property 'a.b[1]' of 'x', but got 'y'");
 
     err(function () {
-      assert.nestedInclude({a: {b: ['x', 'y']}}, 'blah', {'a.b[1]': 'x'});
+      assert.nestedInclude({a: {b: ['x', 'y']}}, {'a.b[1]': 'x'}, 'blah');
     }, "blah: expected { a: { b: [ 'x', 'y' ] } } to have nested property 'a.b[1]' of 'x', but got 'y'");
 
     err(function () {
@@ -771,7 +771,7 @@ describe('assert', function () {
     }, "expected { a: { b: [ 'x', 'y' ] } } to have nested property 'a.c'");
 
     err(function () {
-      assert.nestedInclude({a: {b: ['x', 'y']}}, {'a.b[1]': 'y'});
+      assert.notNestedInclude({a: {b: ['x', 'y']}}, {'a.b[1]': 'y'});
     }, "expected { a: { b: [ 'x', 'y' ] } } to not have nested property 'a.b[1]' of 'y'");
   });
 
@@ -788,7 +788,7 @@ describe('assert', function () {
     }, "blah: expected { a: { b: [ [Object] ] } } to have deep nested property 'a.b[0]' of { y: 2 }, but got { x: 1 }");
 
     err(function () {
-      assert.deepNestedInclude({a: {b: [{x: 1}]}}, 'blah', {'a.b[0]': {y: 2}});
+      assert.deepNestedInclude({a: {b: [{x: 1}]}}, {'a.b[0]': {y: 2}}, 'blah');
     }, "blah: expected { a: { b: [ [Object] ] } } to have deep nested property 'a.b[0]' of { y: 2 }, but got { x: 1 }");
 
     err(function () {

--- a/test/assert.js
+++ b/test/assert.js
@@ -812,7 +812,7 @@ describe('assert', function () {
     }, "blah: expected { a: 1 } to have own property 'a' of 3, but got 1");
 
     err(function () {
-      assert.ownInclude({a: 1}, 'blah', {a: 3});
+      assert.ownInclude({a: 1}, {a: 3}, 'blah');
     }, "blah: expected { a: 1 } to have own property 'a' of 3, but got 1");
 
     err(function () {
@@ -834,7 +834,7 @@ describe('assert', function () {
     }, "blah: expected { a: { b: 2 } } to have deep own property 'a' of { c: 3 }, but got { b: 2 }");
 
     err(function () {
-      assert.deepOwnInclude({a: {b: 2}}, 'blah', {a: {c: 3}});
+      assert.deepOwnInclude({a: {b: 2}}, {a: {c: 3}}, 'blah');
     }, "blah: expected { a: { b: 2 } } to have deep own property 'a' of { c: 3 }, but got { b: 2 }");
 
     err(function () {

--- a/test/assert.js
+++ b/test/assert.js
@@ -775,6 +775,30 @@ describe('assert', function () {
     }, "expected { a: { b: [ 'x', 'y' ] } } to not have nested property 'a.b[1]' of 'y'");
   });
 
+  it('ownInclude and notOwnInclude', function() {
+    assert.ownInclude({a: 1}, {a: 1});
+    assert.notOwnInclude({a: 1}, {a: 3});
+    assert.notOwnInclude({a: 1}, {'toString': Object.prototype.toString});
+
+    assert.notOwnInclude({a: {b: 2}}, {a: {b: 2}});
+
+    err(function () {
+      assert.ownInclude({a: 1}, {a: 3}, 'blah');
+    }, "blah: expected { a: 1 } to have own property 'a' of 3, but got 1");
+
+    err(function () {
+      assert.ownInclude({a: 1}, 'blah', {a: 3});
+    }, "blah: expected { a: 1 } to have own property 'a' of 3, but got 1");
+
+    err(function () {
+      assert.ownInclude({a: 1}, {'toString': Object.prototype.toString});
+    }, "expected { a: 1 } to have own property 'toString'");
+
+    err(function () {
+      assert.notOwnInclude({a: 1}, {a: 1});
+    }, "expected { a: 1 } to not have own property 'a' of 1");
+  });
+
   it('keys(array|Object|arguments)', function(){
     assert.hasAllKeys({ foo: 1 }, [ 'foo' ]);
     assert.hasAllKeys({ foo: 1, bar: 2 }, [ 'foo', 'bar' ]);

--- a/test/assert.js
+++ b/test/assert.js
@@ -771,8 +771,8 @@ describe('assert', function () {
     }, "expected { a: { b: [ 'x', 'y' ] } } to have nested property 'a.c'");
 
     err(function () {
-      assert.notNestedInclude({a: {b: ['x', 'y']}}, {'a.b[1]': 'y'});
-    }, "expected { a: { b: [ 'x', 'y' ] } } to not have nested property 'a.b[1]' of 'y'");
+      assert.notNestedInclude({a: {b: ['x', 'y']}}, {'a.b[1]': 'y'}, 'blah');
+    }, "blah: expected { a: { b: [ 'x', 'y' ] } } to not have nested property 'a.b[1]' of 'y'");
   });
 
   it('deepNestedInclude and notDeepNestedInclude', function() {
@@ -796,8 +796,8 @@ describe('assert', function () {
     }, "expected { a: { b: [ [Object] ] } } to have deep nested property 'a.c'");
 
     err(function () {
-      assert.notDeepNestedInclude({a: {b: [{x: 1}]}}, {'a.b[0]': {x: 1}});
-    }, "expected { a: { b: [ [Object] ] } } to not have deep nested property 'a.b[0]' of { x: 1 }");
+      assert.notDeepNestedInclude({a: {b: [{x: 1}]}}, {'a.b[0]': {x: 1}}, 'blah');
+    }, "blah: expected { a: { b: [ [Object] ] } } to not have deep nested property 'a.b[0]' of { x: 1 }");
   });
 
   it('ownInclude and notOwnInclude', function() {
@@ -820,8 +820,8 @@ describe('assert', function () {
     }, "expected { a: 1 } to have own property 'toString'");
 
     err(function () {
-      assert.notOwnInclude({a: 1}, {a: 1});
-    }, "expected { a: 1 } to not have own property 'a' of 1");
+      assert.notOwnInclude({a: 1}, {a: 1}, 'blah');
+    }, "blah: expected { a: 1 } to not have own property 'a' of 1");
   });
 
   it('deepOwnInclude and notDeepOwnInclude', function() {
@@ -842,8 +842,8 @@ describe('assert', function () {
     }, "expected { a: { b: 2 } } to have deep own property 'toString'");
 
     err(function () {
-      assert.notDeepOwnInclude({a: {b: 2}}, {a: {b: 2}});
-    }, "expected { a: { b: 2 } } to not have deep own property 'a' of { b: 2 }");
+      assert.notDeepOwnInclude({a: {b: 2}}, {a: {b: 2}}, 'blah');
+    }, "blah: expected { a: { b: 2 } } to not have deep own property 'a' of { b: 2 }");
   });
 
   it('keys(array|Object|arguments)', function(){

--- a/test/assert.js
+++ b/test/assert.js
@@ -775,6 +775,31 @@ describe('assert', function () {
     }, "expected { a: { b: [ 'x', 'y' ] } } to not have nested property 'a.b[1]' of 'y'");
   });
 
+  it('deepNestedInclude and notDeepNestedInclude', function() {
+    assert.deepNestedInclude({a: {b: [{x: 1}]}}, {'a.b[0]': {x: 1}});
+    assert.notDeepNestedInclude({a: {b: [{x: 1}]}}, {'a.b[0]': {y: 2}});
+    assert.notDeepNestedInclude({a: {b: [{x: 1}]}}, {'a.c': {x: 1}});
+
+    assert.deepNestedInclude({'.a': {'[b]': {x: 1}}}, {'\\.a.\\[b\\]': {x: 1}});
+    assert.notDeepNestedInclude({'.a': {'[b]': {x: 1}}}, {'\\.a.\\[b\\]': {y: 2}});
+
+    err(function () {
+      assert.deepNestedInclude({a: {b: [{x: 1}]}}, {'a.b[0]': {y: 2}}, 'blah');
+    }, "blah: expected { a: { b: [ [Object] ] } } to have deep nested property 'a.b[0]' of { y: 2 }, but got { x: 1 }");
+
+    err(function () {
+      assert.deepNestedInclude({a: {b: [{x: 1}]}}, 'blah', {'a.b[0]': {y: 2}});
+    }, "blah: expected { a: { b: [ [Object] ] } } to have deep nested property 'a.b[0]' of { y: 2 }, but got { x: 1 }");
+
+    err(function () {
+      assert.deepNestedInclude({a: {b: [{x: 1}]}}, {'a.c': {x: 1}});
+    }, "expected { a: { b: [ [Object] ] } } to have deep nested property 'a.c'");
+
+    err(function () {
+      assert.notDeepNestedInclude({a: {b: [{x: 1}]}}, {'a.b[0]': {x: 1}});
+    }, "expected { a: { b: [ [Object] ] } } to not have deep nested property 'a.b[0]' of { x: 1 }");
+  });
+
   it('ownInclude and notOwnInclude', function() {
     assert.ownInclude({a: 1}, {a: 1});
     assert.notOwnInclude({a: 1}, {a: 3});

--- a/test/assert.js
+++ b/test/assert.js
@@ -748,6 +748,33 @@ describe('assert', function () {
     }, "expected { foo: { a: 1 }, bar: { b: 2 } } to not have deep property 'foo' of { a: 1 }");
   });
 
+  it('nestedInclude and notNestedInclude', function() {
+    assert.nestedInclude({a: {b: ['x', 'y']}}, {'a.b[1]': 'y'});
+    assert.notNestedInclude({a: {b: ['x', 'y']}}, {'a.b[1]': 'x'});
+    assert.notNestedInclude({a: {b: ['x', 'y']}}, {'a.c': 'y'});
+
+    assert.notNestedInclude({a: {b: [{x: 1}]}}, {'a.b[0]': {x: 1}});
+
+    assert.nestedInclude({'.a': {'[b]': 'x'}}, {'\\.a.\\[b\\]': 'x'});
+    assert.notNestedInclude({'.a': {'[b]': 'x'}}, {'\\.a.\\[b\\]': 'y'});
+
+    err(function () {
+      assert.nestedInclude({a: {b: ['x', 'y']}}, {'a.b[1]': 'x'}, 'blah');
+    }, "blah: expected { a: { b: [ 'x', 'y' ] } } to have nested property 'a.b[1]' of 'x', but got 'y'");
+
+    err(function () {
+      assert.nestedInclude({a: {b: ['x', 'y']}}, 'blah', {'a.b[1]': 'x'});
+    }, "blah: expected { a: { b: [ 'x', 'y' ] } } to have nested property 'a.b[1]' of 'x', but got 'y'");
+
+    err(function () {
+      assert.nestedInclude({a: {b: ['x', 'y']}}, {'a.c': 'y'});
+    }, "expected { a: { b: [ 'x', 'y' ] } } to have nested property 'a.c'");
+
+    err(function () {
+      assert.nestedInclude({a: {b: ['x', 'y']}}, {'a.b[1]': 'y'});
+    }, "expected { a: { b: [ 'x', 'y' ] } } to not have nested property 'a.b[1]' of 'y'");
+  });
+
   it('keys(array|Object|arguments)', function(){
     assert.hasAllKeys({ foo: 1 }, [ 'foo' ]);
     assert.hasAllKeys({ foo: 1, bar: 2 }, [ 'foo', 'bar' ]);

--- a/test/assert.js
+++ b/test/assert.js
@@ -824,6 +824,28 @@ describe('assert', function () {
     }, "expected { a: 1 } to not have own property 'a' of 1");
   });
 
+  it('deepOwnInclude and notDeepOwnInclude', function() {
+    assert.deepOwnInclude({a: {b: 2}}, {a: {b: 2}});
+    assert.notDeepOwnInclude({a: {b: 2}}, {a: {c: 3}});
+    assert.notDeepOwnInclude({a: {b: 2}}, {'toString': Object.prototype.toString});
+
+    err(function () {
+      assert.deepOwnInclude({a: {b: 2}}, {a: {c: 3}}, 'blah');
+    }, "blah: expected { a: { b: 2 } } to have deep own property 'a' of { c: 3 }, but got { b: 2 }");
+
+    err(function () {
+      assert.deepOwnInclude({a: {b: 2}}, 'blah', {a: {c: 3}});
+    }, "blah: expected { a: { b: 2 } } to have deep own property 'a' of { c: 3 }, but got { b: 2 }");
+
+    err(function () {
+      assert.deepOwnInclude({a: {b: 2}}, {'toString': Object.prototype.toString});
+    }, "expected { a: { b: 2 } } to have deep own property 'toString'");
+
+    err(function () {
+      assert.notDeepOwnInclude({a: {b: 2}}, {a: {b: 2}});
+    }, "expected { a: { b: 2 } } to not have deep own property 'a' of { b: 2 }");
+  });
+
   it('keys(array|Object|arguments)', function(){
     assert.hasAllKeys({ foo: 1 }, [ 'foo' ]);
     assert.hasAllKeys({ foo: 1, bar: 2 }, [ 'foo', 'bar' ]);

--- a/test/assert.js
+++ b/test/assert.js
@@ -744,8 +744,8 @@ describe('assert', function () {
     }, "blah: expected { foo: { a: 1 }, bar: { b: 2 } } to have deep property 'bar' of { b: 9 }, but got { b: 2 }");
 
     err(function () {
-      assert.notDeepInclude({foo: obj1, bar: obj2}, {foo: {a: 1}, bar: {b: 2}});
-    }, "expected { foo: { a: 1 }, bar: { b: 2 } } to not have deep property 'foo' of { a: 1 }");
+      assert.notDeepInclude({foo: obj1, bar: obj2}, {foo: {a: 1}, bar: {b: 2}}, 'blah');
+    }, "blah: expected { foo: { a: 1 }, bar: { b: 2 } } to not have deep property 'foo' of { a: 1 }");
   });
 
   it('nestedInclude and notNestedInclude', function() {

--- a/test/expect.js
+++ b/test/expect.js
@@ -1797,16 +1797,16 @@ describe('expect', function () {
     }, "blah: expected [ { a: 1 }, { b: 2 } ] to deep include { a: 9 }");
 
     err(function () {
-      expect([obj1, obj2]).to.not.deep.include({a: 1});
-    }, "expected [ { a: 1 }, { b: 2 } ] to not deep include { a: 1 }");
+      expect([obj1, obj2], 'blah').to.not.deep.include({a: 1});
+    }, "blah: expected [ { a: 1 }, { b: 2 } ] to not deep include { a: 1 }");
 
     err(function () {
       expect({foo: obj1, bar: obj2}).to.deep.include({foo: {a: 1}, bar: {b: 9}});
     }, "expected { foo: { a: 1 }, bar: { b: 2 } } to have deep property 'bar' of { b: 9 }, but got { b: 2 }");
 
     err(function () {
-      expect({foo: obj1, bar: obj2}).to.not.deep.include({foo: {a: 1}, bar: {b: 2}});
-    }, "expected { foo: { a: 1 }, bar: { b: 2 } } to not have deep property 'foo' of { a: 1 }");
+      expect({foo: obj1, bar: obj2}).to.not.deep.include({foo: {a: 1}, bar: {b: 2}}, 'blah');
+    }, "blah: expected { foo: { a: 1 }, bar: { b: 2 } } to not have deep property 'foo' of { a: 1 }");
   });
 
   it('nested.include()', function () {
@@ -1832,8 +1832,12 @@ describe('expect', function () {
     }, "expected { a: { b: [ 'x', 'y' ] } } to have nested property 'a.c'");
 
     err(function () {
-      expect({a: {b: ['x', 'y']}}).to.not.nested.include({'a.b[1]': 'y'});
-    }, "expected { a: { b: [ 'x', 'y' ] } } to not have nested property 'a.b[1]' of 'y'");
+      expect({a: {b: ['x', 'y']}}).to.not.nested.include({'a.b[1]': 'y'}, 'blah');
+    }, "blah: expected { a: { b: [ 'x', 'y' ] } } to not have nested property 'a.b[1]' of 'y'");
+
+    err(function () {
+      expect({a: {b: ['x', 'y']}}, 'blah').to.not.nested.include({'a.b[1]': 'y'});
+    }, "blah: expected { a: { b: [ 'x', 'y' ] } } to not have nested property 'a.b[1]' of 'y'");
   });
 
   it('deep.nested.include()', function () {
@@ -1859,8 +1863,12 @@ describe('expect', function () {
     }, "expected { a: { b: [ [Object] ] } } to have deep nested property 'a.c'");
 
     err(function () {
-      expect({a: {b: [{x: 1}]}}).to.not.deep.nested.include({'a.b[0]': {x: 1}});
-    }, "expected { a: { b: [ [Object] ] } } to not have deep nested property 'a.b[0]' of { x: 1 }");
+      expect({a: {b: [{x: 1}]}}).to.not.deep.nested.include({'a.b[0]': {x: 1}}, 'blah');
+    }, "blah: expected { a: { b: [ [Object] ] } } to not have deep nested property 'a.b[0]' of { x: 1 }");
+
+    err(function () {
+      expect({a: {b: [{x: 1}]}}, 'blah').to.not.deep.nested.include({'a.b[0]': {x: 1}});
+    }, "blah: expected { a: { b: [ [Object] ] } } to not have deep nested property 'a.b[0]' of { x: 1 }");
   });
 
   it('own.include()', function () {
@@ -1883,8 +1891,12 @@ describe('expect', function () {
     }, "expected { a: 1 } to have own property 'toString'");
 
     err(function () {
-      expect({a: 1}).to.not.own.include({a: 1});
-    }, "expected { a: 1 } to not have own property 'a' of 1");
+      expect({a: 1}).to.not.own.include({a: 1}, 'blah');
+    }, "blah: expected { a: 1 } to not have own property 'a' of 1");
+
+    err(function () {
+      expect({a: 1}, 'blah').to.not.own.include({a: 1});
+    }, "blah: expected { a: 1 } to not have own property 'a' of 1");
   });
 
   it('deep.own.include()', function () {
@@ -1906,8 +1918,12 @@ describe('expect', function () {
     }, "expected { a: { b: 2 } } to have deep own property 'toString'");
 
     err(function () {
-      expect({a: {b: 2}}).to.not.deep.own.include({a: {b: 2}});
-    }, "expected { a: { b: 2 } } to not have deep own property 'a' of { b: 2 }");
+      expect({a: {b: 2}}).to.not.deep.own.include({a: {b: 2}}, 'blah');
+    }, "blah: expected { a: { b: 2 } } to not have deep own property 'a' of { b: 2 }");
+
+    err(function () {
+      expect({a: {b: 2}}, 'blah').to.not.deep.own.include({a: {b: 2}});
+    }, "blah: expected { a: { b: 2 } } to not have deep own property 'a' of { b: 2 }");
   });
 
   it('keys(array|Object|arguments)', function(){

--- a/test/should.js
+++ b/test/should.js
@@ -1426,8 +1426,8 @@ describe('should', function() {
     }, "expected { foo: { a: 1 }, bar: { b: 2 } } to have deep property 'bar' of { b: 9 }, but got { b: 2 }");
 
     err(function () {
-      ({foo: obj1, bar: obj2}).should.not.deep.include({foo: {a: 1}, bar: {b: 2}});
-    }, "expected { foo: { a: 1 }, bar: { b: 2 } } to not have deep property 'foo' of { a: 1 }");
+      ({foo: obj1, bar: obj2}).should.not.deep.include({foo: {a: 1}, bar: {b: 2}}, 'blah');
+    }, "blah: expected { foo: { a: 1 }, bar: { b: 2 } } to not have deep property 'foo' of { a: 1 }");
   });
 
   it('nested.include()', function () {
@@ -1449,8 +1449,8 @@ describe('should', function() {
     }, "expected { a: { b: [ 'x', 'y' ] } } to have nested property 'a.c'");
 
     err(function () {
-      ({a: {b: ['x', 'y']}}).should.not.nested.include({'a.b[1]': 'y'});
-    }, "expected { a: { b: [ 'x', 'y' ] } } to not have nested property 'a.b[1]' of 'y'");
+      ({a: {b: ['x', 'y']}}).should.not.nested.include({'a.b[1]': 'y'}, 'blah');
+    }, "blah: expected { a: { b: [ 'x', 'y' ] } } to not have nested property 'a.b[1]' of 'y'");
   });
 
   it('deep.nested.include()', function () {
@@ -1472,8 +1472,8 @@ describe('should', function() {
     }, "expected { a: { b: [ [Object] ] } } to have deep nested property 'a.c'");
 
     err(function () {
-      ({a: {b: [{x: 1}]}}).should.not.deep.nested.include({'a.b[0]': {x: 1}});
-    }, "expected { a: { b: [ [Object] ] } } to not have deep nested property 'a.b[0]' of { x: 1 }");
+      ({a: {b: [{x: 1}]}}).should.not.deep.nested.include({'a.b[0]': {x: 1}}, 'blah');
+    }, "blah: expected { a: { b: [ [Object] ] } } to not have deep nested property 'a.b[0]' of { x: 1 }");
   });
 
   it('own.include()', function () {
@@ -1492,8 +1492,8 @@ describe('should', function() {
     }, "expected { a: 1 } to have own property 'toString'");
 
     err(function () {
-      ({a: 1}).should.not.own.include({a: 1});
-    }, "expected { a: 1 } to not have own property 'a' of 1");
+      ({a: 1}).should.not.own.include({a: 1}, 'blah');
+    }, "blah: expected { a: 1 } to not have own property 'a' of 1");
   });
 
   it('deep.own.include()', function () {
@@ -1511,8 +1511,8 @@ describe('should', function() {
     }, "expected { a: { b: 2 } } to have deep own property 'toString'");
 
     err(function () {
-      ({a: {b: 2}}).should.not.deep.own.include({a: {b: 2}});
-    }, "expected { a: { b: 2 } } to not have deep own property 'a' of { b: 2 }");
+      ({a: {b: 2}}).should.not.deep.own.include({a: {b: 2}}, 'blah');
+    }, "blah: expected { a: { b: 2 } } to not have deep own property 'a' of { b: 2 }");
   });
 
   it('keys(array|Object|arguments)', function(){


### PR DESCRIPTION
I added these methods and their negated versions to the assert interface and adapted the expect-style tests to assert-style as discussed in this issue: https://github.com/chaijs/chai/issues/905.