### PR TITLE
property assertion should only accept strings if nested, fixes #1043

### DIFF
--- a/lib/chai/core/assertions.js
+++ b/lib/chai/core/assertions.js
@@ -1770,11 +1770,19 @@ module.exports = function (chai, _) {
 
     if (isNested) {
       if (nameType !== 'string') {
-        throw new AssertionError(flagMsg + 'the argument to property must be a string when using nested syntax');
+        throw new AssertionError(
+          flagMsg + 'the argument to property must be a string when using nested syntax',
+          undefined,
+          ssfi
+        );
       }
     } else {
       if (nameType !== 'string' && nameType !== 'number' && nameType !== 'symbol') {
-        throw new AssertionError(flagMsg + ' the argument to property must be a string, number, or symbol');
+        throw new AssertionError(
+          flagMsg + 'the argument to property must be a string, number, or symbol',
+          undefined,
+          ssfi
+        );
       }
     }
 

--- a/lib/chai/core/assertions.js
+++ b/lib/chai/core/assertions.js
@@ -1765,14 +1765,13 @@ module.exports = function (chai, _) {
       , obj = flag(this, 'object')
       , ssfi = flag(this, 'ssfi');
 
+    flagMsg = flagMsg ? flagMsg + ': ' : '';
+
     if (typeof name !== 'string' && isNested) {
-      var msgPrefix = flag(this, 'message')
-      msgPrefix = msgPrefix ? msgPrefix + ': ' : ''
-      throw new AssertionError(msgPrefix + 'the argument to `property` must be a string')
+      throw new AssertionError(flagMsg + 'the argument to `property` must be a string')
     }
 
     if (isNested && isOwn) {
-      flagMsg = flagMsg ? flagMsg + ': ' : '';
       throw new AssertionError(
         flagMsg + 'The "nested" and "own" flags cannot be combined.',
         undefined,
@@ -1781,7 +1780,6 @@ module.exports = function (chai, _) {
     }
 
     if (obj === null || obj === undefined) {
-      flagMsg = flagMsg ? flagMsg + ': ' : '';
       throw new AssertionError(
         flagMsg + 'Target cannot be null or undefined.',
         undefined,

--- a/lib/chai/core/assertions.js
+++ b/lib/chai/core/assertions.js
@@ -1770,11 +1770,11 @@ module.exports = function (chai, _) {
 
     if (isNested) {
       if (nameType !== 'string') {
-        throw new AssertionError(flagMsg + 'the argument to `property` must be a string');
+        throw new AssertionError(flagMsg + 'the argument to property must be a string when using nested syntax');
       }
     } else {
       if (nameType !== 'string' && nameType !== 'number' && nameType !== 'symbol') {
-        throw new AssertionError(flagMsg + 'the argument to `property` must be either of type string, number or symbol');
+        throw new AssertionError(flagMsg + ' the argument to property must be a string, number, or symbol');
       }
     }
 

--- a/lib/chai/core/assertions.js
+++ b/lib/chai/core/assertions.js
@@ -1763,12 +1763,19 @@ module.exports = function (chai, _) {
       , isOwn = flag(this, 'own')
       , flagMsg = flag(this, 'message')
       , obj = flag(this, 'object')
-      , ssfi = flag(this, 'ssfi');
+      , ssfi = flag(this, 'ssfi')
+      , nameType = typeof name;
 
     flagMsg = flagMsg ? flagMsg + ': ' : '';
 
-    if (typeof name !== 'string' && isNested) {
-      throw new AssertionError(flagMsg + 'the argument to `property` must be a string')
+    if (isNested) {
+      if (nameType !== 'string') {
+        throw new AssertionError(flagMsg + 'the argument to `property` must be a string');
+      }
+    } else {
+      if (nameType !== 'string' && nameType !== 'number' && nameType !== 'symbol') {
+        throw new AssertionError(flagMsg + 'the argument to `property` must be either of type string, number or symbol');
+      }
     }
 
     if (isNested && isOwn) {

--- a/lib/chai/core/assertions.js
+++ b/lib/chai/core/assertions.js
@@ -1765,6 +1765,12 @@ module.exports = function (chai, _) {
       , obj = flag(this, 'object')
       , ssfi = flag(this, 'ssfi');
 
+    if (typeof name !== 'string' && isNested) {
+      var msgPrefix = flag(this, 'message')
+      msgPrefix = msgPrefix ? msgPrefix + ': ' : ''
+      throw new AssertionError(msgPrefix + 'the argument to `property` must be a string')
+    }
+
     if (isNested && isOwn) {
       flagMsg = flagMsg ? flagMsg + ': ' : '';
       throw new AssertionError(

--- a/test/assert.js
+++ b/test/assert.js
@@ -1460,13 +1460,9 @@ describe('assert', function () {
       assert.propertyVal(dummyObj, 'a', '2', 'blah');
     }, "blah: expected { a: '1' } to have property 'a' of '2', but got '1'");
 
-    assert.doesNotThrow(function () {
-      assert.nestedProperty({a:1}, '{a:1}');
-    }, Error, 'the argument to property must be a string when using nested syntax');
-
-    assert.throws(function () {
-      assert.nestedProperty({a:1}, {'a':'1'});
-    }, Error, 'the argument to property must be a string when using nested syntax');
+    err(function () {
+      assert.nestedProperty({a:1}, {'a':'1'}, 'blah');
+    }, 'blah: the argument to property must be a string when using nested syntax');
   });
 
   it('deepPropertyVal', function () {

--- a/test/assert.js
+++ b/test/assert.js
@@ -1,6 +1,5 @@
 describe('assert', function () {
   var assert = chai.assert;
-  var expect = chai.expect;
 
   it('assert', function () {
     var foo = 'bar';
@@ -1461,13 +1460,13 @@ describe('assert', function () {
       assert.propertyVal(dummyObj, 'a', '2', 'blah');
     }, "blah: expected { a: '1' } to have property 'a' of '2', but got '1'");
 
-    expect(function () {
+    chai.expect(function () {
       assert.nestedProperty({a:1}, '{a:1}');
-    }).to.not.throw('the argument to `property` must be a string');
+    }).to.not.throw('the argument to property must be a string when using nested syntax');
 
-    expect(function () {
+    chai.expect(function () {
       assert.nestedProperty({a:1}, {'a':'1'});
-    }).to.throw('the argument to `property` must be a string');
+    }).to.throw('the argument to property must be a string when using nested syntax');
   });
 
   it('deepPropertyVal', function () {

--- a/test/assert.js
+++ b/test/assert.js
@@ -1460,13 +1460,13 @@ describe('assert', function () {
       assert.propertyVal(dummyObj, 'a', '2', 'blah');
     }, "blah: expected { a: '1' } to have property 'a' of '2', but got '1'");
 
-    chai.expect(function () {
+    assert.doesNotThrow(function () {
       assert.nestedProperty({a:1}, '{a:1}');
-    }).to.not.throw('the argument to property must be a string when using nested syntax');
+    }, Error, 'the argument to property must be a string when using nested syntax');
 
-    chai.expect(function () {
+    assert.throws(function () {
       assert.nestedProperty({a:1}, {'a':'1'});
-    }).to.throw('the argument to property must be a string when using nested syntax');
+    }, Error, 'the argument to property must be a string when using nested syntax');
   });
 
   it('deepPropertyVal', function () {

--- a/test/assert.js
+++ b/test/assert.js
@@ -1457,6 +1457,10 @@ describe('assert', function () {
     }, "blah: Target cannot be null or undefined.");
 
     err(function () {
+      assert.property({a:1}, {'a':'1'}, 'blah');
+    }, 'blah: the argument to property must be a string, number, or symbol');
+
+    err(function () {
       assert.propertyVal(dummyObj, 'a', '2', 'blah');
     }, "blah: expected { a: '1' } to have property 'a' of '2', but got '1'");
 

--- a/test/assert.js
+++ b/test/assert.js
@@ -1,5 +1,6 @@
 describe('assert', function () {
   var assert = chai.assert;
+  var expect = chai.expect;
 
   it('assert', function () {
     var foo = 'bar';
@@ -1459,6 +1460,14 @@ describe('assert', function () {
     err(function () {
       assert.propertyVal(dummyObj, 'a', '2', 'blah');
     }, "blah: expected { a: '1' } to have property 'a' of '2', but got '1'");
+
+    expect(function () {
+      assert.nestedProperty({a:1}, '{a:1}');
+    }).to.not.throw('the argument to `property` must be a string');
+
+    expect(function () {
+      assert.nestedProperty({a:1}, {'a':'1'});
+    }).to.throw('the argument to `property` must be a string');
   });
 
   it('deepPropertyVal', function () {

--- a/test/assert.js
+++ b/test/assert.js
@@ -1395,6 +1395,7 @@ describe('assert', function () {
     var obj = { foo: { bar: 'baz' } };
     var simpleObj = { foo: 'bar' };
     var undefinedKeyObj = { foo: undefined };
+    var dummyObj = { a: '1' };
     assert.property(obj, 'foo');
     assert.property(obj, 'toString');
     assert.propertyVal(obj, 'toString', Object.prototype.toString);
@@ -1454,6 +1455,10 @@ describe('assert', function () {
     err(function () {
       assert.property(undefined, 'a', 'blah');
     }, "blah: Target cannot be null or undefined.");
+
+    err(function () {
+      assert.propertyVal(dummyObj, 'a', '2', 'blah');
+    }, "blah: expected { a: '1' } to have property 'a' of '2', but got '1'");
   });
 
   it('deepPropertyVal', function () {

--- a/test/expect.js
+++ b/test/expect.js
@@ -1464,14 +1464,6 @@ describe('expect', function () {
     }, "blah: Target cannot be null or undefined.");
 
     expect(function () {
-      expect({a:1}).to.have.nested.property('{a:1}');
-    }).to.not.throw('the argument to `property` must be a string');
-
-    expect(function () {
-      expect({a:1}).to.have.nested.property({'a':'1'});
-    }).to.throw('the argument to `property` must be a string');
-
-    expect(function () {
       expect({a:1}).to.have.property(null);
     }).to.throw('the argument to `property` must be either of type string, number or symbol');
   });
@@ -1767,6 +1759,10 @@ describe('expect', function () {
       expect({ 'foo.bar': 'baz' })
         .to.have.nested.property('foo.bar');
     }, "expected { 'foo.bar': 'baz' } to have nested property 'foo.bar'");
+
+    expect(function () {
+      expect({a:1}).to.have.nested.property({'a':'1'});
+    }).to.throw('the argument to `property` must be a string');
   });
 
   it('nested.property(name, val)', function(){

--- a/test/expect.js
+++ b/test/expect.js
@@ -1463,9 +1463,9 @@ describe('expect', function () {
       expect(undefined, 'blah').to.have.property("a");
     }, "blah: Target cannot be null or undefined.");
 
-    expect(function () {
-      expect({a:1}).to.have.property(null);
-    }).to.throw('the argument to property must be a string, number, or symbol');
+    err(function () {
+      expect({a:1}, 'blah').to.have.property(null)
+    }, "blah: the argument to property must be a string, number, or symbol");
   });
 
   it('property(name, val)', function(){
@@ -1760,9 +1760,9 @@ describe('expect', function () {
         .to.have.nested.property('foo.bar');
     }, "expected { 'foo.bar': 'baz' } to have nested property 'foo.bar'");
 
-    expect(function () {
-      expect({a:1}).to.have.nested.property({'a':'1'});
-    }).to.throw('the argument to property must be a string when using nested syntax');
+    err(function () {
+      expect({a:1}, 'blah').to.have.nested.property({'a':'1'});
+    }, "blah: the argument to property must be a string when using nested syntax");
   });
 
   it('nested.property(name, val)', function(){

--- a/test/expect.js
+++ b/test/expect.js
@@ -1462,6 +1462,14 @@ describe('expect', function () {
     err(function () {
       expect(undefined, 'blah').to.have.property("a");
     }, "blah: Target cannot be null or undefined.");
+
+    expect(function () {
+      expect({a:1}).to.have.nested.property('{a:1}');
+    }).to.not.throw('the argument to `property` must be a string');
+
+    expect(function () {
+      expect({a:1}).to.have.nested.property({'a':'1'});
+    }).to.throw('the argument to `property` must be a string');
   });
 
   it('property(name, val)', function(){

--- a/test/expect.js
+++ b/test/expect.js
@@ -1465,7 +1465,7 @@ describe('expect', function () {
 
     expect(function () {
       expect({a:1}).to.have.property(null);
-    }).to.throw('the argument to `property` must be either of type string, number or symbol');
+    }).to.throw('the argument to property must be a string, number, or symbol');
   });
 
   it('property(name, val)', function(){
@@ -1762,7 +1762,7 @@ describe('expect', function () {
 
     expect(function () {
       expect({a:1}).to.have.nested.property({'a':'1'});
-    }).to.throw('the argument to `property` must be a string');
+    }).to.throw('the argument to property must be a string when using nested syntax');
   });
 
   it('nested.property(name, val)', function(){

--- a/test/expect.js
+++ b/test/expect.js
@@ -1470,6 +1470,10 @@ describe('expect', function () {
     expect(function () {
       expect({a:1}).to.have.nested.property({'a':'1'});
     }).to.throw('the argument to `property` must be a string');
+
+    expect(function () {
+      expect({a:1}).to.have.property(null);
+    }).to.throw('the argument to `property` must be either of type string, number or symbol');
   });
 
   it('property(name, val)', function(){

--- a/test/should.js
+++ b/test/should.js
@@ -1182,6 +1182,10 @@ describe('should', function() {
     err(function() {
       ({a: {b: 1}}).should.have.own.nested.property("a.b");
     }, "The \"nested\" and \"own\" flags cannot be combined.");
+
+    err(function () {
+      ({a:1}).should.have.property(undefined);
+    }, "the argument to property must be a string, number, or symbol");
   });
 
   it('property(name, val)', function(){
@@ -1409,13 +1413,9 @@ describe('should', function() {
 
     ({a:1}).should.have.nested.property('a');
 
-    (function () {
-      ({a:1}).should.have.nested.property('{a:1}');
-    }).should.not.throw('the argument to property must be a string when using nested syntax');
-
-    (function () {
+    err(function(){
       ({a:1}).should.have.nested.property({'a':'1'});
-    }).should.throw('the argument to property must be a string when using nested syntax');
+    }, "the argument to property must be a string when using nested syntax");
 
     err(function(){
       ({ 'foo.bar': 'baz' }).should.have.nested.property('foo.bar');

--- a/test/should.js
+++ b/test/should.js
@@ -1,5 +1,6 @@
 describe('should', function() {
   var should = chai.Should();
+  var expect = chai.expect;
 
   it('assertion', function(){
     'test'.should.be.a('string');
@@ -1408,6 +1409,14 @@ describe('should', function() {
     ({ 'foo.bar[]': 'baz'}).should.have.nested.property('foo\\.bar\\[\\]');
 
     ({a:1}).should.have.nested.property('a');
+
+    expect(function () {
+      ({a:1}).should.have.nested.property('{a:1}');
+    }).to.not.throw('the argument to `property` must be a string');
+
+    expect(function () {
+      ({a:1}).should.have.nested.property({'a':'1'});
+    }).to.throw('the argument to `property` must be a string');
 
     err(function(){
       ({ 'foo.bar': 'baz' }).should.have.nested.property('foo.bar');

--- a/test/should.js
+++ b/test/should.js
@@ -1,6 +1,5 @@
 describe('should', function() {
   var should = chai.Should();
-  var expect = chai.expect;
 
   it('assertion', function(){
     'test'.should.be.a('string');
@@ -1410,13 +1409,13 @@ describe('should', function() {
 
     ({a:1}).should.have.nested.property('a');
 
-    expect(function () {
+    (function () {
       ({a:1}).should.have.nested.property('{a:1}');
-    }).to.not.throw('the argument to `property` must be a string');
+    }).should.not.throw('the argument to property must be a string when using nested syntax');
 
-    expect(function () {
+    (function () {
       ({a:1}).should.have.nested.property({'a':'1'});
-    }).to.throw('the argument to `property` must be a string');
+    }).should.throw('the argument to property must be a string when using nested syntax');
 
     err(function(){
       ({ 'foo.bar': 'baz' }).should.have.nested.property('foo.bar');

--- a/test/should.js
+++ b/test/should.js
@@ -1407,6 +1407,8 @@ describe('should', function() {
 
     ({ 'foo.bar[]': 'baz'}).should.have.nested.property('foo\\.bar\\[\\]');
 
+    ({a:1}).should.have.nested.property('a');
+
     err(function(){
       ({ 'foo.bar': 'baz' }).should.have.nested.property('foo.bar');
     }, "expected { 'foo.bar': 'baz' } to have nested property 'foo.bar'");


### PR DESCRIPTION
### Description of the Change

Adds case check when property assertion is not string and nested flag is set.

### Why should this be in core?

Adds required check case when non-string param is passed with nested flag set.

### Benefits

It will provide more descriptive error to the devs on invalid passed params.
