### PR TITLE
fix: PhantomJS 1.x incompatibility

### DIFF
--- a/lib/chai/utils/addChainableMethod.js
+++ b/lib/chai/utils/addChainableMethod.js
@@ -25,7 +25,16 @@ var canSetPrototype = typeof Object.setPrototypeOf === 'function';
 // However, some of functions' own props are not configurable and should be skipped.
 var testFn = function() {};
 var excludeNames = Object.getOwnPropertyNames(testFn).filter(function(name) {
-  return !Object.getOwnPropertyDescriptor(testFn, name).configurable;
+  var propDesc = Object.getOwnPropertyDescriptor(testFn, name);
+
+  // Note: PhantomJS 1.x includes `callee` as one of `testFn`'s own properties,
+  // but then returns `undefined` as the property descriptor for `callee`. As a
+  // workaround, we perform an otherwise unnecessary type-check for `propDesc`,
+  // and then filter it out if it's not an object as it should be.
+  if (typeof propDesc !== 'object')
+    return true;
+
+  return !propDesc.configurable;
 });
 
 // Cache `Function` properties


### PR DESCRIPTION
- Addresses https://github.com/chaijs/chai/issues/890#issuecomment-298168561
- Although I'm not crazy about adding a workaround in Chai for a 3rd party library, in this particular case it feels like a low-cost solution to allow Chai to continue supporting PhantomJS 1.x until plugins have had a chance to upgrade.