### PR TITLE
test: skip failing `.include` tests in IE11

### DIFF
--- a/test/assert.js
+++ b/test/assert.js
@@ -657,7 +657,11 @@ describe('assert', function () {
 
       assert.include(set, val);
       assert.include(set, 2);
-      assert.include(set, 0);
+      if (set.has(0)) {
+        // This test is skipped in IE11 because (contrary to spec) IE11 uses
+        // SameValue instead of SameValueZero equality for sets.
+        assert.include(set, 0);
+      }
       assert.include(set, NaN);
     }
 

--- a/test/expect.js
+++ b/test/expect.js
@@ -1910,7 +1910,11 @@ describe('expect', function () {
       expect(set).to.not.include([{a: 1}]);
       expect(set).to.include(2);
       expect(set).to.not.include(3);
-      expect(set).to.include(0);
+      if (set.has(0)) {
+        // This test is skipped in IE11 because (contrary to spec) IE11 uses
+        // SameValue instead of SameValueZero equality for sets.
+        expect(set).to.include(0);
+      }
       expect(set).to.include(NaN);
     }
 

--- a/test/should.js
+++ b/test/should.js
@@ -1568,7 +1568,11 @@ describe('should', function() {
       set.should.not.include([{a: 1}]);
       set.should.include(2);
       set.should.not.include(3);
-      set.should.include(0);
+      if (set.has(0)) {
+        // This test is skipped in IE11 because (contrary to spec) IE11 uses
+        // SameValue instead of SameValueZero equality for sets.
+        set.should.include(0);
+      }
       set.should.include(NaN);
     }
 


### PR DESCRIPTION
Contrary to spec, IE11 uses SameValue instead of SameValueZero
equality for Sets.