### PR TITLE
Add a missing var keyword found by lgtm.com

### DIFF
--- a/lib/chai/utils/inspect.js
+++ b/lib/chai/utils/inspect.js
@@ -86,7 +86,7 @@ function formatValue(ctx, value, recurseTimes) {
           var container = document.createElementNS(ns, '_');
 
           container.appendChild(value.cloneNode(false));
-          html = container.innerHTML
+          var html = container.innerHTML
             .replace('><', '>' + value.innerHTML + '<');
           container.innerHTML = '';
           return html;


### PR DESCRIPTION
In this code path, `html` is defined as a global variable rather than a local one, this is probably not what was intended.

This problem was found by lgtm.com: https://lgtm.com/projects/g/chaijs/chai/alerts/

chai is actually in pretty good shape as far as lgtm's default selection of javascript queries are concerned, in fact this is currently the only result that is found. But perhaps it would be of interest to enable PR integration for chai to prevent problems appearing that lgtm's current queries find? You can do this from here: https://lgtm.com/projects/g/chaijs/chai/ci/ And read more about it here: https://lgtm.com/docs/lgtm/config/pr-integration

*Full Disclosure: I'm a core developer at lgtm.com*