### PR TITLE
Remove unnecessary code

### DIFF
--- a/lib/chai/core/assertions.js
+++ b/lib/chai/core/assertions.js
@@ -3723,7 +3723,7 @@ module.exports = function (chai, _) {
     var obj = flag(this, 'object');
 
     this.assert(
-        typeof obj === "number" && isFinite(obj)
+        typeof obj === 'number' && isFinite(obj)
       , 'expected #{this} to be a finite number'
       , 'expected #{this} to not be a finite number'
     );

--- a/lib/chai/core/assertions.js
+++ b/lib/chai/core/assertions.js
@@ -210,7 +210,6 @@ module.exports = function (chai, _) {
     flag(this, 'all', false);
   });
 
-
   /**
    * ### .all
    *
@@ -2271,7 +2270,6 @@ module.exports = function (chai, _) {
       if (keysType !== 'Array') {
         keys = Array.prototype.slice.call(arguments);
       }
-
     } else {
       actual = _.getOwnEnumerableProperties(obj);
 
@@ -3077,7 +3075,6 @@ module.exports = function (chai, _) {
   }
 
   Assertion.addMethod('oneOf', oneOf);
-
 
   /**
    * ### .change(subject[, prop[, msg]])

--- a/lib/chai/core/assertions.js
+++ b/lib/chai/core/assertions.js
@@ -3004,7 +3004,7 @@ module.exports = function (chai, _) {
     var contains = flag(this, 'contains');
     var ordered = flag(this, 'ordered');
 
-    var subject, failMsg, failNegateMsg, lengthCheck;
+    var subject, failMsg, failNegateMsg;
 
     if (contains) {
       subject = ordered ? 'an ordered superset' : 'a superset';

--- a/lib/chai/interface/assert.js
+++ b/lib/chai/interface/assert.js
@@ -4,9 +4,7 @@
  * MIT Licensed
  */
 
-
 module.exports = function (chai, util) {
-
   /*!
    * Chai dependencies.
    */

--- a/lib/chai/utils/getMessage.js
+++ b/lib/chai/utils/getMessage.js
@@ -10,7 +10,6 @@
 
 var flag = require('./flag')
   , getActual = require('./getActual')
-  , inspect = require('./inspect')
   , objDisplay = require('./objDisplay');
 
 /**

--- a/lib/chai/utils/inspect.js
+++ b/lib/chai/utils/inspect.js
@@ -332,10 +332,7 @@ function formatProperty(ctx, value, recurseTimes, visibleKeys, key, array) {
 }
 
 function reduceToSingleString(output, base, braces) {
-  var numLinesEst = 0;
   var length = output.reduce(function(prev, cur) {
-    numLinesEst++;
-    if (cur.indexOf('\n') >= 0) numLinesEst++;
     return prev + cur.length + 1;
   }, 0);
 

--- a/lib/chai/utils/inspect.js
+++ b/lib/chai/utils/inspect.js
@@ -196,7 +196,6 @@ function formatValue(ctx, value, recurseTimes) {
   return reduceToSingleString(output, base, braces);
 }
 
-
 function formatPrimitive(ctx, value) {
   switch (typeof value) {
     case 'undefined':
@@ -226,11 +225,9 @@ function formatPrimitive(ctx, value) {
   }
 }
 
-
 function formatError(value) {
   return '[' + Error.prototype.toString.call(value) + ']';
 }
-
 
 function formatArray(ctx, value, recurseTimes, visibleKeys, keys) {
   var output = [];
@@ -333,7 +330,6 @@ function formatProperty(ctx, value, recurseTimes, visibleKeys, key, array) {
 
   return name + ': ' + str;
 }
-
 
 function reduceToSingleString(output, base, braces) {
   var numLinesEst = 0;

--- a/test/assert.js
+++ b/test/assert.js
@@ -130,7 +130,6 @@ describe('assert', function () {
     err(function () {
       assert.typeOf(5, 'string', 'blah');
     }, "blah: expected 5 to be a string");
-
   });
 
   it('notTypeOf', function () {
@@ -241,7 +240,6 @@ describe('assert', function () {
     err(function(){
       assert.notInstanceOf(new Foo(), undefined);
     }, "The instanceof assertion needs a constructor but undefined was given.");
-
 
     if (typeof Symbol !== 'undefined' && typeof Symbol.hasInstance !== 'undefined') {
         err(function(){
@@ -1769,8 +1767,6 @@ describe('assert', function () {
     err(function () {
       assert.operator(w, '===', null);
      }, "expected undefined to be === null");
-
-
   });
 
   it('closeTo', function(){
@@ -2043,7 +2039,6 @@ describe('assert', function () {
     err(function() {
       assert.oneOf({ four: 4 }, [1, 2, { four: 4 }]);
     }, 'expected { four: 4 } to be one of [ 1, 2, { four: 4 } ]');
-
   });
 
   it('above', function() {

--- a/test/configuration.js
+++ b/test/configuration.js
@@ -810,5 +810,4 @@ describe('configuration', function () {
       }
     });
   });
-
 });

--- a/test/should.js
+++ b/test/should.js
@@ -2054,7 +2054,6 @@ describe('should', function() {
         testSet.should.have.all.keys([{thisIs: 'anExampleObject'}, {doingThisBecauseOf: 'referential equality'}]);
       });
 
-
       // Using the same assertions as above but with `.deep` flag instead of using referential equality
       testSet.should.have.any.deep.keys({thisIs: 'anExampleObject'});
       testSet.should.have.any.deep.keys('thisDoesNotExist', 'thisToo', {thisIs: 'anExampleObject'});


### PR DESCRIPTION
* Remove unnecessary line feeds
* Remove unused variable declaration
* Remove meaningless processing (lib/chai/utils/inspect.js)
    * `numLinesEst` does not seem to be used anywhere after this.

It is not a remove, but changed to a single quote unified to other coding styles. (`'number'` of lib/chai/core/assertions.js)