### PR TITLE
WIP: Update `.throw` and add `.error`

### DIFF
--- a/lib/chai/core/assertions.js
+++ b/lib/chai/core/assertions.js
@@ -2380,20 +2380,24 @@ module.exports = function (chai, _) {
    * @returns Boolean
    */
   function matchError(err, errLike, errMsgMatcher) {
-    var isMatchingErrLike = true;
-    var isMatchingMessage = true;
+    if (!err) return false;
 
-    if (errLike instanceof Error) {
-      isMatchingErrLike = _.checkError.compatibleInstance(err, errLike);
-    } else if (errLike) {
-      isMatchingErrLike = _.checkError.compatibleConstructor(err, errLike);
+    if (errLike instanceof Error
+        && !_.checkError.compatibleInstance(err, errLike)) {
+      return false;
     }
 
-    if (errMsgMatcher !== undefined && errMsgMatcher !== null) {
-      isMatchingMessage = _.checkError.compatibleMessage(err, errMsgMatcher);
+    if (errLike && !_.checkError.compatibleConstructor(err, errLike)) {
+      return false;
     }
 
-    return isMatchingErrLike && isMatchingMessage;
+    if (errMsgMatcher !== undefined
+        && errMsgMatcher !== null
+        && !_.checkError.compatibleMessage(err, errMsgMatcher)) {
+      return false;
+    }
+
+    return true;
   }
 
   /*!
@@ -2430,7 +2434,7 @@ module.exports = function (chai, _) {
   }
 
   /**
-   * ### .throw([errorLike], [errMsgMatcher], [msg])
+   * ### .throw([errLike], [errMsgMatcher], [msg])
    *
    * When no arguments are provided, `.throw` invokes the target function and
    * asserts that an error is thrown.
@@ -2656,6 +2660,142 @@ module.exports = function (chai, _) {
   Assertion.addMethod('throw', assertThrows);
   Assertion.addMethod('throws', assertThrows);
   Assertion.addMethod('Throw', assertThrows);
+
+  /**
+   * ### .error([errLike], [errMsgMatcher], [msg])
+   *
+   * When no arguments are provided, `.error` asserts that the target is an
+   * instance of `Error`.
+   * 
+   *     expect(new Error('Illegal salmon!')).to.be.an.error();
+   *
+   * When one argument is provided, and it's an error constructor, `.error`
+   * asserts that the target is an instance of that error constructor.
+   *
+   *     expect(new TypeError('Illegal salmon!')).to.be.an.error(TypeError);
+   *
+   * When one argument is provided, and it's an error instance, `.error`
+   * asserts that the target is strictly (`===`) equal to that error instance.
+   *
+   *     var err = new TypeError('Illegal salmon!');
+   *
+   *     expect(err).to.be.an.error(err);
+   *
+   * When one argument is provided, and it's a string, `.error` asserts that
+   * the target is an instance of `Error` with a message that contains that
+   * string.
+   *
+   *     expect(new Error('Illegal salmon!')).to.be.an.error('salmon');
+   *
+   * When one argument is provided, and it's a regular expression, `.error`
+   * asserts that the target is an instance of `Error` with a message that
+   * matches that regular expression.
+   *
+   *     expect(new Error('Illegal salmon!')).to.be.an.error(/salmon/);
+   *
+   * When two arguments are provided, and the first is an error instance or
+   * constructor, and the second is a string or regular expression, `.error`
+   * asserts that the target fulfills both conditions as described above.
+   *
+   *     var err = new TypeError('Illegal salmon!');
+   *
+   *     expect(err).to.be.an.error(TypeError, 'salmon');
+   *     expect(err).to.be.an.error(TypeError, /salmon/);
+   *     expect(err).to.be.an.error(err, 'salmon');
+   *     expect(err).to.be.an.error(err, /salmon/);
+   *
+   * Add `.not` earlier in the chain to negate `.error`.
+   *     
+   *     expect(42).to.not.be.an.error();
+   * 
+   * However, it's dangerous to negate `.error` when providing any arguments.
+   * The problem is that it creates uncertain expectations by asserting that
+   * the target either isn't an error, or that it is an error but of a
+   * different type than the given type, or that it is an error of the given
+   * type but with a message that doesn't include the given string. It's often
+   * best to identify the exact output that's expected, and then write an
+   * assertion that only accepts that exact output.
+   *
+   * When the target isn't expected to be an error, it's often best to assert
+   * what it's expected to equal.
+   *
+   *     var myNum = 42;
+   *
+   *     expect(myNum).to.equal(42); // Recommended
+   *     expect(myNum).to.not.be.an.error(); // Not recommended
+   *
+   * When the target is expected to be an error, it's often best to assert that
+   * the error is of its expected type, and has a message that includes an
+   * expected string, rather than asserting that it doesn't have one of many
+   * unexpected types, and doesn't have a message that includes some string.
+   *
+   *     var err = new TypeError('Illegal salmon!');
+   *
+   *     expect(err).to.be.an.error(TypeError, 'salmon'); // Recommended
+   *     expect(err).to.not.be.an.error(ReferenceError, 'x'); // Not recommended
+   *
+   * `.error` accepts an optional `msg` argument which is a custom error
+   * message to show when the assertion fails. The message can also be given as
+   * the second argument to `expect`. When not providing two arguments, always
+   * use the second form.
+   *
+   *     var myNum = 42;
+   *
+   *     expect(myNum).to.be.an.error(TypeError, 'x', 'nooo why fail??');
+   *     expect(myNum, 'nooo why fail??').to.be.an.error();
+   *
+   * Due to limitations in ES5, `.error` may not always work as expected when
+   * using a transpiler such as Babel or TypeScript. In particular, it may
+   * produce unexpected results when subclassing the built-in `Error` object
+   * and then passing the subclassed constructor to `.error`. See your
+   * transpiler's docs for details:
+   *
+   * - ([Babel](https://babeljs.io/docs/usage/caveats/#classes))
+   * - ([TypeScript](https://github.com/Microsoft/TypeScript/wiki/Breaking-Changes#extending-built-ins-like-error-array-and-map-may-no-longer-work))
+   *
+   * @name error
+   * @param {Error|ErrorConstructor} errLike
+   * @param {String|RegExp} errMsgMatcher error message
+   * @param {String} msg _optional_
+   * @see https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Error#Error_types
+   * @namespace BDD
+   * @api public
+   */
+
+  Assertion.addMethod('error', function (errLike, errMsgMatcher, msg) {
+    if (msg) flag(this, 'message', msg);
+
+    var obj = flag(this, 'object')
+      , negate = Boolean(flag(this, 'negate'));
+
+    // Handle `errLike` being overloaded due to `errMsgMatcher` being given as
+    // the first argument instead of the second.
+    var errLikeType = _.type(errLike).toLowerCase();
+    if (errLikeType === 'string' || errLikeType === 'regexp') {
+      errMsgMatcher = errLike;
+      errLike = null;
+    }
+
+    // If no `errLike` is specified, use the base `Error` constructor.
+    if (errLike === null || errLike === undefined) {
+      errLike = Error;
+    }
+ 
+    // We append the expected value instead of using #{exp} because #{exp} adds
+    // single quotes around the expected value, even when it doesn't make sense
+    // (e.g., "expect [Error] to be 'a TypeError'").
+    var expectedDesc = describeExpectedError(errLike, errMsgMatcher);
+    var failMsg = 'expected #{act} to be ' + expectedDesc;
+    var negatedFailMsg = 'expected #{act} to not be ' + expectedDesc;
+
+    this.assert(
+      matchError(obj, errLike, errMsgMatcher),
+      failMsg,
+      negatedFailMsg,
+      errLike,
+      obj
+    );
+  });
 
   /**
    * ### .respondTo(method[, msg])

--- a/lib/chai/core/assertions.js
+++ b/lib/chai/core/assertions.js
@@ -2363,6 +2363,72 @@ module.exports = function (chai, _) {
   Assertion.addMethod('keys', assertKeys);
   Assertion.addMethod('key', assertKeys);
 
+  /*!
+   * Validate that `err` matches criteria represented by `errLike` and/or
+   * `errMsgMatcher`.
+   *
+   * If `errLike` is an Error object, then `err` must be strictly (`===`) equal
+   * to `errLike`. If `errLike` is an Error constructor, then `err` must be an
+   * instance of `errLike`.
+   *
+   * If `errMsgMatcher` is a string or regex, then `err`'s message must include
+   * or match `errMsgMatcher`.
+   * 
+   * @param {Error} err
+   * @param {Error|ErrorConstructor} errLike
+   * @param {String|RegExp} errMsgMatcher
+   * @returns Boolean
+   */
+  function matchError(err, errLike, errMsgMatcher) {
+    var isMatchingErrLike = true;
+    var isMatchingMessage = true;
+
+    if (errLike instanceof Error) {
+      isMatchingErrLike = _.checkError.compatibleInstance(err, errLike);
+    } else if (errLike) {
+      isMatchingErrLike = _.checkError.compatibleConstructor(err, errLike);
+    }
+
+    if (errMsgMatcher !== undefined && errMsgMatcher !== null) {
+      isMatchingMessage = _.checkError.compatibleMessage(err, errMsgMatcher);
+    }
+
+    return isMatchingErrLike && isMatchingMessage;
+  }
+
+  /*!
+   * Return a string describing what kind of error is expected based on
+   * criteria represented by `errLike` and/or `errMsgMatcher`.
+   *
+   * @param {Error|ErrorConstructor} errLike
+   * @param {String|RegExp} errMsgMatcher
+   * @returns String
+   */
+  function describeExpectedError(errLike, errMsgMatcher) {
+    if (errLike instanceof Error) {
+      return _.inspect(errLike);
+    }
+
+    var desc = '';
+    if (errLike) {
+      var constructor = _.checkError.getConstructorName(errLike);
+      var first = constructor.charAt(0).toLowerCase();
+      var article = ~[ 'a', 'e', 'i', 'o', 'u' ].indexOf(first) ? 'an ' : 'a ';
+      desc += article + constructor;
+    } else {
+      desc += 'an error';
+    }
+
+    var errMsgMatcherType = _.type(errMsgMatcher).toLowerCase();
+    if (errMsgMatcherType === 'string') {
+      desc += " including '" + errMsgMatcher + "'";
+    } else if (errMsgMatcherType === 'regexp') {
+      desc += ' matching ' + errMsgMatcher;
+    }
+
+    return desc;
+  }
+
   /**
    * ### .throw([errorLike], [errMsgMatcher], [msg])
    *
@@ -2519,7 +2585,7 @@ module.exports = function (chai, _) {
    * @name throw
    * @alias throws
    * @alias Throw
-   * @param {Error|ErrorConstructor} errorLike
+   * @param {Error|ErrorConstructor} errLike
    * @param {String|RegExp} errMsgMatcher error message
    * @param {String} msg _optional_
    * @see https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Error#Error_types
@@ -2528,128 +2594,61 @@ module.exports = function (chai, _) {
    * @api public
    */
 
-  function assertThrows (errorLike, errMsgMatcher, msg) {
+  function assertThrows (errLike, errMsgMatcher, msg) {
     if (msg) flag(this, 'message', msg);
+    _.expectTypes(this, ['function']);
+
     var obj = flag(this, 'object')
-      , ssfi = flag(this, 'ssfi')
-      , flagMsg = flag(this, 'message')
-      , negate = flag(this, 'negate') || false;
-    new Assertion(obj, flagMsg, ssfi, true).is.a('function');
+      , negate = Boolean(flag(this, 'negate'));
 
-    if (errorLike instanceof RegExp || typeof errorLike === 'string') {
-      errMsgMatcher = errorLike;
-      errorLike = null;
+    // Handle `errLike` being overloaded due to `errMsgMatcher` being given as
+    // the first argument instead of the second.
+    var errLikeType = _.type(errLike).toLowerCase();
+    if (errLikeType === 'string' || errLikeType === 'regexp') {
+      errMsgMatcher = errLike;
+      errLike = null;
     }
-
+ 
+    // Note that any type of value can be thrown, even `undefined`, so it's
+    // unreliable to use the value of `caughtErr` to determine if an error was
+    // thrown. Instead, track if an error was thrown using a separate boolean.
+    var wasErrThrown = false;
     var caughtErr;
     try {
       obj();
     } catch (err) {
+      wasErrThrown = true;
       caughtErr = err;
     }
 
-    // If we have the negate flag enabled and at least one valid argument it means we do expect an error
-    // but we want it to match a given set of criteria
-    var everyArgIsUndefined = errorLike === undefined && errMsgMatcher === undefined;
+    // We append the expected value instead of using #{exp} because #{exp} adds
+    // single quotes around the expected value, even when it doesn't make sense
+    // (e.g., "expect [Function] to throw 'a TypeError'").
+    var expectedDesc = describeExpectedError(errLike, errMsgMatcher);
+    var failMsg = 'expected #{this} to throw ' + expectedDesc;
+    var negatedFailMsg = 'expected #{this} to not throw ' + expectedDesc;
 
-    // If we've got the negate flag enabled and both args, we should only fail if both aren't compatible
-    // See Issue #551 and PR #683@GitHub
-    var everyArgIsDefined = Boolean(errorLike && errMsgMatcher);
-    var errorLikeFail = false;
-    var errMsgMatcherFail = false;
-
-    // Checking if error was thrown
-    if (everyArgIsUndefined || !everyArgIsUndefined && !negate) {
-      // We need this to display results correctly according to their types
-      var errorLikeString = 'an error';
-      if (errorLike instanceof Error) {
-        errorLikeString = '#{exp}';
-      } else if (errorLike) {
-        errorLikeString = _.checkError.getConstructorName(errorLike);
-      }
-
-      this.assert(
-          caughtErr
-        , 'expected #{this} to throw ' + errorLikeString
-        , 'expected #{this} to not throw an error but #{act} was thrown'
-        , errorLike && errorLike.toString()
-        , (caughtErr instanceof Error ?
-            caughtErr.toString() : (typeof caughtErr === 'string' ? caughtErr : caughtErr &&
-                                    _.checkError.getConstructorName(caughtErr)))
-      );
+    var doesErrMatch;
+    if (wasErrThrown) {
+      doesErrMatch = matchError(caughtErr, errLike, errMsgMatcher);
+      failMsg += ' but #{act} was thrown';
+      if (caughtErr !== errLike) {
+        negatedFailMsg += ' but #{act} was thrown';
+      } // Else, it's implicit and doesn't need to be added.
+    } else {
+      doesErrMatch = false;
+      if (expectedDesc !== 'an error') {
+        failMsg += ' but no error was thrown';
+      } // Else, it's implicit and doesn't need to be added.
     }
 
-    if (errorLike && caughtErr) {
-      // We should compare instances only if `errorLike` is an instance of `Error`
-      if (errorLike instanceof Error) {
-        var isCompatibleInstance = _.checkError.compatibleInstance(caughtErr, errorLike);
-
-        if (isCompatibleInstance === negate) {
-          // These checks were created to ensure we won't fail too soon when we've got both args and a negate
-          // See Issue #551 and PR #683@GitHub
-          if (everyArgIsDefined && negate) {
-            errorLikeFail = true;
-          } else {
-            this.assert(
-                negate
-              , 'expected #{this} to throw #{exp} but #{act} was thrown'
-              , 'expected #{this} to not throw #{exp}' + (caughtErr && !negate ? ' but #{act} was thrown' : '')
-              , errorLike.toString()
-              , caughtErr.toString()
-            );
-          }
-        }
-      }
-
-      var isCompatibleConstructor = _.checkError.compatibleConstructor(caughtErr, errorLike);
-      if (isCompatibleConstructor === negate) {
-        if (everyArgIsDefined && negate) {
-            errorLikeFail = true;
-        } else {
-          this.assert(
-              negate
-            , 'expected #{this} to throw #{exp} but #{act} was thrown'
-            , 'expected #{this} to not throw #{exp}' + (caughtErr ? ' but #{act} was thrown' : '')
-            , (errorLike instanceof Error ? errorLike.toString() : errorLike && _.checkError.getConstructorName(errorLike))
-            , (caughtErr instanceof Error ? caughtErr.toString() : caughtErr && _.checkError.getConstructorName(caughtErr))
-          );
-        }
-      }
-    }
-
-    if (caughtErr && errMsgMatcher !== undefined && errMsgMatcher !== null) {
-      // Here we check compatible messages
-      var placeholder = 'including';
-      if (errMsgMatcher instanceof RegExp) {
-        placeholder = 'matching'
-      }
-
-      var isCompatibleMessage = _.checkError.compatibleMessage(caughtErr, errMsgMatcher);
-      if (isCompatibleMessage === negate) {
-        if (everyArgIsDefined && negate) {
-            errMsgMatcherFail = true;
-        } else {
-          this.assert(
-            negate
-            , 'expected #{this} to throw error ' + placeholder + ' #{exp} but got #{act}'
-            , 'expected #{this} to throw error not ' + placeholder + ' #{exp}'
-            ,  errMsgMatcher
-            ,  _.checkError.getMessage(caughtErr)
-          );
-        }
-      }
-    }
-
-    // If both assertions failed and both should've matched we throw an error
-    if (errorLikeFail && errMsgMatcherFail) {
-      this.assert(
-        negate
-        , 'expected #{this} to throw #{exp} but #{act} was thrown'
-        , 'expected #{this} to not throw #{exp}' + (caughtErr ? ' but #{act} was thrown' : '')
-        , (errorLike instanceof Error ? errorLike.toString() : errorLike && _.checkError.getConstructorName(errorLike))
-        , (caughtErr instanceof Error ? caughtErr.toString() : caughtErr && _.checkError.getConstructorName(caughtErr))
-      );
-    }
+    this.assert(
+      doesErrMatch,
+      failMsg,
+      negatedFailMsg,
+      errLike || errMsgMatcher,
+      caughtErr
+    );
 
     flag(this, 'object', caughtErr);
   };

--- a/test/assert.js
+++ b/test/assert.js
@@ -1575,19 +1575,19 @@ describe('assert', function () {
 
       err(function () {
         assert[throws](function() { throw new Error('foo') }, TypeError);
-      }, "expected [Function] to throw 'TypeError' but 'Error: foo' was thrown")
+      }, "expected [Function] to throw a TypeError but [Error: foo] was thrown")
 
       err(function () {
         assert[throws](function() { throw new Error('foo') }, 'bar');
-      }, "expected [Function] to throw error including 'bar' but got 'foo'")
+      }, "expected [Function] to throw an error including 'bar' but [Error: foo] was thrown")
 
       err(function () {
         assert[throws](function() { throw new Error('foo') }, Error, 'bar', 'blah');
-      }, "blah: expected [Function] to throw error including 'bar' but got 'foo'")
+      }, "blah: expected [Function] to throw an Error including 'bar' but [Error: foo] was thrown")
 
       err(function () {
         assert[throws](function() { throw new Error('foo') }, TypeError, 'bar', 'blah');
-      }, "blah: expected [Function] to throw 'TypeError' but 'Error: foo' was thrown")
+      }, "blah: expected [Function] to throw a TypeError including 'bar' but [Error: foo] was thrown")
 
       err(function () {
         assert[throws](function() {});
@@ -1595,19 +1595,19 @@ describe('assert', function () {
 
       err(function () {
         assert[throws](function() { throw new Error('') }, 'bar');
-      }, "expected [Function] to throw error including 'bar' but got ''");
+      }, "expected [Function] to throw an error including 'bar' but [Error] was thrown");
 
       err(function () {
         assert[throws](function() { throw new Error('') }, /bar/);
-      }, "expected [Function] to throw error matching /bar/ but got ''");
+      }, "expected [Function] to throw an error matching /bar/ but [Error] was thrown");
 
       err(function () {
         assert[throws]({});
-      }, "expected {} to be a function");
+      }, "object tested must be a function, but object given");
 
       err(function () {
         assert[throws]({}, Error, 'testing', 'blah');
-      }, "blah: expected {} to be a function");
+      }, "blah: object tested must be a function, but object given");
     });
   });
 
