### PR TITLE
fix: simplify chai module export

### DIFF
--- a/lib/chai.js
+++ b/lib/chai.js
@@ -5,18 +5,19 @@
  */
 
 var used = [];
+var chai = {};
 
 /*!
  * Chai version
  */
 
-exports.version = '4.1.2';
+chai.version = '4.1.2';
 
 /*!
  * Assertion Error
  */
 
-exports.AssertionError = require('assertion-error');
+chai.AssertionError = require('assertion-error');
 
 /*!
  * Utils for plugins (not exported)
@@ -34,59 +35,61 @@ var util = require('./chai/utils');
  * @api public
  */
 
-exports.use = function (fn) {
+chai.use = function (fn) {
   if (!~used.indexOf(fn)) {
-    fn(exports, util);
+    fn(chai, util);
     used.push(fn);
   }
 
-  return exports;
+  return chai;
 };
 
 /*!
  * Utility Functions
  */
 
-exports.util = util;
+chai.util = util;
 
 /*!
  * Configuration
  */
 
 var config = require('./chai/config');
-exports.config = config;
+chai.config = config;
 
 /*!
  * Primary `Assertion` prototype
  */
 
 var assertion = require('./chai/assertion');
-exports.use(assertion);
+chai.use(assertion);
 
 /*!
  * Core Assertions
  */
 
 var core = require('./chai/core/assertions');
-exports.use(core);
+chai.use(core);
 
 /*!
  * Expect interface
  */
 
 var expect = require('./chai/interface/expect');
-exports.use(expect);
+chai.use(expect);
 
 /*!
  * Should interface
  */
 
 var should = require('./chai/interface/should');
-exports.use(should);
+chai.use(should);
 
 /*!
  * Assert interface
  */
 
 var assert = require('./chai/interface/assert');
-exports.use(assert);
+chai.use(assert);
+
+module.exports = chai;


### PR DESCRIPTION
There's an issue around chai using the `exports` keyword in a dynamic way that means the main module cannot be used in a way with module systems that statically infer what the exports are. 

This change simply refactors the export code to ensure `chai` is a single module that gets exported once, and doesn't refer to `module.exports` or `exports` inside of any function calls.

See https://github.com/josh/selector-observer/pull/4