### PR TITLE
refactor: `expectTypes` to access `ssfi` flag

### DIFF
--- a/lib/chai/core/assertions.js
+++ b/lib/chai/core/assertions.js
@@ -462,7 +462,7 @@ module.exports = function (chai, _) {
   function include (val, msg) {
     if (msg) flag(this, 'message', msg);
 
-    _.expectTypes(this, ['array', 'object', 'string'], flag(this, 'ssfi'));
+    _.expectTypes(this, ['array', 'object', 'string']);
 
     var obj = flag(this, 'object')
       , objType = _.type(obj).toLowerCase()

--- a/lib/chai/utils/expectTypes.js
+++ b/lib/chai/utils/expectTypes.js
@@ -13,8 +13,6 @@
  *
  * @param {Mixed} obj constructed Assertion
  * @param {Array} type A list of allowed types for this assertion
- * @param {Function} ssfi starting point for removing implementation frames from
- *                        stack trace of AssertionError
  * @namespace Utils
  * @name expectTypes
  * @api public
@@ -24,8 +22,9 @@ var AssertionError = require('assertion-error');
 var flag = require('./flag');
 var type = require('type-detect');
 
-module.exports = function expectTypes(obj, types, ssfi) {
+module.exports = function expectTypes(obj, types) {
   var flagMsg = flag(obj, 'message');
+  var ssfi = flag(obj, 'ssfi');
 
   flagMsg = flagMsg ? flagMsg + ': ' : '';
 


### PR DESCRIPTION
The `ssfi` flag doesn't need to be passed to the `expectTypes`
util function because it can access it directly from the assertion
object.