### PR TITLE
fix: check target's type in `.property` assertion

### DIFF
--- a/lib/chai/core/assertions.js
+++ b/lib/chai/core/assertions.js
@@ -1644,6 +1644,7 @@ module.exports = function (chai, _) {
     var isNested = flag(this, 'nested')
       , isOwn = flag(this, 'own')
       , flagMsg = flag(this, 'message')
+      , obj = flag(this, 'object')
       , ssfi = flag(this, 'ssfi');
 
     if (isNested && isOwn) {
@@ -1655,9 +1656,17 @@ module.exports = function (chai, _) {
       );
     }
 
+    if (obj === null || obj === undefined) {
+      flagMsg = flagMsg ? flagMsg + ': ' : '';
+      throw new AssertionError(
+        flagMsg + 'Target cannot be null or undefined.',
+        undefined,
+        ssfi
+      );
+    }
+
     var isDeep = flag(this, 'deep')
       , negate = flag(this, 'negate')
-      , obj = flag(this, 'object')
       , pathInfo = isNested ? _.getPathInfo(obj, name) : null
       , value = isNested ? pathInfo.value : obj[name];
 

--- a/test/assert.js
+++ b/test/assert.js
@@ -1339,6 +1339,14 @@ describe('assert', function () {
     err(function () {
       assert.notNestedPropertyVal(obj, 'foo.bar', 'baz', 'blah');
     }, "blah: expected { foo: { bar: 'baz' } } to not have nested property 'foo.bar' of 'baz'");
+
+    err(function () {
+      assert.property(null, 'a', 'blah');
+    }, "blah: Target cannot be null or undefined.");
+
+    err(function () {
+      assert.property(undefined, 'a', 'blah');
+    }, "blah: Target cannot be null or undefined.");
   });
 
   it('deepPropertyVal', function () {

--- a/test/expect.js
+++ b/test/expect.js
@@ -1263,6 +1263,14 @@ describe('expect', function () {
     err(function() {
       expect({a: {b: 1}}, 'blah').to.have.own.nested.property("a.b");
     }, "blah: The \"nested\" and \"own\" flags cannot be combined.");
+
+    err(function () {
+      expect(null, 'blah').to.have.property("a");
+    }, "blah: Target cannot be null or undefined.");
+
+    err(function () {
+      expect(undefined, 'blah').to.have.property("a");
+    }, "blah: Target cannot be null or undefined.");
   });
 
   it('property(name, val)', function(){


### PR DESCRIPTION
Previously, the `.property` assertion failed ungracefully if the target was `null` or `undefined`. This commit causes an `AssertionError` to be thrown instead so that the ssfi flag and custom error messages are respected.