### PR TITLE
Add `configs` to the use function

### DIFF
--- a/lib/chai.js
+++ b/lib/chai.js
@@ -10,7 +10,7 @@ var used = [];
  * Chai version
  */
 
-exports.version = '4.1.1';
+exports.version = '4.2.1';
 
 /*!
  * Assertion Error
@@ -34,9 +34,9 @@ var util = require('./chai/utils');
  * @api public
  */
 
-exports.use = function (fn) {
+exports.use = function (fn, configs) {
   if (!~used.indexOf(fn)) {
-    fn(exports, util);
+    fn(exports, util, configs);
     used.push(fn);
   }
 


### PR DESCRIPTION
Added `configs` parameter to the `use` function.

Example:
```
import myChaiLibrary from '...';
chai.use(myChaiLibrary, configs)
```
The `used` function now can accept a 3rd parameter, which is the passed settings:

```
function myChaiLibrary(_chai, utils, configs) {

}
```

This adds a nice way to pass configs, rather than writing use then adding `chai.myChaiLibrary.someConfig = true` for example.

Additionally, sometimes, like in my library case, i have some required configs i need during the `use` function call, now i have to create a factory function which accepts the configs, then i have to call the use on the result of the setup. I prefer this way.


Cheers!

