### PR TITLE
Fix Out-Of-Order Variable Declarations

### DIFF
--- a/.lgtm-queries/README.md
+++ b/.lgtm-queries/README.md
@@ -1,0 +1,8 @@
+# Chai Coding Style Queries
+
+This directory contains lgtm.com queries that help enforce our
+[coding style guidelines](https://github.com/chaijs/chai/wiki/Chai-Coding-Style-Guide).
+
+Currently these can only be run manually on the latest version that lgtm.com has
+analysed, but they plan to add support for custom queries in PR integration in
+the future.

--- a/.lgtm-queries/sorted-vars.ql
+++ b/.lgtm-queries/sorted-vars.ql
@@ -1,0 +1,76 @@
+/**
+ * @name Incorrectly Ordered Variable Declaration
+ * @description declarations should be declared in alphabetical order whenever possible. The exception is if a declaration requires a previous declaration.
+ * @kind problem
+ * @problem.severity warning
+ */
+import javascript
+
+class LocalVariableDecl extends VarDeclStmt {
+
+  LocalVariableDecl() {
+  	// Only care about declarations which declare a single variable
+   	count(this.getADecl()) = 1
+   	// Exclude Imports
+   	and not (this.getADecl().getInit().(CallExpr).getCallee().(VarAccess).getName() = "require")
+  }
+
+  string getName() {
+    result = this.getADecl().getBindingPattern().getAVariable().getName()
+  }
+
+  LocalVariableDecl getImmediatelyPreceedingDeclaration() {
+    exists(LocalVariableDecl decl, int i |
+      result = decl and
+      // The two variable declarations have the same parent
+      decl.getParentStmt() = this.getParentStmt() and
+      // decl is the statement immediately before this
+      decl.getParentStmt().getChild(i) = decl and
+      decl.getParentStmt().getChild(i + 1) = this
+    )
+  }
+
+  /**
+   * A "group" is considered to be a continuous list of variable declarations
+   */
+  LocalVariableDecl getAllPreceedingDeclarationsInGroup() {
+    // Transitive Closure
+    result = this.getImmediatelyPreceedingDeclaration+()
+  }
+
+  LocalVariableDecl getAUsedDeclaration() {
+    exists(LocalVariableDecl decl |
+      // decl is a preceeding declaration
+      decl = this.getAllPreceedingDeclarationsInGroup() and
+      // the variable declared by decl is used in the declaration of this
+      this.getADecl().getInit().getAChild*() = decl.getADecl().getBindingPattern().getAVariable().getAnAccess() and
+      result = decl
+    )
+  }
+
+  /**
+   * Get a declaration that should appear BEFORE this declaration.
+   */
+  LocalVariableDecl getAnIncorrectlyPlacedSucceedingDeclaration() {
+    // this declaration appears before the result
+    this = result.getAllPreceedingDeclarationsInGroup() and
+    // this declaration is alphabetically AFTER the result
+    this.getName() > result.getName() and
+    // this declaration is not used by the result
+    not(this = result.getAUsedDeclaration())
+  }
+}
+
+from LocalVariableDecl incorrectlyPlacedDecl, LocalVariableDecl preceedingDecl
+where
+  incorrectlyPlacedDecl = preceedingDecl.getAnIncorrectlyPlacedSucceedingDeclaration()
+  // Exclude this result if there is another declaration before preceedingDecl that also finds incorrectlyPlacedDecl
+  and not exists(LocalVariableDecl earlierDecl |
+    preceedingDecl != earlierDecl and
+    incorrectlyPlacedDecl = earlierDecl.getAnIncorrectlyPlacedSucceedingDeclaration() and
+    earlierDecl.getLocation().startsBefore(preceedingDecl.getLocation())
+  )
+select incorrectlyPlacedDecl, "The variable declaration for $@ should appear before the declaration for $@",
+       incorrectlyPlacedDecl, incorrectlyPlacedDecl.getName(),
+       preceedingDecl, preceedingDecl.getName()
+

--- a/lib/chai/core/assertions.js
+++ b/lib/chai/core/assertions.js
@@ -1490,9 +1490,9 @@ module.exports = function (chai, _) {
   function assertInstanceOf (constructor, msg) {
     if (msg) flag(this, 'message', msg);
 
-    var target = flag(this, 'object')
-    var ssfi = flag(this, 'ssfi');
     var flagMsg = flag(this, 'message');
+    var ssfi = flag(this, 'ssfi');
+    var target = flag(this, 'object');
     var validInstanceOfTarget = constructor === Object(constructor) && (
         typeof constructor === 'function' ||
         (typeof Symbol !== 'undefined' &&
@@ -3392,10 +3392,10 @@ module.exports = function (chai, _) {
   function assertDelta(delta, msg) {
     if (msg) flag(this, 'message', msg);
 
-    var msgObj = flag(this, 'deltaMsgObj');
-    var initial = flag(this, 'initialDeltaValue');
-    var final = flag(this, 'finalDeltaValue');
     var behavior = flag(this, 'deltaBehavior');
+    var final = flag(this, 'finalDeltaValue');
+    var initial = flag(this, 'initialDeltaValue');
+    var msgObj = flag(this, 'deltaMsgObj');
     var realDelta = flag(this, 'realDelta');
 
     var expression;


### PR DESCRIPTION
Following #988, I decided to see if lgtm.com would be useful for enforcing chai's coding style guidelines. I'm not sure if this is the sort of thing you'd be interested in, but I'd love to hear feedback either way.

I wrote a query for variable declaration order, and you can see the results it produces for chai (and mozilla's pdf.js for comparison) here: https://lgtm.com/query/1983330216/lang:javascript/

Currently it's quite a broad query, and has many results in test code, but I can make it more specific if you'd like, and exclude certain results, e,g:
 * if there's whitespace / extra lines between groups of variable declarations, consider them different groups.
 * exclude test code
 * exclude complicated variable declarations (for some definition of complicated)

I'm not sure whether you'd like to include this query in this repository, but it does have some interesting results, some of which I've addressed in a separate commit, and we could start to write further queries. We do have plans to allow projects to run their own custom queries as part of pull request integration soon, but we don't currently have a timeline for that.

If you like this sort of contribution, I can write queries for some of your other guidelines to see what we can find.

*Full Disclosure: I'm a core developer at lgtm.com*