### PR TITLE
Revert get version package json

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ chai.js: node_modules lib/*
 #
 
 define release
-	./node_modules/.bin/bump -y --$(1) package.json
+	./node_modules/.bin/bump -y --$(1) package.json lib/chai.js
 	make chai.js
 	git add --force chai.js lib/chai.js package.json bower.json
 	npm ls --depth=-1 --long . --loglevel silent | head -1 | git commit -F-

--- a/chai.js
+++ b/chai.js
@@ -14,7 +14,7 @@ var used = [];
  * Chai version
  */
 
-exports.version = require('../package').version;
+exports.version = '4.0.2';
 
 /*!
  * Assertion Error
@@ -95,7 +95,7 @@ exports.use(should);
 var assert = require('./chai/interface/assert');
 exports.use(assert);
 
-},{"../package":40,"./chai/assertion":3,"./chai/config":4,"./chai/core/assertions":5,"./chai/interface/assert":6,"./chai/interface/expect":7,"./chai/interface/should":8,"./chai/utils":22,"assertion-error":33}],3:[function(require,module,exports){
+},{"./chai/assertion":3,"./chai/config":4,"./chai/core/assertions":5,"./chai/interface/assert":6,"./chai/interface/expect":7,"./chai/interface/should":8,"./chai/utils":22,"assertion-error":33}],3:[function(require,module,exports){
 /*!
  * chai
  * http://chaijs.com
@@ -10978,63 +10978,6 @@ module.exports = function typeDetect(obj) {
 };
 
 module.exports.typeDetect = module.exports;
-
-},{}],40:[function(require,module,exports){
-module.exports={
-  "author": "Jake Luer <jake@alogicalparadox.com>",
-  "name": "chai",
-  "description": "BDD/TDD assertion library for node.js and the browser. Test framework agnostic.",
-  "keywords": [
-    "test",
-    "assertion",
-    "assert",
-    "testing",
-    "chai"
-  ],
-  "homepage": "http://chaijs.com",
-  "license": "MIT",
-  "contributors": [
-    "Jake Luer <jake@alogicalparadox.com>",
-    "Domenic Denicola <domenic@domenicdenicola.com> (http://domenicdenicola.com)",
-    "Veselin Todorov <hi@vesln.com>",
-    "John Firebaugh <john.firebaugh@gmail.com>"
-  ],
-  "version": "4.0.0",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/chaijs/chai"
-  },
-  "bugs": {
-    "url": "https://github.com/chaijs/chai/issues"
-  },
-  "main": "./index",
-  "browser": "./chai.js",
-  "scripts": {
-    "test": "make test"
-  },
-  "engines": {
-    "node": ">=4"
-  },
-  "dependencies": {
-    "assertion-error": "^1.0.1",
-    "check-error": "^1.0.1",
-    "deep-eql": "^2.0.1",
-    "get-func-name": "^2.0.0",
-    "pathval": "^1.0.0",
-    "type-detect": "^4.0.0"
-  },
-  "devDependencies": {
-    "browserify": "^13.0.1",
-    "bump-cli": "^1.1.3",
-    "istanbul": "^0.4.3",
-    "karma": "^1.0.0",
-    "karma-firefox-launcher": "^1.0.0",
-    "karma-mocha": "^1.0.1",
-    "karma-phantomjs-launcher": "^1.0.0",
-    "karma-sauce-launcher": "^1.0.0",
-    "mocha": "^3.0.0"
-  }
-}
 
 },{}]},{},[1])(1)
 });

--- a/lib/chai.js
+++ b/lib/chai.js
@@ -10,7 +10,7 @@ var used = [];
  * Chai version
  */
 
-exports.version = '4.0.1';
+exports.version = '4.0.2';
 
 /*!
  * Assertion Error

--- a/lib/chai.js
+++ b/lib/chai.js
@@ -10,7 +10,7 @@ var used = [];
  * Chai version
  */
 
-exports.version = require('../package').version;
+exports.version = '4.0.1';
 
 /*!
  * Assertion Error

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "Veselin Todorov <hi@vesln.com>",
     "John Firebaugh <john.firebaugh@gmail.com>"
   ],
-  "version": "4.0.1",
+  "version": "4.0.2",
   "repository": {
     "type": "git",
     "url": "https://github.com/chaijs/chai"


### PR DESCRIPTION
This fixes #981 by not requiring a `.json` file inside our code in order for webpack not to need `json-loader`. This change was introduced #819.

This commit also reverts changes made at #967, because now we still need to bump the version in the `lib/chai.js` file.

Finally, since this seems a very important thing to release ASAP given the number of people using webpack1, I've added a commit that does this release.