### PR TITLE
feat: Add the assert.fail([message]) interface

### DIFF
--- a/lib/chai/interface/assert.js
+++ b/lib/chai/interface/assert.js
@@ -41,9 +41,17 @@ module.exports = function (chai, util) {
   };
 
   /**
+   * ### .fail([message])
    * ### .fail(actual, expected, [message], [operator])
    *
    * Throw a failure. Node.js `assert` module-compatible.
+   *
+   *     assert.fail();
+   *     assert.fail("custom error message");
+   *     assert.fail(1, 2);
+   *     assert.fail(1, 2, "custom error message");
+   *     assert.fail(1, 2, "custom error message", ">");
+   *     assert.fail(1, 2, undefined, ">");
    *
    * @name fail
    * @param {Mixed} actual
@@ -55,6 +63,13 @@ module.exports = function (chai, util) {
    */
 
   assert.fail = function (actual, expected, message, operator) {
+    if (arguments.length < 2) {
+        // Comply with Node's fail([message]) interface
+
+        message = actual;
+        actual = undefined;
+    }
+
     message = message || 'assert.fail()';
     throw new chai.AssertionError(message, {
         actual: actual

--- a/lib/chai/interface/expect.js
+++ b/lib/chai/interface/expect.js
@@ -10,9 +10,17 @@ module.exports = function (chai, util) {
   };
 
   /**
+   * ### .fail([message])
    * ### .fail(actual, expected, [message], [operator])
    *
    * Throw a failure.
+   *
+   *     expect.fail();
+   *     expect.fail("custom error message");
+   *     expect.fail(1, 2);
+   *     expect.fail(1, 2, "custom error message");
+   *     expect.fail(1, 2, "custom error message", ">");
+   *     expect.fail(1, 2, undefined, ">");
    *
    * @name fail
    * @param {Mixed} actual
@@ -24,6 +32,11 @@ module.exports = function (chai, util) {
    */
 
   chai.expect.fail = function (actual, expected, message, operator) {
+    if (arguments.length < 2) {
+        message = actual;
+        actual = undefined;
+    }
+
     message = message || 'expect.fail()';
     throw new chai.AssertionError(message, {
         actual: actual

--- a/lib/chai/interface/should.js
+++ b/lib/chai/interface/should.js
@@ -42,9 +42,18 @@ module.exports = function (chai, util) {
     var should = {};
 
     /**
+     * ### .fail([message])
      * ### .fail(actual, expected, [message], [operator])
      *
      * Throw a failure.
+     *
+     *     should.fail();
+     *     should.fail("custom error message");
+     *     should.fail(1, 2);
+     *     should.fail(1, 2, "custom error message");
+     *     should.fail(1, 2, "custom error message", ">");
+     *     should.fail(1, 2, undefined, ">");
+     *
      *
      * @name fail
      * @param {Mixed} actual
@@ -56,6 +65,11 @@ module.exports = function (chai, util) {
      */
 
     should.fail = function (actual, expected, message, operator) {
+      if (arguments.length < 2) {
+          message = actual;
+          actual = undefined;
+      }
+
       message = message || 'should.fail()';
       throw new chai.AssertionError(message, {
           actual: actual

--- a/test/assert.js
+++ b/test/assert.js
@@ -14,10 +14,24 @@ describe('assert', function () {
     }, "expected foo to equal `bar`");
   });
 
-  it('fail', function () {
-    chai.expect(function () {
-      assert.fail(0, 1, 'this has failed');
-    }).to.throw(chai.AssertionError, /this has failed/);
+  describe("fail", function() {
+    it('should accept a message as the 3rd argument', function () {
+      err(function() {
+        assert.fail(0, 1, 'this has failed');
+      }, /this has failed/);
+    });
+
+    it('should accept a message as the only argument', function () {
+      err(function() {
+        assert.fail('this has failed');
+      }, /this has failed/);
+    });
+
+    it('should produce a default message when called without any arguments', function () {
+      err(function() {
+        assert.fail();
+      }, /assert\.fail()/);
+    });
   });
 
   it('isTrue', function () {

--- a/test/expect.js
+++ b/test/expect.js
@@ -236,10 +236,24 @@ describe('expect', function () {
     , 'of', 'same', 'but', 'does' ].forEach(test);
   });
 
-  it('fail', function () {
-    err(function() {
-      expect.fail(0, 1, 'this has failed');
-    }, /this has failed/);
+  describe("fail", function() {
+    it('should accept a message as the 3rd argument', function () {
+      err(function() {
+        expect.fail(0, 1, 'this has failed');
+      }, /this has failed/);
+    });
+
+    it('should accept a message as the only argument', function () {
+      err(function() {
+        expect.fail('this has failed');
+      }, /this has failed/);
+    });
+
+    it('should produce a default message when called without any arguments', function () {
+      err(function() {
+        expect.fail();
+      }, /expect\.fail()/);
+    });
   });
 
   it('true', function(){

--- a/test/should.js
+++ b/test/should.js
@@ -233,10 +233,24 @@ describe('should', function() {
     , 'of', 'same', 'but', 'does' ].forEach(test);
   });
 
-  it('fail', function () {
-    err(function() {
-      should.fail(0, 1, 'this has failed');
-    }, 'this has failed');
+  describe("fail", function() {
+    it('should accept a message as the 3rd argument', function () {
+      err(function() {
+        should.fail(0, 1, 'this has failed');
+      }, /this has failed/);
+    });
+
+    it('should accept a message as the only argument', function () {
+      err(function() {
+        should.fail('this has failed');
+      }, /this has failed/);
+    });
+
+    it('should produce a default message when called without any arguments', function () {
+      err(function() {
+        should.fail();
+      }, /should\.fail()/);
+    });
   });
 
   it('root exist', function () {


### PR DESCRIPTION
In relation to #1116 the `assert.fail` interface should accept only 1 arguments to fail with a custom message.