@@ -1652,51 +1652,51 @@ describe('assert', function () {
 
     err(function () {
       assert.doesNotThrow(function() { throw new Error('foo'); });
-    }, "expected [Function] to not throw an error but 'Error: foo' was thrown");
+    }, "expected [Function] to not throw an error but [Error: foo] was thrown");
 
     err(function () {
       assert.doesNotThrow(function() { throw new CustomError('foo'); });
-    }, "expected [Function] to not throw an error but 'CustomError: foo' was thrown");
+    }, /expected \[Function\] to not throw an error but {.*name.*message.*} was thrown/);
 
     err(function () {
       assert.doesNotThrow(function() { throw new Error('foo'); }, Error);
-    }, "expected [Function] to not throw 'Error' but 'Error: foo' was thrown");
+    }, "expected [Function] to not throw an Error but [Error: foo] was thrown");
 
     err(function () {
       assert.doesNotThrow(function() { throw new CustomError('foo'); }, CustomError);
-    }, "expected [Function] to not throw 'CustomError' but 'CustomError: foo' was thrown");
+    }, /expected \[Function\] to not throw a CustomError but {.*name.*message.*} was thrown/);
 
     err(function () {
       assert.doesNotThrow(function() { throw new Error('foo'); }, 'foo');
-    }, "expected [Function] to throw error not including 'foo'");
+    }, "expected [Function] to not throw an error including 'foo' but [Error: foo] was thrown");
 
     err(function () {
       assert.doesNotThrow(function() { throw new Error('foo'); }, /foo/);
-    }, "expected [Function] to throw error not matching /foo/");
+    }, "expected [Function] to not throw an error matching /foo/ but [Error: foo] was thrown");
 
     err(function () {
       assert.doesNotThrow(function() { throw new Error('foo'); }, Error, 'foo', 'blah');
-    }, "blah: expected [Function] to not throw 'Error' but 'Error: foo' was thrown");
+    }, "blah: expected [Function] to not throw an Error including 'foo' but [Error: foo] was thrown");
 
     err(function () {
       assert.doesNotThrow(function() { throw new CustomError('foo'); }, CustomError, 'foo', 'blah');
-    }, "blah: expected [Function] to not throw 'CustomError' but 'CustomError: foo' was thrown");
+    }, /blah: expected \[Function\] to not throw a CustomError including 'foo' but {.*name.*message.*} was thrown/);
 
     err(function () {
       assert.doesNotThrow(function() { throw new Error(''); }, '');
-    }, "expected [Function] to throw error not including ''");
+    }, "expected [Function] to not throw an error including '' but [Error] was thrown");
 
     err(function () {
       assert.doesNotThrow(function() { throw new Error(''); }, Error, '');
-    }, "expected [Function] to not throw 'Error' but 'Error' was thrown");
+    }, "expected [Function] to not throw an Error including '' but [Error] was thrown");
 
     err(function () {
       assert.doesNotThrow({});
-    }, "expected {} to be a function");
+    }, "object tested must be a function, but object given");
 
     err(function () {
       assert.doesNotThrow({}, Error, 'testing', 'blah');
-    }, "blah: expected {} to be a function");
+    }, "blah: object tested must be a function, but object given");
   });
 
   it('ifError', function() {

--- a/test/expect.js
+++ b/test/expect.js
@@ -2755,107 +2755,107 @@ describe('expect', function () {
 
     err(function(){
       expect(goodFn, 'blah').to.throw(ReferenceError);
-    }, /^blah: expected \[Function(: goodFn)*\] to throw ReferenceError$/);
+    }, /^blah: expected \[Function(: goodFn)*\] to throw a ReferenceError but no error was thrown$/);
 
     err(function(){
       expect(goodFn, 'blah').to.throw(specificError);
-    }, /^blah: expected \[Function(: goodFn)*\] to throw 'RangeError: boo'$/);
+    }, /^blah: expected \[Function(: goodFn)*\] to throw \[RangeError: boo\] but no error was thrown$/);
 
     err(function(){
       expect(badFn, 'blah').to.not.throw();
-    }, /^blah: expected \[Function(: badFn)*\] to not throw an error but 'Error: testing' was thrown$/);
+    }, /^blah: expected \[Function(: badFn)*\] to not throw an error but \[Error: testing\] was thrown$/);
 
     err(function(){
       expect(badFn, 'blah').to.throw(ReferenceError);
-    }, /^blah: expected \[Function(: badFn)*\] to throw 'ReferenceError' but 'Error: testing' was thrown$/);
+    }, /^blah: expected \[Function(: badFn)*\] to throw a ReferenceError but \[Error: testing\] was thrown$/);
 
     err(function(){
       expect(badFn, 'blah').to.throw(specificError);
-    }, /^blah: expected \[Function(: badFn)*\] to throw 'RangeError: boo' but 'Error: testing' was thrown$/);
+    }, /^blah: expected \[Function(: badFn)*\] to throw \[RangeError: boo\] but \[Error: testing\] was thrown$/);
 
     err(function(){
       expect(badFn, 'blah').to.not.throw(Error);
-    }, /^blah: expected \[Function(: badFn)*\] to not throw 'Error' but 'Error: testing' was thrown$/);
+    }, /^blah: expected \[Function(: badFn)*\] to not throw an Error but \[Error: testing\] was thrown$/);
 
     err(function(){
       expect(refErrFn, 'blah').to.not.throw(ReferenceError);
-    }, /^blah: expected \[Function(: refErrFn)*\] to not throw 'ReferenceError' but 'ReferenceError: hello' was thrown$/);
+    }, /^blah: expected \[Function(: refErrFn)*\] to not throw a ReferenceError but \[ReferenceError: hello\] was thrown$/);
 
     err(function(){
       expect(badFn, 'blah').to.throw(PoorlyConstructedError);
-    }, /^blah: expected \[Function(: badFn)*\] to throw 'PoorlyConstructedError' but 'Error: testing' was thrown$/);
+    }, /^blah: expected \[Function(: badFn)*\] to throw a PoorlyConstructedError but \[Error: testing\] was thrown$/);
 
     err(function(){
       expect(ickyErrFn, 'blah').to.not.throw(PoorlyConstructedError);
-    }, /^blah: (expected \[Function(: ickyErrFn)*\] to not throw 'PoorlyConstructedError' but)(.*)(PoorlyConstructedError|\{ Object \()(.*)(was thrown)$/);
+    }, /^blah: expected \[Function(: ickyErrFn)*\] to not throw a PoorlyConstructedError but {.*name.*} was thrown$/);
 
     err(function(){
       expect(ickyErrFn, 'blah').to.throw(ReferenceError);
-    }, /^blah: (expected \[Function(: ickyErrFn)*\] to throw 'ReferenceError' but)(.*)(PoorlyConstructedError|\{ Object \()(.*)(was thrown)$/);
+    }, /^blah: expected \[Function(: ickyErrFn)*\] to throw a ReferenceError but {.*name.*} was thrown$/);
 
     err(function(){
       expect(specificErrFn, 'blah').to.throw(new ReferenceError('eek'));
-    }, /^blah: expected \[Function(: specificErrFn)*\] to throw 'ReferenceError: eek' but 'RangeError: boo' was thrown$/);
+    }, /^blah: expected \[Function(: specificErrFn)*\] to throw \[ReferenceError: eek\] but \[RangeError: boo\] was thrown$/);
 
     err(function(){
       expect(specificErrFn, 'blah').to.not.throw(specificError);
-    }, /^blah: expected \[Function(: specificErrFn)*\] to not throw 'RangeError: boo'$/);
+    }, /^blah: expected \[Function(: specificErrFn)*\] to not throw \[RangeError: boo\]$/);
 
     err(function (){
       expect(badFn, 'blah').to.not.throw(/testing/);
-    }, /^blah: expected \[Function(: badFn)*\] to throw error not matching \/testing\/$/);
+    }, /^blah: expected \[Function(: badFn)*\] to not throw an error matching \/testing\/ but \[Error: testing\] was thrown$/);
 
     err(function () {
       expect(badFn, 'blah').to.throw(/hello/);
-    }, /^blah: expected \[Function(: badFn)*\] to throw error matching \/hello\/ but got 'testing'$/);
+    }, /^blah: expected \[Function(: badFn)*\] to throw an error matching \/hello\/ but \[Error: testing\] was thrown$/);
 
     err(function () {
       expect(badFn).to.throw(Error, /hello/, 'blah');
-    }, /^blah: expected \[Function(: badFn)*\] to throw error matching \/hello\/ but got 'testing'$/);
+    }, /^blah: expected \[Function(: badFn)*\] to throw an Error matching \/hello\/ but \[Error: testing\] was thrown$/);
 
     err(function () {
       expect(badFn, 'blah').to.throw(Error, /hello/);
-    }, /^blah: expected \[Function(: badFn)*\] to throw error matching \/hello\/ but got 'testing'$/);
+    }, /^blah: expected \[Function(: badFn)*\] to throw an Error matching \/hello\/ but \[Error: testing\] was thrown$/);
 
     err(function () {
       expect(badFn).to.throw(Error, 'hello', 'blah');
-    }, /^blah: expected \[Function(: badFn)*\] to throw error including 'hello' but got 'testing'$/);
+    }, /^blah: expected \[Function(: badFn)*\] to throw an Error including 'hello' but \[Error: testing\] was thrown$/);
 
     err(function () {
       expect(badFn, 'blah').to.throw(Error, 'hello');
-    }, /^blah: expected \[Function(: badFn)*\] to throw error including 'hello' but got 'testing'$/);
+    }, /^blah: expected \[Function(: badFn)*\] to throw an Error including 'hello' but \[Error: testing\] was thrown$/);
 
     err(function () {
       expect(customErrFn, 'blah').to.not.throw();
-    }, /^blah: expected \[Function(: customErrFn)*\] to not throw an error but 'CustomError: foo' was thrown$/);
+    }, /^blah: expected \[Function(: customErrFn)*\] to not throw an error but {.*name.*message.*} was thrown$/);
 
     err(function(){
       expect(badFn).to.not.throw(Error, 'testing', 'blah');
-    }, /^blah: expected \[Function(: badFn)*\] to not throw 'Error' but 'Error: testing' was thrown$/);
+    }, /^blah: expected \[Function(: badFn)*\] to not throw an Error including 'testing' but \[Error: testing\] was thrown$/);
 
     err(function(){
       expect(badFn, 'blah').to.not.throw(Error, 'testing');
-    }, /^blah: expected \[Function(: badFn)*\] to not throw 'Error' but 'Error: testing' was thrown$/);
+    }, /^blah: expected \[Function(: badFn)*\] to not throw an Error including 'testing' but \[Error: testing\] was thrown$/);
 
     err(function(){
       expect(emptyStringErrFn).to.not.throw(Error, '', 'blah');
-    }, /^blah: expected \[Function(: emptyStringErrFn)*\] to not throw 'Error' but 'Error' was thrown$/);
+    }, /^blah: expected \[Function(: emptyStringErrFn)*\] to not throw an Error including '' but \[Error\] was thrown$/);
 
     err(function(){
       expect(emptyStringErrFn, 'blah').to.not.throw(Error, '');
-    }, /^blah: expected \[Function(: emptyStringErrFn)*\] to not throw 'Error' but 'Error' was thrown$/);
+    }, /^blah: expected \[Function(: emptyStringErrFn)*\] to not throw an Error including '' but \[Error\] was thrown$/);
 
     err(function(){
       expect(emptyStringErrFn, 'blah').to.not.throw('');
-    }, /^blah: expected \[Function(: emptyStringErrFn)*\] to throw error not including ''$/);
+    }, /^blah: expected \[Function(: emptyStringErrFn)*\] to not throw an error including '' but \[Error\] was thrown$/);
 
     err(function () {
       expect({}, 'blah').to.throw();
-    }, "blah: expected {} to be a function");
+    }, "blah: object tested must be a function, but object given");
 
     err(function () {
       expect({}).to.throw(Error, 'testing', 'blah');
-    }, "blah: expected {} to be a function");
+    }, "blah: object tested must be a function, but object given");
   });
 
   it('respondTo', function(){

--- a/test/expect.js
+++ b/test/expect.js
@@ -2858,6 +2858,250 @@ describe('expect', function () {
     }, "blah: object tested must be a function, but object given");
   });
 
