### PR TITLE
Remove bump command to change lib/chai.js

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ chai.js: node_modules lib/*
 #
 
 define release
-	./node_modules/.bin/bump -y --$(1) package.json lib/chai.js
+	./node_modules/.bin/bump -y --$(1) package.json
 	make chai.js
 	git add --force chai.js lib/chai.js package.json bower.json
 	npm ls --depth=-1 --long . --loglevel silent | head -1 | git commit -F-


### PR DESCRIPTION
Hey everyone, me and @vieiralucas have had problems with the make task that does a major release.

[It was trying to bump the version number on the `lib/chai.js` file too](https://github.com/chaijs/chai/blob/0825826059637cfb22c71aa87db9324620cd0eab/Makefile#L24), which has been updated to get it from `package.json`, so the command was failing.