### PR TITLE
Use a hardcoded no-op instead of instancing

### DIFF
--- a/lib/chai/utils/addProperty.js
+++ b/lib/chai/utils/addProperty.js
@@ -36,7 +36,7 @@ var transferFlags = require('./transferFlags');
  */
 
 module.exports = function addProperty(ctx, name, getter) {
-  getter = getter === undefined ? new Function() : getter;
+  getter = getter === undefined ? function () {} : getter;
 
   Object.defineProperty(ctx, name,
     { get: function propertyGetter() {


### PR DESCRIPTION
Using `new Function()` is considered unsafe evaluation, which means it breaks if executed in an environment with a strict Content Security Policy (CSP).

In my case, it's causing an EvalError for a [test-runner](https://github.com/Alhadis/Atom-Mocha) I wrote for [Atom](https://atom.io/):

~~~
EvalError: Refused to evaluate a string as JavaScript because 'unsafe-eval' is not an allowed source of script in the following Content Security Policy directive: "script-src 'self'".

	at new Function (<anonymous>)
	at Object.addProperty (/Users/johngardner/Labs/Atom-Mocha/node_modules/chai/lib/chai/utils/addProperty.js:39:35)
	at Function.Assertion.addProperty (/Users/johngardner/Labs/Atom-Mocha/node_modules/chai/lib/chai/assertion.js:94:10)
	at /Users/johngardner/Labs/Atom-Mocha/node_modules/chai/lib/chai/core/assertions.js:46:15
	at Array.forEach (native)
	at module.exports (/Users/johngardner/Labs/Atom-Mocha/node_modules/chai/lib/chai/core/assertions.js:45:35)
	at Object.exports.use (/Users/johngardner/Labs/Atom-Mocha/node_modules/chai/lib/chai.js:39:5)
	at Object.<anonymous> (/Users/johngardner/Labs/Atom-Mocha/node_modules/chai/lib/chai.js:71:9)
	at Object.<anonymous> (/Users/johngardner/Labs/Atom-Mocha/node_modules/chai/lib/chai.js:94:3)
	at Module._compile (/Applications/Atom.app/Contents/Resources/app/src/native-compile-cache.js:87:30)
	at Object.value [as .js] (/Applications/Atom.app/Contents/Resources/app/src/compile-cache.js:234:23)
	at Module.load (module.js:488:32)
	at tryModuleLoad (module.js:447:12)
	at Function.Module._load (module.js:439:3)
	at Module.require (module.js:498:17)
	at require (/Applications/Atom.app/Contents/Resources/app/src/native-compile-cache.js:47:27)
	at Object.<anonymous> (/Users/johngardner/Labs/Atom-Mocha/node_modules/chai/index.js:1:173)
	at Object.<anonymous> (/Users/johngardner/Labs/Atom-Mocha/node_modules/chai/index.js:3:3)
	at Module._compile (/Applications/Atom.app/Contents/Resources/app/src/native-compile-cache.js:87:30)
	at Object.value [as .js] (/Applications/Atom.app/Contents/Resources/app/src/compile-cache.js:234:23)
	at Module.load (module.js:488:32)
	at tryModuleLoad (module.js:447:12)
	at Function.Module._load (module.js:439:3)
	at Module.require (module.js:498:17)
	at require (/Applications/Atom.app/Contents/Resources/app/src/native-compile-cache.js:47:27)
	at Object.<anonymous> (/Users/johngardner/Labs/Atom-Mocha/lib/main.js:6:18)
	at Object.<anonymous> (/Users/johngardner/Labs/Atom-Mocha/lib/main.js:527:3)
	at Module._compile (/Applications/Atom.app/Contents/Resources/app/src/native-compile-cache.js:87:30)
	at Object.value [as .js] (/Applications/Atom.app/Contents/Resources/app/src/compile-cache.js:234:23)
	at Module.load (module.js:488:32)
handleSetupError @ index.js:87
~~~

This is only being used to provide a no-op function, so there's no need to use `new Function()` when an anonymous function will suffice.