+  describe("error", function () {
+    var specificError = new TypeError("oh noo");
+
+    // See GH-45: some poorly-constructed custom errors don't have useful names
+    // on either their constructor or their constructor prototype, but instead
+    // only set the name inside the constructor itself.
+    var PoorlyConstructedError = function (message) {
+      this.name = "PoorlyConstructedError";
+      this.message = message;
+    };
+    PoorlyConstructedError.prototype = Object.create(Error.prototype);
+
+    function CustomError(message) {
+      this.name = "CustomError";
+      this.message = message;
+    }
+    CustomError.prototype = Error.prototype;
+
+    describe("no errLike; no errMsgMatcher", function () {
+      it("passes when target is an error", function () {
+        expect(new Error()).to.be.an.error();
+        expect(new Error("oh noo")).to.be.an.error();
+        expect(new TypeError()).to.be.an.error();
+        expect(new PoorlyConstructedError()).to.be.an.error();
+        expect(new CustomError()).to.be.an.error();
+      });
+      it("fails when target isn't an error", function () {
+        err(function () {
+          expect({name: "NotAnError"}, "blah").to.be.an.error();
+        }, "blah: expected { name: 'NotAnError' } to be an Error");
+        err(function () {
+          expect("not an error", "blah").to.be.an.error();
+        }, "blah: expected 'not an error' to be an Error");
+        err(function () {
+          expect(undefined, "blah").to.be.an.error();
+        }, "blah: expected undefined to be an Error");
+      });
+    });
+    describe("errLike is TypeError; no errMsgMatcher", function () {
+      it("passes when target is a TypeError", function () {
+        expect(new TypeError()).to.be.an.error(TypeError);
+        expect(new TypeError("oh noo")).to.be.an.error(TypeError);
+      });
+      it("fails when target isn't a TypeError", function () {
+        err(function () {
+          expect(new Error(), "blah").to.be.an.error(TypeError);
+        }, "blah: expected [Error] to be a TypeError");
+        err(function () {
+          expect(new ReferenceError(), "blah").to.be.an.error(TypeError);
+        }, "blah: expected [ReferenceError] to be a TypeError");
+      });
+    });
+    describe("errLike is an error instance; no errMsgMatcher", function () {
+      it("passes when target is the same error instance", function () {
+        expect(specificError).to.be.an.error(specificError);
+      });
+      it("fails when target isn't the same error instance", function () {
+        err(function () {
+          expect(new TypeError("oh noo"), "blah").to.be.an.error(specificError);
+        }, "blah: expected [TypeError: oh noo] to be [TypeError: oh noo]");
+      });
+    });
+    describe("errLike is 'foo'; no errMsgMatcher", function () {
+      it("passes when target is an error including 'foo'", function () {
+        expect(new Error("foobar")).to.be.an.error("foo");
+        expect(new CustomError("foobar")).to.be.an.error("foo");
+      });
+      it("fails when target isn't an error including 'foo'", function () {
+        err(function () {
+          expect(new Error("oh noo"), "blah").to.be.an.error("foo");
+        }, "blah: expected [Error: oh noo] to be an Error including 'foo'");
+        err(function () {
+          expect("foobar", "blah").to.be.an.error("foo");
+        }, "blah: expected 'foobar' to be an Error including 'foo'");
+      });
+    });
+    describe("errLike is /foo/; no errMsgMatcher", function () {
+      it("passes when target is an error matching /foo/", function () {
+        expect(new Error("foobar")).to.be.an.error(/foo/);
+        expect(new CustomError("foobar")).to.be.an.error(/foo/);
+      });
+      it("fails when target isn't an error matching /foo/", function () {
+        err(function () {
+          expect(new Error("oh noo"), "blah").to.be.an.error(/foo/);
+        }, "blah: expected [Error: oh noo] to be an Error matching /foo/");
+        err(function () {
+          expect("foobar", "blah").to.be.an.error(/foo/);
+        }, "blah: expected 'foobar' to be an Error matching /foo/");
+      });
+    });
+    describe("errLike is TypeError; errMsgMatcher is 'foo'", function () {
+      it("passes when target is a TypeError including 'foo'", function () {
+        expect(new TypeError("foobar")).to.be.an.error(TypeError, "foo");
+      });
+      it("fails when target isn't a TypeError including 'foo'", function () {
+        err(function () {
+          expect(new Error("foobar")).to.be.an.error(TypeError, "foo", "blah");
+        }, "blah: expected [Error: foobar] to be a TypeError including 'foo'");
+        err(function () {
+          expect(new ReferenceError("foobar")).to.be.an.error(TypeError, "foo", "blah");
+        }, "blah: expected [ReferenceError: foobar] to be a TypeError including 'foo'");
+        err(function () {
+          expect(new TypeError("oh noo")).to.be.an.error(TypeError, "foo", "blah");
+        }, "blah: expected [TypeError: oh noo] to be a TypeError including 'foo'");
+      });
+    });
+    describe("errLike is TypeError; errMsgMatcher is /foo/", function () {
+      it("passes when target is a TypeError matching /foo/", function () {
+        expect(new TypeError("foobar")).to.be.an.error(TypeError, /foo/);
+      });
+      it("fails when target isn't a TypeError matching /foo/", function () {
+        err(function () {
+          expect(new Error("foobar")).to.be.an.error(TypeError, /foo/, "blah");
+        }, "blah: expected [Error: foobar] to be a TypeError matching /foo/");
+        err(function () {
+          expect(new ReferenceError("foobar")).to.be.an.error(TypeError, /foo/, "blah");
+        }, "blah: expected [ReferenceError: foobar] to be a TypeError matching /foo/");
+        err(function () {
+          expect(new TypeError("oh noo")).to.be.an.error(TypeError, /foo/, "blah");
+        }, "blah: expected [TypeError: oh noo] to be a TypeError matching /foo/");
+      });
+    });
+  });
+
+  describe("not.error", function () {
+    var specificError = new TypeError("oh noo");
+
+    // See GH-45: some poorly-constructed custom errors don't have useful names
+    // on either their constructor or their constructor prototype, but instead
+    // only set the name inside the constructor itself.
+    var PoorlyConstructedError = function (message) {
+      this.name = "PoorlyConstructedError";
+      this.message = message;
+    };
+    PoorlyConstructedError.prototype = Object.create(Error.prototype);
+
+    function CustomError(message) {
+      this.name = "CustomError";
+      this.message = message;
+    }
+    CustomError.prototype = Error.prototype;
+
+    describe("no errLike; no errMsgMatcher", function () {
+      it("passes when target isn't an error", function () {
+        expect({name: "NotAnError"}).to.not.be.an.error();
+        expect("not an error").to.not.be.an.error();
+        expect(undefined).to.not.be.an.error();
+      });
+      it("fails when target is an error", function () {
+        err(function () {
+          expect(new Error(), "blah").to.not.be.an.error();
+        }, "blah: expected [Error] to not be an Error");
+        err(function () {
+          expect(new Error("oh noo"), "blah").to.not.be.an.error();
+        }, "blah: expected [Error: oh noo] to not be an Error");
+        err(function () {
+          expect(new TypeError(), "blah").to.not.be.an.error();
+        }, "blah: expected [TypeError] to not be an Error");
+        err(function () {
+          expect(new PoorlyConstructedError(), "blah").to.not.be.an.error();
+        }, /blah: expected {.*name.*} to not be an Error/);
+        err(function () {
+          expect(new CustomError(), "blah").to.not.be.an.error();
+        }, /blah: expected {.*name.*} to not be an Error/);
+      });
+    });
+    describe("errLike is TypeError; no errMsgMatcher", function () {
+      it("passes when target isn't a TypeError", function () {
+        expect(new Error()).to.not.be.an.error(TypeError);
+        expect(new ReferenceError()).to.not.be.an.error(TypeError);
+      });
+      it("fails when target is a TypeError", function () {
+        err(function () {
+          expect(new TypeError(), "blah").to.not.be.an.error(TypeError);
+        }, "blah: expected [TypeError] to not be a TypeError");
+        err(function () {
+          expect(new TypeError("oh noo"), "blah").to.not.be.an.error(TypeError);
+        }, "blah: expected [TypeError: oh noo] to not be a TypeError");
+      });
+    });
+    describe("errLike is an error instance; no errMsgMatcher", function () {
+      it("passes when target isn't the same error instance", function () {
+        expect(new TypeError("oh noo")).to.not.be.an.error(specificError);
+      });
+      it("fails when target is the same error instance", function () {
+        err(function () {
+          expect(specificError, "blah").to.not.be.an.error(specificError);
+        }, "blah: expected [TypeError: oh noo] to not be [TypeError: oh noo]");
+      });
+    });
+    describe("errLike is 'foo'; no errMsgMatcher", function () {
+      it("passes when target isn't an error including 'foo'", function () {
+        expect(new Error("oh noo")).to.not.be.an.error("foo");
+        expect("foobar").to.not.be.an.error("foo");
+      });
+      it("fails when target is an error including 'foo'", function () {
+        err(function () {
+          expect(new Error("foobar"), "blah").to.not.be.an.error("foo");
+        }, "blah: expected [Error: foobar] to not be an Error including 'foo'");
+        err(function () {
+          expect(new CustomError("foobar"), "blah").to.not.be.an.error("foo");
+        }, /blah: expected {.*name.*message.*} to not be an Error including 'foo'/);
+      });
+    });
+    describe("errLike is /foo/; no errMsgMatcher", function () {
+      it("passes when target isn't an error matching /foo/", function () {
+        expect(new Error("oh noo")).to.not.be.an.error(/foo/);
+        expect("foobar").to.not.be.an.error(/foo/);
+      });
+      it("fails when target is an error matching /foo/", function () {
+        err(function () {
+          expect(new Error("foobar"), "blah").to.not.be.an.error(/foo/);
+        }, "blah: expected [Error: foobar] to not be an Error matching /foo/");
+        err(function () {
+          expect(new CustomError("foobar"), "blah").to.not.be.an.error(/foo/);
+        }, /blah: expected {.*name.*message.*} to not be an Error matching \/foo\//);
+      });
+    });
+    describe("errLike is TypeError; errMsgMatcher is 'foo'", function () {
+      it("passes when target isn't a TypeError including 'foo'", function () {
+        expect(new Error("foobar")).to.not.be.an.error(TypeError, "foo");
+        expect(new ReferenceError("foobar")).to.not.be.an.error(TypeError, "foo");
+        expect(new TypeError("oh noo")).to.not.be.an.error(TypeError, "foo");
+      });
+      it("fails when target is a TypeError including 'foo'", function () {
+        err(function () {
+          expect(new TypeError("foobar")).to.not.be.an.error(TypeError, "foo", "blah");
+        }, "blah: expected [TypeError: foobar] to not be a TypeError including 'foo'");
+      });
+    });
+    describe("errLike is TypeError; errMsgMatcher is /foo/", function () {
+      it("passes when target isn't a TypeError matching /foo/", function () {
+        expect(new Error("foobar")).to.not.be.an.error(TypeError, /foo/);
+        expect(new ReferenceError("foobar")).to.not.be.an.error(TypeError, /foo/);
+        expect(new TypeError("oh noo")).to.not.be.an.error(TypeError, /foo/);
+      });
+      it("fails when target is a TypeError matching /foo/", function () {
+        err(function () {
+          expect(new TypeError("foobar")).to.not.be.an.error(TypeError, /foo/, "blah");
+        }, "blah: expected [TypeError: foobar] to not be a TypeError matching /foo/");
+      });
+    });
+  });
+
   it('respondTo', function(){
     function Foo(){};
     Foo.prototype.bar = function(){};

--- a/test/should.js
+++ b/test/should.js
@@ -2451,6 +2451,246 @@ describe('should', function() {
     }, "blah: object tested must be a function, but object given");
   });
 
+  describe("error", function () {
+    var specificError = new TypeError("oh noo");
+
+    // See GH-45: some poorly-constructed custom errors don't have useful names
+    // on either their constructor or their constructor prototype, but instead
+    // only set the name inside the constructor itself.
+    var PoorlyConstructedError = function (message) {
+      this.name = "PoorlyConstructedError";
+      this.message = message;
+    };
+    PoorlyConstructedError.prototype = Object.create(Error.prototype);
+
+    function CustomError(message) {
+      this.name = "CustomError";
+      this.message = message;
+    }
+    CustomError.prototype = Error.prototype;
+
+    describe("no errLike; no errMsgMatcher", function () {
+      it("passes when target is an error", function () {
+        (new Error()).should.be.an.error();
+        (new Error("oh noo")).should.be.an.error();
+        (new TypeError()).should.be.an.error();
+        (new PoorlyConstructedError()).should.be.an.error();
+        (new CustomError()).should.be.an.error();
+      });
+      it("fails when target isn't an error", function () {
+        err(function () {
+          ({name: "NotAnError"}).should.be.an.error();
+        }, "expected { name: 'NotAnError' } to be an Error");
+        err(function () {
+          "not an error".should.be.an.error();
+        }, "expected 'not an error' to be an Error");
+      });
+    });
+    describe("errLike is TypeError; no errMsgMatcher", function () {
+      it("passes when target is a TypeError", function () {
+        (new TypeError()).should.be.an.error(TypeError);
+        (new TypeError("oh noo")).should.be.an.error(TypeError);
+      });
+      it("fails when target isn't a TypeError", function () {
+        err(function () {
+          (new Error()).should.be.an.error(TypeError);
+        }, "expected [Error] to be a TypeError");
+        err(function () {
+          (new ReferenceError()).should.be.an.error(TypeError);
+        }, "expected [ReferenceError] to be a TypeError");
+      });
+    });
+    describe("errLike is an error instance; no errMsgMatcher", function () {
+      it("passes when target is the same error instance", function () {
+        specificError.should.be.an.error(specificError);
+      });
+      it("fails when target isn't the same error instance", function () {
+        err(function () {
+          (new TypeError("oh noo")).should.be.an.error(specificError);
+        }, "expected [TypeError: oh noo] to be [TypeError: oh noo]");
+      });
+    });
+    describe("errLike is 'foo'; no errMsgMatcher", function () {
+      it("passes when target is an error including 'foo'", function () {
+        (new Error("foobar")).should.be.an.error("foo");
+        (new CustomError("foobar")).should.be.an.error("foo");
+      });
+      it("fails when target isn't an error including 'foo'", function () {
+        err(function () {
+          (new Error("oh noo")).should.be.an.error("foo");
+        }, "expected [Error: oh noo] to be an Error including 'foo'");
+        err(function () {
+          "foobar".should.be.an.error("foo");
+        }, "expected 'foobar' to be an Error including 'foo'");
+      });
+    });
+    describe("errLike is /foo/; no errMsgMatcher", function () {
+      it("passes when target is an error matching /foo/", function () {
+        (new Error("foobar")).should.be.an.error(/foo/);
+        (new CustomError("foobar")).should.be.an.error(/foo/);
+      });
+      it("fails when target isn't an error matching /foo/", function () {
+        err(function () {
+          (new Error("oh noo")).should.be.an.error(/foo/);
+        }, "expected [Error: oh noo] to be an Error matching /foo/");
+        err(function () {
+          "foobar".should.be.an.error(/foo/);
+        }, "expected 'foobar' to be an Error matching /foo/");
+      });
+    });
+    describe("errLike is TypeError; errMsgMatcher is 'foo'", function () {
+      it("passes when target is a TypeError including 'foo'", function () {
+        (new TypeError("foobar")).should.be.an.error(TypeError, "foo");
+      });
+      it("fails when target isn't a TypeError including 'foo'", function () {
+        err(function () {
+          (new Error("foobar")).should.be.an.error(TypeError, "foo", "blah");
+        }, "blah: expected [Error: foobar] to be a TypeError including 'foo'");
+        err(function () {
+          (new ReferenceError("foobar")).should.be.an.error(TypeError, "foo", "blah");
+        }, "blah: expected [ReferenceError: foobar] to be a TypeError including 'foo'");
+        err(function () {
+          (new TypeError("oh noo")).should.be.an.error(TypeError, "foo", "blah");
+        }, "blah: expected [TypeError: oh noo] to be a TypeError including 'foo'");
+      });
+    });
+    describe("errLike is TypeError; errMsgMatcher is /foo/", function () {
+      it("passes when target is a TypeError matching /foo/", function () {
+        (new TypeError("foobar")).should.be.an.error(TypeError, /foo/);
+      });
+      it("fails when target isn't a TypeError matching /foo/", function () {
+        err(function () {
+          (new Error("foobar")).should.be.an.error(TypeError, /foo/, "blah");
+        }, "blah: expected [Error: foobar] to be a TypeError matching /foo/");
+        err(function () {
+          (new ReferenceError("foobar")).should.be.an.error(TypeError, /foo/, "blah");
+        }, "blah: expected [ReferenceError: foobar] to be a TypeError matching /foo/");
+        err(function () {
+          (new TypeError("oh noo")).should.be.an.error(TypeError, /foo/, "blah");
+        }, "blah: expected [TypeError: oh noo] to be a TypeError matching /foo/");
+      });
+    });
+  });
+
+  describe("not.error", function () {
+    var specificError = new TypeError("oh noo");
+
+    // See GH-45: some poorly-constructed custom errors don't have useful names
+    // on either their constructor or their constructor prototype, but instead
+    // only set the name inside the constructor itself.
+    var PoorlyConstructedError = function (message) {
+      this.name = "PoorlyConstructedError";
+      this.message = message;
+    };
+    PoorlyConstructedError.prototype = Object.create(Error.prototype);
+
+    function CustomError(message) {
+      this.name = "CustomError";
+      this.message = message;
+    }
+    CustomError.prototype = Error.prototype;
+
+    describe("no errLike; no errMsgMatcher", function () {
+      it("passes when target isn't an error", function () {
+        ({name: "NotAnError"}).should.not.be.an.error();
+        "not an error".should.not.be.an.error();
+      });
+      it("fails when target is an error", function () {
+        err(function () {
+          (new Error()).should.not.be.an.error();
+        }, "expected [Error] to not be an Error");
+        err(function () {
+          (new Error("oh noo")).should.not.be.an.error();
+        }, "expected [Error: oh noo] to not be an Error");
+        err(function () {
+          (new TypeError()).should.not.be.an.error();
+        }, "expected [TypeError] to not be an Error");
+        err(function () {
+          (new PoorlyConstructedError()).should.not.be.an.error();
+        }, /expected {.*name.*} to not be an Error/);
+        err(function () {
+          (new CustomError()).should.not.be.an.error();
+        }, /expected {.*name.*} to not be an Error/);
+      });
+    });
+    describe("errLike is TypeError; no errMsgMatcher", function () {
+      it("passes when target isn't a TypeError", function () {
+        (new Error()).should.not.be.an.error(TypeError);
+        (new ReferenceError()).should.not.be.an.error(TypeError);
+      });
+      it("fails when target is a TypeError", function () {
+        err(function () {
+          (new TypeError()).should.not.be.an.error(TypeError);
+        }, "expected [TypeError] to not be a TypeError");
+        err(function () {
+          (new TypeError("oh noo")).should.not.be.an.error(TypeError);
+        }, "expected [TypeError: oh noo] to not be a TypeError");
+      });
+    });
+    describe("errLike is an error instance; no errMsgMatcher", function () {
+      it("passes when target isn't the same error instance", function () {
+        (new TypeError("oh noo")).should.not.be.an.error(specificError);
+      });
+      it("fails when target is the same error instance", function () {
+        err(function () {
+          specificError.should.not.be.an.error(specificError);
+        }, "expected [TypeError: oh noo] to not be [TypeError: oh noo]");
+      });
+    });
+    describe("errLike is 'foo'; no errMsgMatcher", function () {
+      it("passes when target isn't an error including 'foo'", function () {
+        (new Error("oh noo")).should.not.be.an.error("foo");
+        "foobar".should.not.be.an.error("foo");
+      });
+      it("fails when target is an error including 'foo'", function () {
+        err(function () {
+          (new Error("foobar")).should.not.be.an.error("foo");
+        }, "expected [Error: foobar] to not be an Error including 'foo'");
+        err(function () {
+          (new CustomError("foobar")).should.not.be.an.error("foo");
+        }, /expected {.*name.*message.*} to not be an Error including 'foo'/);
+      });
+    });
+    describe("errLike is /foo/; no errMsgMatcher", function () {
+      it("passes when target isn't an error matching /foo/", function () {
+        (new Error("oh noo")).should.not.be.an.error(/foo/);
+        ("foobar").should.not.be.an.error(/foo/);
+      });
+      it("fails when target is an error matching /foo/", function () {
+        err(function () {
+          (new Error("foobar")).should.not.be.an.error(/foo/);
+        }, "expected [Error: foobar] to not be an Error matching /foo/");
+        err(function () {
+          (new CustomError("foobar")).should.not.be.an.error(/foo/);
+        }, /expected {.*name.*message.*} to not be an Error matching \/foo\//);
+      });
+    });
+    describe("errLike is TypeError; errMsgMatcher is 'foo'", function () {
+      it("passes when target isn't a TypeError including 'foo'", function () {
+        (new Error("foobar")).should.not.be.an.error(TypeError, "foo");
+        (new ReferenceError("foobar")).should.not.be.an.error(TypeError, "foo");
+        (new TypeError("oh noo")).should.not.be.an.error(TypeError, "foo");
+      });
+      it("fails when target is a TypeError including 'foo'", function () {
+        err(function () {
+          (new TypeError("foobar")).should.not.be.an.error(TypeError, "foo", "blah");
+        }, "blah: expected [TypeError: foobar] to not be a TypeError including 'foo'");
+      });
+    });
+    describe("errLike is TypeError; errMsgMatcher is /foo/", function () {
+      it("passes when target isn't a TypeError matching /foo/", function () {
+        (new Error("foobar")).should.not.be.an.error(TypeError, /foo/);
+        (new ReferenceError("foobar")).should.not.be.an.error(TypeError, /foo/);
+        (new TypeError("oh noo")).should.not.be.an.error(TypeError, /foo/);
+      });
+      it("fails when target is a TypeError matching /foo/", function () {
+        err(function () {
+          (new TypeError("foobar")).should.not.be.an.error(TypeError, /foo/, "blah");
+        }, "blah: expected [TypeError: foobar] to not be a TypeError matching /foo/");
+      });
+    });
+  });
+
   it('respondTo', function(){
     function Foo(){};
     Foo.prototype.bar = function(){};

--- a/test/should.js
+++ b/test/should.js
@@ -279,11 +279,11 @@ describe('should', function() {
 
     err(function () {
       should.Throw(function () { throw new Error('error!') }, Error, 'needed user!', 'blah');
-    }, "blah: expected [Function] to throw error including 'needed user!' but got 'error!'");
+    }, "blah: expected [Function] to throw an Error including 'needed user!' but [Error: error!] was thrown");
 
     err(function () {
       should.not.Throw(function () { throw new Error('error!') }, Error, 'error!', 'blah');
-    }, "blah: expected [Function] to not throw 'Error' but 'Error: error!' was thrown");
+    }, "blah: expected [Function] to not throw an Error including 'error!' but [Error: error!] was thrown");
   });
 
   it('true', function(){
@@ -2348,27 +2348,27 @@ describe('should', function() {
 
     err(function(){
       (goodFn).should.throw(ReferenceError);
-    }, /^expected \[Function(: goodFn)*\] to throw ReferenceError$/);
+    }, /^expected \[Function(: goodFn)*\] to throw a ReferenceError but no error was thrown$/);
 
     err(function(){
       (goodFn).should.throw(specificError);
-    }, /^expected \[Function(: goodFn)*\] to throw 'RangeError: boo'$/);
+    }, /^expected \[Function(: goodFn)*\] to throw \[RangeError: boo\] but no error was thrown$/);
 
     err(function(){
       (badFn).should.not.throw();
-    }, /^expected \[Function(: badFn)*\] to not throw an error but 'Error: testing' was thrown$/);
+    }, /^expected \[Function(: badFn)*\] to not throw an error but \[Error: testing\] was thrown$/);
 
     err(function(){
       (badFn).should.throw(ReferenceError);
-    }, /^expected \[Function(: badFn)*\] to throw 'ReferenceError' but 'Error: testing' was thrown$/);
+    }, /^expected \[Function(: badFn)*\] to throw a ReferenceError but \[Error: testing\] was thrown$/);
 
     err(function(){
       (badFn).should.throw(specificError);
-    }, /^expected \[Function(: badFn)*\] to throw 'RangeError: boo' but 'Error: testing' was thrown$/);
+    }, /^expected \[Function(: badFn)*\] to throw \[RangeError: boo\] but \[Error: testing\] was thrown$/);
 
     err(function(){
       (badFn).should.not.throw(Error);
-    }, /^expected \[Function(: badFn)*\] to not throw 'Error' but 'Error: testing' was thrown$/);
+    }, /^expected \[Function(: badFn)*\] to not throw an Error but \[Error: testing\] was thrown$/);
 
     err(function(){
       (stringErrFn).should.not.throw();
@@ -2376,79 +2376,79 @@ describe('should', function() {
 
     err(function(){
       (stringErrFn).should.throw(ReferenceError);
-    }, /^expected \[Function(: stringErrFn)*\] to throw 'ReferenceError' but 'testing' was thrown$/);
+    }, /^expected \[Function(: stringErrFn)*\] to throw a ReferenceError but 'testing' was thrown$/);
 
     err(function(){
       (stringErrFn).should.throw(specificError);
-    }, /^expected \[Function(: stringErrFn)*\] to throw 'RangeError: boo' but 'testing' was thrown$/);
+    }, /^expected \[Function(: stringErrFn)*\] to throw \[RangeError: boo\] but 'testing' was thrown$/);
 
     err(function(){
       (stringErrFn).should.not.throw('testing');
-    }, /^expected \[Function(: stringErrFn)*\] to throw error not including 'testing'$/);
+    }, /^expected \[Function(: stringErrFn)*\] to not throw an error including 'testing' but 'testing' was thrown$/);
 
     err(function(){
       (refErrFn).should.not.throw(ReferenceError);
-    }, /^expected \[Function(: refErrFn)*\] to not throw 'ReferenceError' but 'ReferenceError: hello' was thrown$/);
+    }, /^expected \[Function(: refErrFn)*\] to not throw a ReferenceError but \[ReferenceError: hello\] was thrown$/);
 
     err(function(){
       (badFn).should.throw(PoorlyConstructedError);
-    }, /^expected \[Function(: badFn)*\] to throw 'PoorlyConstructedError' but 'Error: testing' was thrown$/);
+    }, /^expected \[Function(: badFn)*\] to throw a PoorlyConstructedError but \[Error: testing\] was thrown$/);
 
     err(function(){
       (ickyErrFn).should.not.throw(PoorlyConstructedError);
-    }, /^(expected \[Function(: ickyErrFn)*\] to not throw 'PoorlyConstructedError' but)(.*)(PoorlyConstructedError|\{ Object \()(.*)(was thrown)$/);
+    }, /^expected \[Function(: ickyErrFn)*\] to not throw a PoorlyConstructedError but {.*name.*} was thrown$/);
 
     err(function(){
       (ickyErrFn).should.throw(ReferenceError);
-    }, /^(expected \[Function(: ickyErrFn)*\] to throw 'ReferenceError' but)(.*)(PoorlyConstructedError|\{ Object \()(.*)(was thrown)$/);
+    }, /^expected \[Function(: ickyErrFn)*\] to throw a ReferenceError but {.*name.*} was thrown$/);
 
     err(function(){
       (specificErrFn).should.throw(new ReferenceError('eek'));
-    }, /^expected \[Function(: specificErrFn)*\] to throw 'ReferenceError: eek' but 'RangeError: boo' was thrown$/);
+    }, /^expected \[Function(: specificErrFn)*\] to throw \[ReferenceError: eek\] but \[RangeError: boo\] was thrown$/);
 
     err(function(){
       (specificErrFn).should.not.throw(specificError);
-    }, /^expected \[Function(: specificErrFn)*\] to not throw 'RangeError: boo'$/);
+    }, /^expected \[Function(: specificErrFn)*\] to not throw \[RangeError: boo\]$/);
 
     err(function (){
       (badFn).should.not.throw(/testing/);
-    }, /^expected \[Function(: badFn)*\] to throw error not matching \/testing\/$/);
+    }, /^expected \[Function(: badFn)*\] to not throw an error matching \/testing\/ but \[Error: testing\] was thrown$/);
 
     err(function () {
       (badFn).should.throw(/hello/);
-    }, /^expected \[Function(: badFn)*\] to throw error matching \/hello\/ but got \'testing\'$/);
+    }, /^expected \[Function(: badFn)*\] to throw an error matching \/hello\/ but \[Error: testing\] was thrown$/);
 
     err(function () {
       (badFn).should.throw(Error, /hello/, 'blah');
-    }, /^blah: expected \[Function(: badFn)*\] to throw error matching \/hello\/ but got 'testing'$/);
+    }, /^blah: expected \[Function(: badFn)*\] to throw an Error matching \/hello\/ but \[Error: testing\] was thrown$/);
 
     err(function () {
       (badFn).should.throw(Error, 'hello', 'blah');
-    }, /^blah: expected \[Function(: badFn)*\] to throw error including 'hello' but got 'testing'$/);
+    }, /^blah: expected \[Function(: badFn)*\] to throw an Error including 'hello' but \[Error: testing\] was thrown$/);
 
     err(function () {
       (customErrFn).should.not.throw();
-    }, /^expected \[Function(: customErrFn)*\] to not throw an error but 'CustomError: foo' was thrown$/);
+    }, /^expected \[Function(: customErrFn)*\] to not throw an error but {.*name.*message.*} was thrown$/);
 
     err(function(){
       (badFn).should.not.throw(Error, 'testing');
-    }, /^expected \[Function(: badFn)*\] to not throw 'Error' but 'Error: testing' was thrown$/);
+    }, /^expected \[Function(: badFn)*\] to not throw an Error including 'testing' but \[Error: testing\] was thrown$/);
 
     err(function(){
       (emptyStringErrFn).should.not.throw(Error, '');
-    }, /^expected \[Function(: emptyStringErrFn)*\] to not throw 'Error' but 'Error' was thrown$/);
+    }, /^expected \[Function(: emptyStringErrFn)*\] to not throw an Error including '' but \[Error\] was thrown$/);
 
     err(function(){
       (emptyStringErrFn).should.not.throw('');
-    }, /^expected \[Function(: emptyStringErrFn)*\] to throw error not including ''$/);
+    }, /^expected \[Function(: emptyStringErrFn)*\] to not throw an error including '' but \[Error\] was thrown$/);
 
     err(function () {
       ({}).should.throw();
-    }, "expected {} to be a function");
+    }, "object tested must be a function, but object given");
 
     err(function () {
       ({}).should.throw(Error, 'testing', 'blah');
-    }, "blah: expected {} to be a function");
+    }, "blah: object tested must be a function, but object given");
   });
 
   it('respondTo', function(){


### PR DESCRIPTION
# **DO NOT MERGE; THIS IS A WORK IN PROGRESS!!**

I've been doing a lot of work on #930. This turned out to be a lot harder than expected; `.throw` couldn't be updated to simply call `.error` internally due to the difference in failed assertion messages between the two. I suspect this is the same kind of issue causing problems in plugins like `chai-as-promised` when they try to adapt `.throw`.

The more I looked at our current `.throw` implementation, the more I realized that the complexity wasn't because of negation as we originally thought but rather because of how the failed assertion messages were being composed. As a result, this PR turned into a pretty big refactor of `.throw` to reduce complexity. This also required changing some of `.throw`'s failed assertion messages to be more consistent.

Some notes/thoughts:

- This PR currently only adds `.error` to the BDD interface. I'll add the Assert interface later.
- Is changing a failed assertion message considered a breaking change? On the one hand, it's likely to break the tests of any plugins that do string matching against failed assertion messages. On the other hand, it's unlikely to break the actual functionality of the plugin from the end user's perspective, or any of the end user's tests. I'm currently learning toward "no".
- The `matchError` and `decribeExpectedError` helper functions should probably be moved to the `check-error` module.
- Part of what `.throw` does is assert that a function throws, without taking into account what it throws. This means it will work if the target function throws something besides an `Error` object (e.g., a string, a number, `null`, or even `undefined`). I think it's important that the `.throw` logic retain this base functionality. However, when it comes to adding arguments to the `.throw` function to perform additional assertions on the value that was thrown, I think we should consider requiring that the object thrown be an `Error` object. Currently, the behavior of the various `check-error` functions is a little sketchy if the object being tested isn't an `Error`. This problem carries over into the `matchError` helper function as well.