### PR TITLE
Create CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+*       @chaijs/chai


### PR DESCRIPTION
Thanks to the new [Code Owners feature](https://github.com/blog/2392-introducing-code-owners) we can now automatically require reviews from individual contributors, or a group of contributors.

This change adds a `CODEOWNERS` file to this repo, saying that all files in the repo are owned by @chaijs/chai - which consists of @logicalparadox, @astorije, @keithamus, @shvaikalesh, @lucasfcosta, @vieiralucas and @meeber. With this file, at least _one_ of those maintainers will need to approve every pull request coming into this repo. The team will pinged for every PR.