### PR TITLE
 docs: Add type definitions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,8 +76,12 @@ test-sauce: clean-browser chai.js
 	@CHAI_TEST_ENV=sauce ./node_modules/karma/bin/karma start \
 		--single-run
 
+test-typescript:
+	@./node_modules/.bin/tsc -p test/typings
+
 test-travisci:
 	@echo TRAVIS_JOB_ID $(TRAVIS_JOB_ID)
+	@make test-typescript
 	@make test-cov
 	@make test-sauce
 

--- a/lib/chai.d.ts
+++ b/lib/chai.d.ts
@@ -1,0 +1,1511 @@
+import _AssertionError = require("assertion-error");
+
+declare namespace chai {
+    interface ChaiStatic {
+        expect: ExpectStatic;
+        should: Assertion & (() => Should);
+        /**
+         * Provides a way to extend the internals of Chai
+         */
+        use(fn: (chai: any, utils: any) => void): ChaiStatic;
+        assert: AssertStatic;
+        config: Config;
+        AssertionError: typeof _AssertionError;
+        version: string;
+    }
+
+    export interface ExpectStatic extends AssertionStatic {
+        fail(actual?: any, expected?: any, message?: string, operator?: Operator): void;
+    }
+
+    export interface AssertStatic extends Assert {
+    }
+
+    export interface AssertionStatic {
+        (target: any, message?: string): Assertion;
+    }
+
+    export type Operator = string; // "==" | "===" | ">" | ">=" | "<" | "<=" | "!=" | "!==";
+
+    export type OperatorComparable = boolean | null | number | string | undefined | Date;
+
+    interface ShouldAssertion {
+        equal(value1: any, value2: any, message?: string): void;
+        Throw: ShouldThrow;
+        throw: ShouldThrow;
+        exist(value: any, message?: string): void;
+    }
+
+    interface Should extends ShouldAssertion {
+        not: ShouldAssertion;
+        fail(actual: any, expected: any, message?: string, operator?: Operator): void;
+    }
+
+    interface ShouldThrow {
+        (actual: Function): void;
+        (actual: Function, expected: string|RegExp, message?: string): void;
+        (actual: Function, constructor: Error|Function, expected?: string|RegExp, message?: string): void;
+    }
+
+    interface Assertion extends LanguageChains, NumericComparison, TypeComparison {
+        not: Assertion;
+        deep: Deep;
+        ordered: Ordered;
+        nested: Nested;
+        any: KeyFilter;
+        all: KeyFilter;
+        a: TypeComparison;
+        an: TypeComparison;
+        include: Include;
+        includes: Include;
+        contain: Include;
+        contains: Include;
+        ok: Assertion;
+        true: Assertion;
+        false: Assertion;
+        null: Assertion;
+        undefined: Assertion;
+        NaN: Assertion;
+        exist: Assertion;
+        empty: Assertion;
+        arguments: Assertion;
+        Arguments: Assertion;
+        equal: Equal;
+        equals: Equal;
+        eq: Equal;
+        eql: Equal;
+        eqls: Equal;
+        property: Property;
+        ownProperty: OwnProperty;
+        haveOwnProperty: OwnProperty;
+        ownPropertyDescriptor: OwnPropertyDescriptor;
+        haveOwnPropertyDescriptor: OwnPropertyDescriptor;
+        length: Length;
+        lengthOf: Length;
+        match: Match;
+        matches: Match;
+        string(string: string, message?: string): Assertion;
+        keys: Keys;
+        key(string: string): Assertion;
+        throw: Throw;
+        throws: Throw;
+        Throw: Throw;
+        respondTo: RespondTo;
+        respondsTo: RespondTo;
+        itself: Assertion;
+        satisfy: Satisfy;
+        satisfies: Satisfy;
+        closeTo: CloseTo;
+        approximately: CloseTo;
+        members: Members;
+        increase: PropertyChange;
+        increases: PropertyChange;
+        decrease: PropertyChange;
+        decreases: PropertyChange;
+        change: PropertyChange;
+        changes: PropertyChange;
+        extensible: Assertion;
+        sealed: Assertion;
+        frozen: Assertion;
+        oneOf(list: any[], message?: string): Assertion;
+    }
+
+    interface LanguageChains {
+        to: Assertion;
+        be: Assertion;
+        been: Assertion;
+        is: Assertion;
+        that: Assertion;
+        which: Assertion;
+        and: Assertion;
+        has: Assertion;
+        have: Assertion;
+        with: Assertion;
+        at: Assertion;
+        of: Assertion;
+        same: Assertion;
+        but: Assertion;
+        does: Assertion;
+    }
+
+    interface NumericComparison {
+        above: NumberComparer;
+        gt: NumberComparer;
+        greaterThan: NumberComparer;
+        least: NumberComparer;
+        gte: NumberComparer;
+        below: NumberComparer;
+        lt: NumberComparer;
+        lessThan: NumberComparer;
+        most: NumberComparer;
+        lte: NumberComparer;
+        within(start: number, finish: number, message?: string): Assertion;
+    }
+
+    interface NumberComparer {
+        (value: number, message?: string): Assertion;
+    }
+
+    interface TypeComparison {
+        (type: string, message?: string): Assertion;
+        instanceof: InstanceOf;
+        instanceOf: InstanceOf;
+    }
+
+    interface InstanceOf {
+        (constructor: Object, message?: string): Assertion;
+    }
+
+    interface CloseTo {
+        (expected: number, delta: number, message?: string): Assertion;
+    }
+
+    interface Nested {
+      include: Include;
+      property: Property;
+      members: Members;
+    }
+
+    interface Deep {
+        equal: Equal;
+        equals: Equal;
+        eq: Equal;
+        include: Include;
+        property: Property;
+        members: Members;
+        ordered: Ordered;
+    }
+
+    interface Ordered {
+        members: Members;
+    }
+
+    interface KeyFilter {
+        keys: Keys;
+    }
+
+    interface Equal {
+        (value: any, message?: string): Assertion;
+    }
+
+    interface Property {
+        (name: string, value?: any, message?: string): Assertion;
+    }
+
+    interface OwnProperty {
+        (name: string, message?: string): Assertion;
+    }
+
+    interface OwnPropertyDescriptor {
+        (name: string, descriptor: PropertyDescriptor, message?: string): Assertion;
+        (name: string, message?: string): Assertion;
+    }
+
+    interface Length extends LanguageChains, NumericComparison {
+        (length: number, message?: string): Assertion;
+    }
+
+    interface Include {
+        (value: Object, message?: string): Assertion;
+        (value: string, message?: string): Assertion;
+        (value: number, message?: string): Assertion;
+        keys: Keys;
+        deep: Deep;
+        ordered: Ordered;
+        members: Members;
+        any: KeyFilter;
+        all: KeyFilter;
+    }
+
+    interface Match {
+        (regexp: RegExp|string, message?: string): Assertion;
+    }
+
+    interface Keys {
+        (...keys: string[]): Assertion;
+        (keys: any[]): Assertion;
+        (keys: Object): Assertion;
+    }
+
+    interface Throw {
+        (): Assertion;
+        (expected: string, message?: string): Assertion;
+        (expected: RegExp, message?: string): Assertion;
+        (constructor: Error, expected?: string, message?: string): Assertion;
+        (constructor: Error, expected?: RegExp, message?: string): Assertion;
+        (constructor: Function, expected?: string, message?: string): Assertion;
+        (constructor: Function, expected?: RegExp, message?: string): Assertion;
+    }
+
+    interface RespondTo {
+        (method: string, message?: string): Assertion;
+    }
+
+    interface Satisfy {
+        (matcher: Function, message?: string): Assertion;
+    }
+
+    interface Members {
+        (set: any[], message?: string): Assertion;
+    }
+
+    interface PropertyChange {
+        (object: Object, property: string, message?: string): Assertion;
+    }
+
+    export interface Assert {
+        /**
+         * @param expression    Expression to test for truthiness.
+         * @param message    Message to display on error.
+         */
+        (expression: any, message?: string): void;
+
+        /**
+         * Throws a failure.
+         *
+         * @type T   Type of the objects.
+         * @param actual   Actual value.
+         * @param expected   Potential expected value.
+         * @param message    Message to display on error.
+         * @param operator   Comparison operator, if not strict equality.
+         * @remarks Node.js assert module-compatible.
+         */
+        fail<T>(actual?: T, expected?: T, message?: string, operator?: Operator): void;
+
+        /**
+         * Asserts that object is truthy.
+         *
+         * @type T   Type of object.
+         * @param object   Object to test.
+         * @param message    Message to display on error.
+         */
+        isOk<T>(value: T, message?: string): void;
+
+        /**
+         * Asserts that object is truthy.
+         *
+         * @type T   Type of object.
+         * @param object   Object to test.
+         * @param message    Message to display on error.
+         */
+        ok<T>(value: T, message?: string): void;
+
+        /**
+         * Asserts that object is falsy.
+         *
+         * @type T   Type of object.
+         * @param object   Object to test.
+         * @param message    Message to display on error.
+         */
+        isNotOk<T>(value: T, message?: string): void;
+
+        /**
+         * Asserts that object is falsy.
+         *
+         * @type T   Type of object.
+         * @param object   Object to test.
+         * @param message    Message to display on error.
+         */
+        notOk<T>(value: T, message?: string): void;
+
+        /**
+         * Asserts non-strict equality (==) of actual and expected.
+         *
+         * @type T   Type of the objects.
+         * @param actual   Actual value.
+         * @param expected   Potential expected value.
+         * @param message   Message to display on error.
+         */
+        equal<T>(actual: T, expected: T, message?: string): void;
+
+        /**
+         * Asserts non-strict inequality (==) of actual and expected.
+         *
+         * @type T   Type of the objects.
+         * @param actual   Actual value.
+         * @param expected   Potential expected value.
+         * @param message   Message to display on error.
+         */
+        notEqual<T>(actual: T, expected: T, message?: string): void;
+
+        /**
+         * Asserts strict equality (===) of actual and expected.
+         *
+         * @type T   Type of the objects.
+         * @param actual   Actual value.
+         * @param expected   Potential expected value.
+         * @param message   Message to display on error.
+         */
+        strictEqual<T>(actual: T, expected: T, message?: string): void;
+
+        /**
+         * Asserts strict inequality (==) of actual and expected.
+         *
+         * @type T   Type of the objects.
+         * @param actual   Actual value.
+         * @param expected   Potential expected value.
+         * @param message   Message to display on error.
+         */
+        notStrictEqual<T>(actual: T, expected: T, message?: string): void;
+
+        /**
+         * Asserts that actual is deeply equal to expected.
+         *
+         * @type T   Type of the objects.
+         * @param actual   Actual value.
+         * @param expected   Potential expected value.
+         * @param message   Message to display on error.
+         */
+        deepEqual<T>(actual: T, expected: T, message?: string): void;
+
+        /**
+         * Asserts that actual is not deeply equal to expected.
+         *
+         * @type T   Type of the objects.
+         * @param actual   Actual value.
+         * @param expected   Potential expected value.
+         * @param message   Message to display on error.
+         */
+        notDeepEqual<T>(actual: T, expected: T, message?: string): void;
+
+        /**
+         * Asserts valueToCheck is strictly greater than (>) valueToBeAbove.
+         *
+         * @param valueToCheck   Actual value.
+         * @param valueToBeAbove   Minimum Potential expected value.
+         * @param message   Message to display on error.
+         */
+        isAbove(valueToCheck: number, valueToBeAbove: number, message?: string): void;
+
+        /**
+         * Asserts valueToCheck is greater than or equal to (>=) valueToBeAtLeast.
+         *
+         * @param valueToCheck   Actual value.
+         * @param valueToBeAtLeast   Minimum Potential expected value.
+         * @param message   Message to display on error.
+         */
+        isAtLeast(valueToCheck: number, valueToBeAtLeast: number, message?: string): void;
+
+        /**
+         * Asserts valueToCheck is strictly less than (<) valueToBeBelow.
+         *
+         * @param valueToCheck   Actual value.
+         * @param valueToBeBelow   Minimum Potential expected value.
+         * @param message   Message to display on error.
+         */
+        isBelow(valueToCheck: number, valueToBeBelow: number, message?: string): void;
+
+        /**
+         * Asserts valueToCheck is greater than or equal to (>=) valueToBeAtMost.
+         *
+         * @param valueToCheck   Actual value.
+         * @param valueToBeAtMost   Minimum Potential expected value.
+         * @param message   Message to display on error.
+         */
+        isAtMost(valueToCheck: number, valueToBeAtMost: number, message?: string): void;
+
+        /**
+         * Asserts that value is true.
+         *
+         * @type T   Type of value.
+         * @param value   Actual value.
+         * @param message   Message to display on error.
+         */
+        isTrue<T>(value: T, message?: string): void;
+
+        /**
+         * Asserts that value is false.
+         *
+         * @type T   Type of value.
+         * @param value   Actual value.
+         * @param message   Message to display on error.
+         */
+        isFalse<T>(value: T, message?: string): void;
+
+        /**
+         * Asserts that value is not true.
+         *
+         * @type T   Type of value.
+         * @param value   Actual value.
+         * @param message   Message to display on error.
+         */
+        isNotTrue<T>(value: T, message?: string): void;
+
+        /**
+         * Asserts that value is not false.
+         *
+         * @type T   Type of value.
+         * @param value   Actual value.
+         * @param message   Message to display on error.
+         */
+        isNotFalse<T>(value: T, message?: string): void;
+
+        /**
+         * Asserts that value is null.
+         *
+         * @type T   Type of value.
+         * @param value   Actual value.
+         * @param message   Message to display on error.
+         */
+        isNull<T>(value: T, message?: string): void;
+
+        /**
+         * Asserts that value is not null.
+         *
+         * @type T   Type of value.
+         * @param value   Actual value.
+         * @param message   Message to display on error.
+         */
+        isNotNull<T>(value: T, message?: string): void;
+
+        /**
+         * Asserts that value is not null.
+         *
+         * @type T   Type of value.
+         * @param value   Actual value.
+         * @param message   Message to display on error.
+         */
+        isNaN<T>(value: T, message?: string): void;
+
+        /**
+         * Asserts that value is not null.
+         *
+         * @type T   Type of value.
+         * @param value   Actual value.
+         * @param message   Message to display on error.
+         */
+        isNotNaN<T>(value: T, message?: string): void;
+
+        /**
+         * Asserts that the target is neither null nor undefined.
+         *
+         * @type T   Type of value.
+         * @param value   Actual value.
+         * @param message    Message to display on error.
+         */
+        exists<T>(value: T, message?: string): void;
+
+        /**
+         * Asserts that the target is either null or undefined.
+         *
+         * @type T   Type of value.
+         * @param value   Actual value.
+         * @param message    Message to display on error.
+         */
+        notExists<T>(value: T, message?: string): void;
+
+        /**
+         * Asserts that value is undefined.
+         *
+         * @type T   Type of value.
+         * @param value   Actual value.
+         * @param message   Message to display on error.
+         */
+        isUndefined<T>(value: T, message?: string): void;
+
+        /**
+         * Asserts that value is not undefined.
+         *
+         * @type T   Type of value.
+         * @param value   Actual value.
+         * @param message   Message to display on error.
+         */
+        isDefined<T>(value: T, message?: string): void;
+
+        /**
+         * Asserts that value is a function.
+         *
+         * @type T   Type of value.
+         * @param value   Actual value.
+         * @param message   Message to display on error.
+         */
+        isFunction<T>(value: T, message?: string): void;
+
+        /**
+         * Asserts that value is not a function.
+         *
+         * @type T   Type of value.
+         * @param value   Actual value.
+         * @param message   Message to display on error.
+         */
+        isNotFunction<T>(value: T, message?: string): void;
+
+        /**
+         * Asserts that value is an object of type 'Object'
+         * (as revealed by Object.prototype.toString).
+         *
+         * @type T   Type of value.
+         * @param value   Actual value.
+         * @param message   Message to display on error.
+         * @remarks The assertion does not match subclassed objects.
+         */
+        isObject<T>(value: T, message?: string): void;
+
+        /**
+         * Asserts that value is not an object of type 'Object'
+         * (as revealed by Object.prototype.toString).
+         *
+         * @type T   Type of value.
+         * @param value   Actual value.
+         * @param message   Message to display on error.
+         */
+        isNotObject<T>(value: T, message?: string): void;
+
+        /**
+         * Asserts that value is an array.
+         *
+         * @type T   Type of value.
+         * @param value   Actual value.
+         * @param message   Message to display on error.
+         */
+        isArray<T>(value: T, message?: string): void;
+
+        /**
+         * Asserts that value is not an array.
+         *
+         * @type T   Type of value.
+         * @param value   Actual value.
+         * @param message   Message to display on error.
+         */
+        isNotArray<T>(value: T, message?: string): void;
+
+        /**
+         * Asserts that value is a string.
+         *
+         * @type T   Type of value.
+         * @param value   Actual value.
+         * @param message   Message to display on error.
+         */
+        isString<T>(value: T, message?: string): void;
+
+        /**
+         * Asserts that value is not a string.
+         *
+         * @type T   Type of value.
+         * @param value   Actual value.
+         * @param message   Message to display on error.
+         */
+        isNotString<T>(value: T, message?: string): void;
+
+        /**
+         * Asserts that value is a number.
+         *
+         * @type T   Type of value.
+         * @param value   Actual value.
+         * @param message   Message to display on error.
+         */
+        isNumber<T>(value: T, message?: string): void;
+
+        /**
+         * Asserts that value is not a number.
+         *
+         * @type T   Type of value.
+         * @param value   Actual value.
+         * @param message   Message to display on error.
+         */
+        isNotNumber<T>(value: T, message?: string): void;
+
+        /**
+         * Asserts that value is a boolean.
+         *
+         * @type T   Type of value.
+         * @param value   Actual value.
+         * @param message   Message to display on error.
+         */
+        isBoolean<T>(value: T, message?: string): void;
+
+        /**
+         * Asserts that value is not a boolean.
+         *
+         * @type T   Type of value.
+         * @param value   Actual value.
+         * @param message   Message to display on error.
+         */
+        isNotBoolean<T>(value: T, message?: string): void;
+
+        /**
+         * Asserts that value's type is name, as determined by Object.prototype.toString.
+         *
+         * @type T   Type of value.
+         * @param value   Actual value.
+         * @param name   Potential expected type name of value.
+         * @param message   Message to display on error.
+         */
+        typeOf<T>(value: T, name: string, message?: string): void;
+
+        /**
+         * Asserts that value's type is not name, as determined by Object.prototype.toString.
+         *
+         * @type T   Type of value.
+         * @param value   Actual value.
+         * @param name   Potential expected type name of value.
+         * @param message   Message to display on error.
+         */
+        notTypeOf<T>(value: T, name: string, message?: string): void;
+
+        /**
+         * Asserts that value is an instance of constructor.
+         *
+         * @type T   Type of value.
+         * @param value   Actual value.
+         * @param constructor   Potential expected contructor of value.
+         * @param message   Message to display on error.
+         */
+        instanceOf<T>(value: T, constructor: Function, message?: string): void;
+
+        /**
+         * Asserts that value is not an instance of constructor.
+         *
+         * @type T   Type of value.
+         * @param value   Actual value.
+         * @param constructor   Potential expected contructor of value.
+         * @param message   Message to display on error.
+         */
+        notInstanceOf<T>(value: T, type: Function, message?: string): void;
+
+        /**
+         * Asserts that haystack includes needle.
+         *
+         * @param haystack   Container string.
+         * @param needle   Potential expected substring of haystack.
+         * @param message   Message to display on error.
+         */
+        include(haystack: string, needle: string, message?: string): void;
+
+        /**
+         * Asserts that haystack includes needle.
+         *
+         * @type T   Type of values in haystack.
+         * @param haystack   Container array.
+         * @param needle   Potential value contained in haystack.
+         * @param message   Message to display on error.
+         */
+        include<T>(haystack: T[], needle: T, message?: string): void;
+
+        /**
+         * Asserts that haystack does not include needle.
+         *
+         * @param haystack   Container string.
+         * @param needle   Potential expected substring of haystack.
+         * @param message   Message to display on error.
+         */
+        notInclude(haystack: string, needle: any, message?: string): void;
+
+        /**
+         * Asserts that haystack does not include needle.
+         *
+         * @type T   Type of values in haystack.
+         * @param haystack   Container array.
+         * @param needle   Potential value contained in haystack.
+         * @param message   Message to display on error.
+         */
+        notInclude(haystack: any[], needle: any, message?: string): void;
+
+        /**
+         * Asserts that value matches the regular expression regexp.
+         *
+         * @param value   Actual value.
+         * @param regexp   Potential match of value.
+         * @param message   Message to display on error.
+         */
+        match(value: string, regexp: RegExp, message?: string): void;
+
+        /**
+         * Asserts that value does not match the regular expression regexp.
+         *
+         * @param value   Actual value.
+         * @param regexp   Potential match of value.
+         * @param message   Message to display on error.
+         */
+        notMatch(expected: any, regexp: RegExp, message?: string): void;
+
+        /**
+         * Asserts that object has a property named by property.
+         *
+         * @type T   Type of object.
+         * @param object   Container object.
+         * @param property   Potential contained property of object.
+         * @param message   Message to display on error.
+         */
+        property<T>(object: T, property: string /* keyof T */, message?: string): void;
+
+        /**
+         * Asserts that object has a property named by property.
+         *
+         * @type T   Type of object.
+         * @param object   Container object.
+         * @param property   Potential contained property of object.
+         * @param message   Message to display on error.
+         */
+        notProperty<T>(object: T, property: string /* keyof T */, message?: string): void;
+
+        /**
+         * Asserts that object has a property named by property, which can be a string
+         * using dot- and bracket-notation for deep reference.
+         *
+         * @type T   Type of object.
+         * @param object   Container object.
+         * @param property   Potential contained property of object.
+         * @param message   Message to display on error.
+         */
+        deepProperty<T>(object: T, property: string, message?: string): void;
+
+        /**
+         * Asserts that object does not have a property named by property, which can be a
+         * string using dot- and bracket-notation for deep reference.
+         *
+         * @type T   Type of object.
+         * @param object   Container object.
+         * @param property   Potential contained property of object.
+         * @param message   Message to display on error.
+         */
+        notDeepProperty<T>(object: T, property: string, message?: string): void;
+
+        /**
+         * Asserts that object has a property named by property with value given by value.
+         *
+         * @type T   Type of object.
+         * @type V   Type of value.
+         * @param object   Container object.
+         * @param property   Potential contained property of object.
+         * @param value   Potential expected property value.
+         * @param message   Message to display on error.
+         */
+        propertyVal<T, V>(object: T, property: string /* keyof T */, value: V, message?: string): void;
+
+        /**
+         * Asserts that object has a property named by property with value given by value.
+         *
+         * @type T   Type of object.
+         * @type V   Type of value.
+         * @param object   Container object.
+         * @param property   Potential contained property of object.
+         * @param value   Potential expected property value.
+         * @param message   Message to display on error.
+         */
+        propertyNotVal<T, V>(object: T, property: string /* keyof T */, value: V, message?: string): void;
+
+        /**
+         * Asserts that object has a property named by property, which can be a string
+         * using dot- and bracket-notation for deep reference.
+         *
+         * @type T   Type of object.
+         * @type V   Type of value.
+         * @param object   Container object.
+         * @param property   Potential contained property of object.
+         * @param value   Potential expected property value.
+         * @param message   Message to display on error.
+         */
+        deepPropertyVal<T, V>(object: T, property: string, value: V, message?: string): void;
+
+        /**
+         * Asserts that object does not have a property named by property, which can be a
+         * string using dot- and bracket-notation for deep reference.
+         *
+         * @type T   Type of object.
+         * @type V   Type of value.
+         * @param object   Container object.
+         * @param property   Potential contained property of object.
+         * @param value   Potential expected property value.
+         * @param message   Message to display on error.
+         */
+        deepPropertyNotVal<T, V>(object: T, property: string, value: V, message?: string): void;
+
+        /**
+         * Asserts that object has a length property with the expected value.
+         *
+         * @type T   Type of object.
+         * @param object   Container object.
+         * @param length   Potential expected length of object.
+         * @param message   Message to display on error.
+         */
+        lengthOf<T extends { readonly length?: number }>(object: T, length: number, message?: string): void;
+
+        /**
+         * Asserts that fn will throw an error.
+         *
+         * @param fn   Function that may throw.
+         * @param message   Message to display on error.
+         */
+        throw(fn: Function, message?: string): void;
+
+        /**
+         * Asserts that function will throw an error with message matching regexp.
+         *
+         * @param fn   Function that may throw.
+         * @param regExp   Potential expected message match.
+         * @param message   Message to display on error.
+         */
+        throw(fn: Function, regExp: RegExp): void;
+
+        /**
+         * Asserts that function will throw an error that is an instance of constructor.
+         *
+         * @param fn   Function that may throw.
+         * @param constructor   Potential expected error constructor.
+         * @param message   Message to display on error.
+         */
+        throw(fn: Function, constructor: Function, message?: string): void;
+
+        /**
+         * Asserts that function will throw an error that is an instance of constructor
+         * and an error with message matching regexp.
+         *
+         * @param fn   Function that may throw.
+         * @param constructor   Potential expected error constructor.
+         * @param message   Message to display on error.
+         */
+        throw(fn: Function, constructor: Function, regExp: RegExp): void;
+
+        /**
+         * Asserts that fn will throw an error.
+         *
+         * @param fn   Function that may throw.
+         * @param message   Message to display on error.
+         */
+        throws(fn: Function, message?: string): void;
+
+        /**
+         * Asserts that function will throw an error with message matching regexp.
+         *
+         * @param fn   Function that may throw.
+         * @param regExp   Potential expected message match.
+         * @param message   Message to display on error.
+         */
+        throws(fn: Function, regExp: RegExp, message?: string): void;
+
+        /**
+         * Asserts that function will throw an error that is an instance of constructor.
+         *
+         * @param fn   Function that may throw.
+         * @param constructor   Potential expected error constructor.
+         * @param message   Message to display on error.
+         */
+        throws(fn: Function, errType: Function, message?: string): void;
+
+        /**
+         * Asserts that function will throw an error that is an instance of constructor
+         * and an error with message matching regexp.
+         *
+         * @param fn   Function that may throw.
+         * @param constructor   Potential expected error constructor.
+         * @param message   Message to display on error.
+         */
+        throws(fn: Function, errType: Function, regExp: RegExp): void;
+
+        /**
+         * Asserts that fn will throw an error.
+         *
+         * @param fn   Function that may throw.
+         * @param message   Message to display on error.
+         */
+        Throw(fn: Function, message?: string): void;
+
+        /**
+         * Asserts that function will throw an error with message matching regexp.
+         *
+         * @param fn   Function that may throw.
+         * @param regExp   Potential expected message match.
+         * @param message   Message to display on error.
+         */
+        Throw(fn: Function, regExp: RegExp): void;
+
+        /**
+         * Asserts that function will throw an error that is an instance of constructor.
+         *
+         * @param fn   Function that may throw.
+         * @param constructor   Potential expected error constructor.
+         * @param message   Message to display on error.
+         */
+        Throw(fn: Function, errType: Function, message?: string): void;
+
+        /**
+         * Asserts that function will throw an error that is an instance of constructor
+         * and an error with message matching regexp.
+         *
+         * @param fn   Function that may throw.
+         * @param constructor   Potential expected error constructor.
+         * @param message   Message to display on error.
+         */
+        Throw(fn: Function, errType: Function, regExp: RegExp): void;
+
+        /**
+         * Asserts that fn will not throw an error.
+         *
+         * @param fn   Function that may throw.
+         * @param message   Message to display on error.
+         */
+        doesNotThrow(fn: Function, message?: string): void;
+
+        /**
+         * Asserts that function will throw an error with message matching regexp.
+         *
+         * @param fn   Function that may throw.
+         * @param regExp   Potential expected message match.
+         * @param message   Message to display on error.
+         */
+        doesNotThrow(fn: Function, regExp: RegExp): void;
+
+        /**
+         * Asserts that function will throw an error that is an instance of constructor.
+         *
+         * @param fn   Function that may throw.
+         * @param constructor   Potential expected error constructor.
+         * @param message   Message to display on error.
+         */
+        doesNotThrow(fn: Function, errType: Function, message?: string): void;
+
+        /**
+         * Asserts that function will throw an error that is an instance of constructor
+         * and an error with message matching regexp.
+         *
+         * @param fn   Function that may throw.
+         * @param constructor   Potential expected error constructor.
+         * @param message   Message to display on error.
+         */
+        doesNotThrow(fn: Function, errType: Function, regExp: RegExp): void;
+
+        /**
+         * Compares two values using operator.
+         *
+         * @param val1   Left value during comparison.
+         * @param operator   Comparison operator.
+         * @param val2   Right value during comparison.
+         * @param message   Message to display on error.
+         */
+        operator(val1: OperatorComparable, operator: Operator, val2: OperatorComparable, message?: string): void;
+
+        /**
+         * Asserts that the target is equal to expected, to within a +/- delta range.
+         *
+         * @param actual   Actual value
+         * @param expected   Potential expected value.
+         * @param delta   Maximum differenced between values.
+         * @param message   Message to display on error.
+         */
+        closeTo(actual: number, expected: number, delta: number, message?: string): void;
+
+        /**
+         * Asserts that the target is equal to expected, to within a +/- delta range.
+         *
+         * @param actual   Actual value
+         * @param expected   Potential expected value.
+         * @param delta   Maximum differenced between values.
+         * @param message   Message to display on error.
+         */
+        approximately(act: number, exp: number, delta: number, message?: string): void;
+
+        /**
+         * Asserts that set1 and set2 have the same members. Order is not take into account.
+         *
+         * @type T   Type of set values.
+         * @param set1   Actual set of values.
+         * @param set2   Potential expected set of values.
+         * @param message   Message to display on error.
+         */
+        sameMembers<T>(set1: T[], set2: T[], message?: string): void;
+
+        /**
+         * Asserts that set1 and set2 have the same members using deep equality checking.
+         * Order is not take into account.
+         *
+         * @type T   Type of set values.
+         * @param set1   Actual set of values.
+         * @param set2   Potential expected set of values.
+         * @param message   Message to display on error.
+         */
+        sameDeepMembers<T>(set1: T[], set2: T[], message?: string): void;
+
+        /**
+         * Asserts that set1 and set2 have the same members in the same order.
+         * Uses a strict equality check (===).
+         *
+         * @type T   Type of set values.
+         * @param set1   Actual set of values.
+         * @param set2   Potential expected set of values.
+         * @param message   Message to display on error.
+         */
+        sameOrderedMembers<T>(set1: T[], set2: T[], message?: string): void;
+
+        /**
+         * Asserts that set1 and set2 don’t have the same members in the same order.
+         * Uses a strict equality check (===).
+         *
+         * @type T   Type of set values.
+         * @param set1   Actual set of values.
+         * @param set2   Potential expected set of values.
+         * @param message   Message to display on error.
+         */
+        notSameOrderedMembers<T>(set1: T[], set2: T[], message?: string): void;
+
+        /**
+         * Asserts that set1 and set2 have the same members in the same order.
+         * Uses a deep equality check.
+         *
+         * @type T   Type of set values.
+         * @param set1   Actual set of values.
+         * @param set2   Potential expected set of values.
+         * @param message   Message to display on error.
+         */
+        sameDeepOrderedMembers<T>(set1: T[], set2: T[], message?: string): void;
+
+        /**
+         * Asserts that set1 and set2 don’t have the same members in the same order.
+         * Uses a deep equality check.
+         *
+         * @type T   Type of set values.
+         * @param set1   Actual set of values.
+         * @param set2   Potential expected set of values.
+         * @param message   Message to display on error.
+         */
+        notSameDeepOrderedMembers<T>(set1: T[], set2: T[], message?: string): void;
+
+        /**
+         * Asserts that subset is included in superset in the same order beginning with the first element in superset.
+         * Uses a strict equality check (===).
+         *
+         * @type T   Type of set values.
+         * @param superset   Actual set of values.
+         * @param subset   Potential contained set of values.
+         * @param message   Message to display on error.
+         */
+        includeOrderedMembers<T>(superset: T[], subset: T[], message?: string): void;
+
+        /**
+         * Asserts that subset isn’t included in superset in the same order beginning with the first element in superset.
+         * Uses a strict equality check (===).
+         *
+         * @type T   Type of set values.
+         * @param superset   Actual set of values.
+         * @param subset   Potential contained set of values.
+         * @param message   Message to display on error.
+         */
+        notIncludeOrderedMembers<T>(superset: T[], subset: T[], message?: string): void;
+
+        /**
+         * Asserts that subset is included in superset in the same order beginning with the first element in superset.
+         * Uses a deep equality check.
+         *
+         * @type T   Type of set values.
+         * @param superset   Actual set of values.
+         * @param subset   Potential contained set of values.
+         * @param message   Message to display on error.
+         */
+        includeDeepOrderedMembers<T>(superset: T[], subset: T[], message?: string): void;
+
+        /**
+         * Asserts that subset isn’t included in superset in the same order beginning with the first element in superset.
+         * Uses a deep equality check.
+         *
+         * @type T   Type of set values.
+         * @param superset   Actual set of values.
+         * @param subset   Potential contained set of values.
+         * @param message   Message to display on error.
+         */
+        notIncludeDeepOrderedMembers<T>(superset: T[], subset: T[], message?: string): void;
+
+        /**
+         * Asserts that subset is included in superset. Order is not take into account.
+         *
+         * @type T   Type of set values.
+         * @param superset   Actual set of values.
+         * @param subset   Potential contained set of values.
+         * @param message   Message to display on error.
+         */
+        includeMembers<T>(superset: T[], subset: T[], message?: string): void;
+
+        /**
+         * Asserts that subset is included in superset using deep equality checking.
+         * Order is not take into account.
+         *
+         * @type T   Type of set values.
+         * @param superset   Actual set of values.
+         * @param subset   Potential contained set of values.
+         * @param message   Message to display on error.
+         */
+        includeDeepMembers<T>(superset: T[], subset: T[], message?: string): void;
+
+        /**
+         * Asserts that non-object, non-array value inList appears in the flat array list.
+         *
+         * @type T   Type of list values.
+         * @param inList   Value expected to be in the list.
+         * @param list   List of values.
+         * @param message   Message to display on error.
+         */
+        oneOf<T>(inList: T, list: T[], message?: string): void;
+
+        /**
+         * Asserts that a function changes the value of a property.
+         *
+         * @type T   Type of object.
+         * @param modifier   Function to run.
+         * @param object   Container object.
+         * @param property   Property of object expected to be modified.
+         * @param message   Message to display on error.
+         */
+        changes<T>(modifier: Function, object: T, property: string /* keyof T */, message?: string): void
+
+        /**
+         * Asserts that a function does not change the value of a property.
+         *
+         * @type T   Type of object.
+         * @param modifier   Function to run.
+         * @param object   Container object.
+         * @param property   Property of object expected not to be modified.
+         * @param message   Message to display on error.
+         */
+        doesNotChange<T>(modifier: Function, object: T, property: string /* keyof T */, message?: string): void
+
+        /**
+         * Asserts that a function increases an object property.
+         *
+         * @type T   Type of object.
+         * @param modifier   Function to run.
+         * @param object   Container object.
+         * @param property   Property of object expected to be increased.
+         * @param message   Message to display on error.
+         */
+        increases<T>(modifier: Function, object: T, property: string /* keyof T */, message?: string): void
+
+        /**
+         * Asserts that a function does not increase an object property.
+         *
+         * @type T   Type of object.
+         * @param modifier   Function to run.
+         * @param object   Container object.
+         * @param property   Property of object expected not to be increased.
+         * @param message   Message to display on error.
+         */
+        doesNotIncrease<T>(modifier: Function, object: T, property: string /* keyof T */, message?: string): void
+
+        /**
+         * Asserts that a function decreases an object property.
+         *
+         * @type T   Type of object.
+         * @param modifier   Function to run.
+         * @param object   Container object.
+         * @param property   Property of object expected to be decreased.
+         * @param message   Message to display on error.
+         */
+        decreases<T>(modifier: Function, object: T, property: string /* keyof T */, message?: string): void
+
+        /**
+         * Asserts that a function does not decrease an object property.
+         *
+         * @type T   Type of object.
+         * @param modifier   Function to run.
+         * @param object   Container object.
+         * @param property   Property of object expected not to be decreased.
+         * @param message   Message to display on error.
+         */
+        doesNotDecrease<T>(modifier: Function, object: T, property: string /* keyof T */, message?: string): void
+
+        /**
+         * Asserts if value is not a false value, and throws if it is a true value.
+         *
+         * @type T   Type of object.
+         * @param object   Actual value.
+         * @param message   Message to display on error.
+         * @remarks This is added to allow for chai to be a drop-in replacement for
+         *          Node’s assert class.
+         */
+        ifError<T>(object: T, message?: string): void;
+
+        /**
+         * Asserts that object is extensible (can have new properties added to it).
+         *
+         * @type T   Type of object
+         * @param object   Actual value.
+         * @param message   Message to display on error.
+         */
+        isExtensible<T>(object: T, message?: string): void;
+
+        /**
+         * Asserts that object is extensible (can have new properties added to it).
+         *
+         * @type T   Type of object
+         * @param object   Actual value.
+         * @param message   Message to display on error.
+         */
+        extensible<T>(object: T, message?: string): void;
+
+        /**
+         * Asserts that object is not extensible.
+         *
+         * @type T   Type of object
+         * @param object   Actual value.
+         * @param message   Message to display on error.
+         */
+        isNotExtensible<T>(object: T, message?: string): void;
+
+        /**
+         * Asserts that object is not extensible.
+         *
+         * @type T   Type of object
+         * @param object   Actual value.
+         * @param message   Message to display on error.
+         */
+        notExtensible<T>(object: T, message?: string): void;
+
+        /**
+         * Asserts that object is sealed (can have new properties added to it
+         * and its existing properties cannot be removed).
+         *
+         * @type T   Type of object
+         * @param object   Actual value.
+         * @param message   Message to display on error.
+         */
+        isSealed<T>(object: T, message?: string): void;
+
+        /**
+         * Asserts that object is sealed (can have new properties added to it
+         * and its existing properties cannot be removed).
+         *
+         * @type T   Type of object
+         * @param object   Actual value.
+         * @param message   Message to display on error.
+         */
+        sealed<T>(object: T, message?: string): void;
+
+        /**
+         * Asserts that object is not sealed.
+         *
+         * @type T   Type of object
+         * @param object   Actual value.
+         * @param message   Message to display on error.
+         */
+        isNotSealed<T>(object: T, message?: string): void;
+
+        /**
+         * Asserts that object is not sealed.
+         *
+         * @type T   Type of object
+         * @param object   Actual value.
+         * @param message   Message to display on error.
+         */
+        notSealed<T>(object: T, message?: string): void;
+
+        /**
+         * Asserts that object is frozen (cannot have new properties added to it
+         * and its existing properties cannot be removed).
+         *
+         * @type T   Type of object
+         * @param object   Actual value.
+         * @param message   Message to display on error.
+         */
+        isFrozen<T>(object: T, message?: string): void;
+
+        /**
+         * Asserts that object is frozen (cannot have new properties added to it
+         * and its existing properties cannot be removed).
+         *
+         * @type T   Type of object
+         * @param object   Actual value.
+         * @param message   Message to display on error.
+         */
+        frozen<T>(object: T, message?: string): void;
+
+        /**
+         * Asserts that object is not frozen (cannot have new properties added to it
+         * and its existing properties cannot be removed).
+         *
+         * @type T   Type of object
+         * @param object   Actual value.
+         * @param message   Message to display on error.
+         */
+        isNotFrozen<T>(object: T, message?: string): void;
+
+        /**
+         * Asserts that object is not frozen (cannot have new properties added to it
+         * and its existing properties cannot be removed).
+         *
+         * @type T   Type of object
+         * @param object   Actual value.
+         * @param message   Message to display on error.
+         */
+        notFrozen<T>(object: T, message?: string): void;
+
+        /**
+         * Asserts that the target does not contain any values. For arrays and
+         * strings, it checks the length property. For Map and Set instances, it
+         * checks the size property. For non-function objects, it gets the count
+         * of own enumerable string keys.
+         *
+         * @type T   Type of object
+         * @param object   Actual value.
+         * @param message   Message to display on error.
+         */
+        isEmpty<T>(object: T, message?: string): void;
+
+        /**
+         * Asserts that the target contains values. For arrays and strings, it checks
+         * the length property. For Map and Set instances, it checks the size property.
+         * For non-function objects, it gets the count of own enumerable string keys.
+         *
+         * @type T   Type of object.
+         * @param object   Object to test.
+         * @param message    Message to display on error.
+         */
+        isNotEmpty<T>(object: T, message?: string): void;
+
+        /**
+         * Asserts that `object` has at least one of the `keys` provided.
+         * You can also provide a single object instead of a `keys` array and its keys
+         * will be used as the expected set of keys.
+         *
+         * @type T   Type of object.
+         * @param object   Object to test.
+         * @param keys   Keys to check
+         * @param message    Message to display on error.
+         */
+        hasAnyKeys<T>(object: T, keys: Array<Object | string> | { [key: string]: any }, message?: string): void;
+
+        /**
+         * Asserts that `object` has all and only all of the `keys` provided.
+         * You can also provide a single object instead of a `keys` array and its keys
+         * will be used as the expected set of keys.
+         *
+         * @type T   Type of object.
+         * @param object   Object to test.
+         * @param keys   Keys to check
+         * @param message    Message to display on error.
+         */
+        hasAllKeys<T>(object: T, keys: Array<Object | string> | { [key: string]: any }, message?: string): void;
+
+        /**
+         * Asserts that `object` has all of the `keys` provided but may have more keys not listed.
+         * You can also provide a single object instead of a `keys` array and its keys
+         * will be used as the expected set of keys.
+         *
+         * @type T   Type of object.
+         * @param object   Object to test.
+         * @param keys   Keys to check
+         * @param message    Message to display on error.
+         */
+        containsAllKeys<T>(object: T, keys: Array<Object | string> | { [key: string]: any }, message?: string): void;
+
+        /**
+         * Asserts that `object` has none of the `keys` provided.
+         * You can also provide a single object instead of a `keys` array and its keys
+         * will be used as the expected set of keys.
+         *
+         * @type T   Type of object.
+         * @param object   Object to test.
+         * @param keys   Keys to check
+         * @param message    Message to display on error.
+         */
+        doesNotHaveAnyKeys<T>(object: T, keys: Array<Object | string> | { [key: string]: any }, message?: string): void;
+
+        /**
+         * Asserts that `object` does not have at least one of the `keys` provided.
+         * You can also provide a single object instead of a `keys` array and its keys
+         * will be used as the expected set of keys.
+         *
+         * @type T   Type of object.
+         * @param object   Object to test.
+         * @param keys   Keys to check
+         * @param message    Message to display on error.
+         */
+        doesNotHaveAllKeys<T>(object: T, keys: Array<Object | string> | { [key: string]: any }, message?: string): void;
+
+        /**
+         * Asserts that `object` has at least one of the `keys` provided.
+         * Since Sets and Maps can have objects as keys you can use this assertion to perform
+         * a deep comparison.
+         * You can also provide a single object instead of a `keys` array and its keys
+         * will be used as the expected set of keys.
+         *
+         * @type T   Type of object.
+         * @param object   Object to test.
+         * @param keys   Keys to check
+         * @param message    Message to display on error.
+         */
+        hasAnyDeepKeys<T>(object: T, keys: Array<Object | string> | { [key: string]: any }, message?: string): void;
+
+        /**
+         * Asserts that `object` has all and only all of the `keys` provided.
+         * Since Sets and Maps can have objects as keys you can use this assertion to perform
+         * a deep comparison.
+         * You can also provide a single object instead of a `keys` array and its keys
+         * will be used as the expected set of keys.
+         *
+         * @type T   Type of object.
+         * @param object   Object to test.
+         * @param keys   Keys to check
+         * @param message    Message to display on error.
+         */
+        hasAllDeepKeys<T>(object: T, keys: Array<Object | string> | { [key: string]: any }, message?: string): void;
+
+        /**
+         * Asserts that `object` contains all of the `keys` provided.
+         * Since Sets and Maps can have objects as keys you can use this assertion to perform
+         * a deep comparison.
+         * You can also provide a single object instead of a `keys` array and its keys
+         * will be used as the expected set of keys.
+         *
+         * @type T   Type of object.
+         * @param object   Object to test.
+         * @param keys   Keys to check
+         * @param message    Message to display on error.
+         */
+        containsAllDeepKeys<T>(object: T, keys: Array<Object | string> | { [key: string]: any }, message?: string): void;
+
+        /**
+         * Asserts that `object` contains all of the `keys` provided.
+         * Since Sets and Maps can have objects as keys you can use this assertion to perform
+         * a deep comparison.
+         * You can also provide a single object instead of a `keys` array and its keys
+         * will be used as the expected set of keys.
+         *
+         * @type T   Type of object.
+         * @param object   Object to test.
+         * @param keys   Keys to check
+         * @param message    Message to display on error.
+         */
+        doesNotHaveAnyDeepKeys<T>(object: T, keys: Array<Object | string> | { [key: string]: any }, message?: string): void;
+
+        /**
+         * Asserts that `object` contains all of the `keys` provided.
+         * Since Sets and Maps can have objects as keys you can use this assertion to perform
+         * a deep comparison.
+         * You can also provide a single object instead of a `keys` array and its keys
+         * will be used as the expected set of keys.
+         *
+         * @type T   Type of object.
+         * @param object   Object to test.
+         * @param keys   Keys to check
+         * @param message    Message to display on error.
+         */
+        doesNotHaveAllDeepKeys<T>(object: T, keys: Array<Object | string> | { [key: string]: any }, message?: string): void;
+    }
+
+    export interface Config {
+        /**
+         * Default: false
+         */
+        includeStack: boolean;
+
+        /**
+         * Default: true
+         */
+        showDiff: boolean;
+
+        /**
+         * Default: 40
+         */
+        truncateThreshold: number;
+    }
+
+    export type AssertionError<T = {}> = _AssertionError<T>;
+}
+
+declare const chai: chai.ChaiStatic;
+
+export = chai;
+
+declare global {
+    interface Object {
+        should: chai.Assertion;
+    }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -560,9 +560,9 @@
       "dev": true
     },
     "browserify": {
-      "version": "15.0.0",
-      "resolved": "https://registry.npmjs.org/browserify/-/browserify-15.0.0.tgz",
-      "integrity": "sha512-dERxjzl4yacUzaB4XVVXDFFHARzDr6tLRhjqpE/NJUv0SkS3QVmZKiYTiKEQZhQ2HygCL02FUzSS5r3sY/SlTg==",
+      "version": "16.1.1",
+      "resolved": "https://registry.npmjs.org/browserify/-/browserify-16.1.1.tgz",
+      "integrity": "sha512-iSH21jK0+IApV8YHOfmGt1qsGd74oflQ1Ko/28JOkWLFNBngAQfKb6WYIJ9CufH8vycqKX1sYU3y7ZrVhwevAg==",
       "dev": true,
       "requires": {
         "JSONStream": "1.3.2",
@@ -572,15 +572,15 @@
         "browserify-zlib": "0.2.0",
         "buffer": "5.0.8",
         "cached-path-relative": "1.0.1",
-        "concat-stream": "1.5.2",
+        "concat-stream": "1.6.2",
         "console-browserify": "1.1.0",
         "constants-browserify": "1.0.0",
         "crypto-browserify": "3.12.0",
         "defined": "1.0.0",
         "deps-sort": "2.0.0",
-        "domain-browser": "1.1.7",
+        "domain-browser": "1.2.0",
         "duplexer2": "0.1.4",
-        "events": "1.1.1",
+        "events": "2.0.0",
         "glob": "7.1.2",
         "has": "1.0.1",
         "htmlescape": "1.1.1",
@@ -588,7 +588,8 @@
         "inherits": "2.0.3",
         "insert-module-globals": "7.0.1",
         "labeled-stream-splicer": "2.0.0",
-        "module-deps": "5.0.1",
+        "mkdirp": "0.5.1",
+        "module-deps": "6.0.0",
         "os-browserify": "0.3.0",
         "parents": "1.0.1",
         "path-browserify": "0.0.0",
@@ -607,11 +608,66 @@
         "syntax-error": "1.3.0",
         "through2": "2.0.3",
         "timers-browserify": "1.4.2",
-        "tty-browserify": "0.0.0",
+        "tty-browserify": "0.0.1",
         "url": "0.11.0",
         "util": "0.10.3",
         "vm-browserify": "0.0.4",
         "xtend": "4.0.1"
+      },
+      "dependencies": {
+        "concat-stream": {
+          "version": "1.6.2",
+          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+          "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+          "dev": true,
+          "requires": {
+            "buffer-from": "1.0.0",
+            "inherits": "2.0.3",
+            "readable-stream": "2.3.3",
+            "typedarray": "0.0.6"
+          }
+        },
+        "domain-browser": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.2.0.tgz",
+          "integrity": "sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA==",
+          "dev": true
+        },
+        "events": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/events/-/events-2.0.0.tgz",
+          "integrity": "sha512-r/M5YkNg9zwI8QbSf7tsDWWJvO3PGwZXyG7GpFAxtMASnHL2eblFd7iHiGPtyGKKFPZ59S63NeX10Ws6WqGDcg==",
+          "dev": true
+        },
+        "module-deps": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/module-deps/-/module-deps-6.0.0.tgz",
+          "integrity": "sha512-BKsMhJJENEM4dTgqq2MDTTHXRHcNUFegoAwlG4HO4VMdUyMcJDKgfgI+MOv6tR5Iv8G3MKZFgsSiyP3ZoosRMw==",
+          "dev": true,
+          "requires": {
+            "JSONStream": "1.3.2",
+            "browser-resolve": "1.11.2",
+            "cached-path-relative": "1.0.1",
+            "concat-stream": "1.6.2",
+            "defined": "1.0.0",
+            "detective": "5.0.2",
+            "duplexer2": "0.1.4",
+            "inherits": "2.0.3",
+            "parents": "1.0.1",
+            "readable-stream": "2.3.3",
+            "resolve": "1.5.0",
+            "stream-combiner2": "1.1.1",
+            "subarg": "1.0.0",
+            "through2": "2.0.3",
+            "xtend": "4.0.1"
+          }
+        },
+        "tty-browserify": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.1.tgz",
+          "integrity": "sha512-C3TaO7K81YvjCgQH9Q1S3R3P3BtN3RIM8n+OvX4il1K1zgE8ZhI0op7kClgkxtutIE8hQrcrHBXvIheqKUUCxw==",
+          "dev": true
+        }
       }
     },
     "browserify-aes": {
@@ -698,6 +754,12 @@
       "version": "0.2.13",
       "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
       "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
+      "dev": true
+    },
+    "buffer-from": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.0.0.tgz",
+      "integrity": "sha512-83apNb8KK0Se60UE1+4Ukbe3HbfELJ6UlI4ldtOGs7So4KD26orJM8hIY9lxdzP+UpItH1Yh/Y8GUvNFWFFRxA==",
       "dev": true
     },
     "buffer-xor": {
@@ -814,6 +876,7 @@
       "requires": {
         "anymatch": "1.3.2",
         "async-each": "1.0.1",
+        "fsevents": "1.1.3",
         "glob-parent": "2.0.0",
         "inherits": "2.0.3",
         "is-binary-path": "1.0.1",
@@ -1760,6 +1823,910 @@
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
+    },
+    "fsevents": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.3.tgz",
+      "integrity": "sha512-WIr7iDkdmdbxu/Gh6eKEZJL6KPE74/5MEsf2whTOFNxbIoIixogroLdKYqB6FDav4Wavh/lZdzzd3b2KxIXC5Q==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "nan": "2.10.0",
+        "node-pre-gyp": "0.6.39"
+      },
+      "dependencies": {
+        "abbrev": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "ajv": {
+          "version": "4.11.8",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "co": "4.6.0",
+            "json-stable-stringify": "1.0.1"
+          }
+        },
+        "ansi-regex": {
+          "version": "2.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "aproba": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "are-we-there-yet": {
+          "version": "1.1.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "delegates": "1.0.0",
+            "readable-stream": "2.2.9"
+          }
+        },
+        "asn1": {
+          "version": "0.2.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "assert-plus": {
+          "version": "0.2.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "asynckit": {
+          "version": "0.4.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "aws-sign2": {
+          "version": "0.6.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "aws4": {
+          "version": "1.6.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "balanced-match": {
+          "version": "0.4.2",
+          "bundled": true,
+          "dev": true
+        },
+        "bcrypt-pbkdf": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "tweetnacl": "0.14.5"
+          }
+        },
+        "block-stream": {
+          "version": "0.0.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "inherits": "2.0.3"
+          }
+        },
+        "boom": {
+          "version": "2.10.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "hoek": "2.16.3"
+          }
+        },
+        "brace-expansion": {
+          "version": "1.1.7",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "balanced-match": "0.4.2",
+            "concat-map": "0.0.1"
+          }
+        },
+        "buffer-shims": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "caseless": {
+          "version": "0.12.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "co": {
+          "version": "4.6.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "code-point-at": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "combined-stream": {
+          "version": "1.0.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "delayed-stream": "1.0.0"
+          }
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "console-control-strings": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "core-util-is": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "cryptiles": {
+          "version": "2.0.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "boom": "2.10.1"
+          }
+        },
+        "dashdash": {
+          "version": "1.14.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "assert-plus": "1.0.0"
+          },
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "debug": {
+          "version": "2.6.8",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "deep-extend": {
+          "version": "0.4.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "delayed-stream": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "delegates": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "detect-libc": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "ecc-jsbn": {
+          "version": "0.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "jsbn": "0.1.1"
+          }
+        },
+        "extend": {
+          "version": "3.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "extsprintf": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "forever-agent": {
+          "version": "0.6.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "form-data": {
+          "version": "2.1.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "asynckit": "0.4.0",
+            "combined-stream": "1.0.5",
+            "mime-types": "2.1.15"
+          }
+        },
+        "fs.realpath": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "fstream": {
+          "version": "1.0.11",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "inherits": "2.0.3",
+            "mkdirp": "0.5.1",
+            "rimraf": "2.6.1"
+          }
+        },
+        "fstream-ignore": {
+          "version": "1.0.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "fstream": "1.0.11",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4"
+          }
+        },
+        "gauge": {
+          "version": "2.7.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "aproba": "1.1.1",
+            "console-control-strings": "1.1.0",
+            "has-unicode": "2.0.1",
+            "object-assign": "4.1.1",
+            "signal-exit": "3.0.2",
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "wide-align": "1.1.2"
+          }
+        },
+        "getpass": {
+          "version": "0.1.7",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "assert-plus": "1.0.0"
+          },
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "glob": {
+          "version": "7.1.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
+        },
+        "graceful-fs": {
+          "version": "4.1.11",
+          "bundled": true,
+          "dev": true
+        },
+        "har-schema": {
+          "version": "1.0.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "har-validator": {
+          "version": "4.2.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ajv": "4.11.8",
+            "har-schema": "1.0.5"
+          }
+        },
+        "has-unicode": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "hawk": {
+          "version": "3.1.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "boom": "2.10.1",
+            "cryptiles": "2.0.5",
+            "hoek": "2.16.3",
+            "sntp": "1.0.9"
+          }
+        },
+        "hoek": {
+          "version": "2.16.3",
+          "bundled": true,
+          "dev": true
+        },
+        "http-signature": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "assert-plus": "0.2.0",
+            "jsprim": "1.4.0",
+            "sshpk": "1.13.0"
+          }
+        },
+        "inflight": {
+          "version": "1.0.6",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "once": "1.4.0",
+            "wrappy": "1.0.2"
+          }
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "bundled": true,
+          "dev": true
+        },
+        "ini": {
+          "version": "1.3.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "number-is-nan": "1.0.1"
+          }
+        },
+        "is-typedarray": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "isstream": {
+          "version": "0.1.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "jodid25519": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "jsbn": "0.1.1"
+          }
+        },
+        "jsbn": {
+          "version": "0.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "json-schema": {
+          "version": "0.2.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "json-stable-stringify": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "jsonify": "0.0.0"
+          }
+        },
+        "json-stringify-safe": {
+          "version": "5.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "jsonify": {
+          "version": "0.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "jsprim": {
+          "version": "1.4.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "assert-plus": "1.0.0",
+            "extsprintf": "1.0.2",
+            "json-schema": "0.2.3",
+            "verror": "1.3.6"
+          },
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "mime-db": {
+          "version": "1.27.0",
+          "bundled": true,
+          "dev": true
+        },
+        "mime-types": {
+          "version": "2.1.15",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "mime-db": "1.27.0"
+          }
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "brace-expansion": "1.1.7"
+          }
+        },
+        "minimist": {
+          "version": "0.0.8",
+          "bundled": true,
+          "dev": true
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.8"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "node-pre-gyp": {
+          "version": "0.6.39",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "detect-libc": "1.0.2",
+            "hawk": "3.1.3",
+            "mkdirp": "0.5.1",
+            "nopt": "4.0.1",
+            "npmlog": "4.1.0",
+            "rc": "1.2.1",
+            "request": "2.81.0",
+            "rimraf": "2.6.1",
+            "semver": "5.3.0",
+            "tar": "2.2.1",
+            "tar-pack": "3.4.0"
+          }
+        },
+        "nopt": {
+          "version": "4.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "abbrev": "1.1.0",
+            "osenv": "0.1.4"
+          }
+        },
+        "npmlog": {
+          "version": "4.1.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "are-we-there-yet": "1.1.4",
+            "console-control-strings": "1.1.0",
+            "gauge": "2.7.4",
+            "set-blocking": "2.0.0"
+          }
+        },
+        "number-is-nan": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "oauth-sign": {
+          "version": "0.8.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "once": {
+          "version": "1.4.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "wrappy": "1.0.2"
+          }
+        },
+        "os-homedir": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "os-tmpdir": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "osenv": {
+          "version": "0.1.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "os-homedir": "1.0.2",
+            "os-tmpdir": "1.0.2"
+          }
+        },
+        "path-is-absolute": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "performance-now": {
+          "version": "0.2.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "process-nextick-args": {
+          "version": "1.0.7",
+          "bundled": true,
+          "dev": true
+        },
+        "punycode": {
+          "version": "1.4.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "qs": {
+          "version": "6.4.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "rc": {
+          "version": "1.2.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "deep-extend": "0.4.2",
+            "ini": "1.3.4",
+            "minimist": "1.2.0",
+            "strip-json-comments": "2.0.1"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "1.2.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "readable-stream": {
+          "version": "2.2.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "buffer-shims": "1.0.0",
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "string_decoder": "1.0.1",
+            "util-deprecate": "1.0.2"
+          }
+        },
+        "request": {
+          "version": "2.81.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "aws-sign2": "0.6.0",
+            "aws4": "1.6.0",
+            "caseless": "0.12.0",
+            "combined-stream": "1.0.5",
+            "extend": "3.0.1",
+            "forever-agent": "0.6.1",
+            "form-data": "2.1.4",
+            "har-validator": "4.2.1",
+            "hawk": "3.1.3",
+            "http-signature": "1.1.1",
+            "is-typedarray": "1.0.0",
+            "isstream": "0.1.2",
+            "json-stringify-safe": "5.0.1",
+            "mime-types": "2.1.15",
+            "oauth-sign": "0.8.2",
+            "performance-now": "0.2.0",
+            "qs": "6.4.0",
+            "safe-buffer": "5.0.1",
+            "stringstream": "0.0.5",
+            "tough-cookie": "2.3.2",
+            "tunnel-agent": "0.6.0",
+            "uuid": "3.0.1"
+          }
+        },
+        "rimraf": {
+          "version": "2.6.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "glob": "7.1.2"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "semver": {
+          "version": "5.3.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "set-blocking": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "signal-exit": {
+          "version": "3.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "sntp": {
+          "version": "1.0.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "hoek": "2.16.3"
+          }
+        },
+        "sshpk": {
+          "version": "1.13.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "asn1": "0.2.3",
+            "assert-plus": "1.0.0",
+            "bcrypt-pbkdf": "1.0.1",
+            "dashdash": "1.14.1",
+            "ecc-jsbn": "0.1.1",
+            "getpass": "0.1.7",
+            "jodid25519": "1.0.2",
+            "jsbn": "0.1.1",
+            "tweetnacl": "0.14.5"
+          },
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
+          }
+        },
+        "stringstream": {
+          "version": "0.0.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
+        },
+        "strip-json-comments": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "tar": {
+          "version": "2.2.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "block-stream": "0.0.9",
+            "fstream": "1.0.11",
+            "inherits": "2.0.3"
+          }
+        },
+        "tar-pack": {
+          "version": "3.4.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "debug": "2.6.8",
+            "fstream": "1.0.11",
+            "fstream-ignore": "1.0.5",
+            "once": "1.4.0",
+            "readable-stream": "2.2.9",
+            "rimraf": "2.6.1",
+            "tar": "2.2.1",
+            "uid-number": "0.0.6"
+          }
+        },
+        "tough-cookie": {
+          "version": "2.3.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "punycode": "1.4.1"
+          }
+        },
+        "tunnel-agent": {
+          "version": "0.6.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
+          }
+        },
+        "tweetnacl": {
+          "version": "0.14.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "uid-number": {
+          "version": "0.0.6",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "util-deprecate": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "uuid": {
+          "version": "3.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "verror": {
+          "version": "1.3.6",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "extsprintf": "1.0.2"
+          }
+        },
+        "wide-align": {
+          "version": "1.1.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "string-width": "1.0.2"
+          }
+        },
+        "wrappy": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        }
+      }
     },
     "ftp": {
       "version": "0.3.10",
@@ -3175,47 +4142,18 @@
         }
       }
     },
-    "module-deps": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/module-deps/-/module-deps-5.0.1.tgz",
-      "integrity": "sha512-sigq/hm/L+Z5IGi1DDl0x2ptkw7S86aFh213QhPLD8v9Opv90IHzKIuWJrRa5bJ77DVKHco2CfIEuThcT/vDJA==",
-      "dev": true,
-      "requires": {
-        "JSONStream": "1.3.2",
-        "browser-resolve": "1.11.2",
-        "cached-path-relative": "1.0.1",
-        "concat-stream": "1.6.0",
-        "defined": "1.0.0",
-        "detective": "5.0.2",
-        "duplexer2": "0.1.4",
-        "inherits": "2.0.3",
-        "parents": "1.0.1",
-        "readable-stream": "2.3.3",
-        "resolve": "1.5.0",
-        "stream-combiner2": "1.1.1",
-        "subarg": "1.0.0",
-        "through2": "2.0.3",
-        "xtend": "4.0.1"
-      },
-      "dependencies": {
-        "concat-stream": {
-          "version": "1.6.0",
-          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
-          "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
-          "dev": true,
-          "requires": {
-            "inherits": "2.0.3",
-            "readable-stream": "2.3.3",
-            "typedarray": "0.0.6"
-          }
-        }
-      }
-    },
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
       "dev": true
+    },
+    "nan": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
+      "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA==",
+      "dev": true,
+      "optional": true
     },
     "negotiator": {
       "version": "0.6.1",
@@ -4515,6 +5453,12 @@
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+      "dev": true
+    },
+    "typescript": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.6.1.tgz",
+      "integrity": "sha1-7znN6ierrAtQAkLWcmq5DgyEZjE=",
       "dev": true
     },
     "uglify-js": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   ],
   "homepage": "http://chaijs.com",
   "license": "MIT",
+  "types": "./lib/chai.d.ts",
   "contributors": [
     "Jake Luer <jake@alogicalparadox.com>",
     "Domenic Denicola <domenic@domenicdenicola.com> (http://domenicdenicola.com)",
@@ -50,6 +51,7 @@
     "karma-mocha": "^1.0.1",
     "karma-phantomjs-launcher": "^1.0.0",
     "karma-sauce-launcher": "^1.2.0",
-    "mocha": "^4.0.1"
+    "mocha": "^4.0.1",
+    "typescript": "^2.6.1"
   }
 }

--- a/test/typings/all.ts
+++ b/test/typings/all.ts
@@ -1,0 +1,2043 @@
+import chai = require('chai');
+
+// ReSharper disable WrongExpressionStatement
+
+const expect = chai.expect;
+const assert = chai.assert;
+const should = chai.should();
+declare var err: Function;
+
+function chaiVersion() {
+    expect(chai).to.have.property('version');
+    chai.should.have.property('version');
+}
+
+function assertion() {
+    expect('test').to.be.a('string');
+    'test'.should.be.a('string');
+    expect('foo').to.equal('foo');
+    'foo'.should.equal('foo');
+    should.equal('foo', 'foo');
+}
+
+function fail() {
+    err(() => {
+        should.fail('foo', 'bar');
+    }, 'expected fail to throw an AssertionError');
+    err(() => {
+        should.fail('foo', 'bar', 'should fail');
+    }, 'expected fail to throw an AssertionError');
+    err(() => {
+        should.fail('foo', 'bar', 'should fail', 'equal');
+    }, 'expected fail to throw an AssertionError');
+
+    err(() => {
+        expect.fail('foo', 'bar');
+    }, 'expected fail to throw an AssertionError');
+    err(() => {
+        expect.fail('foo', 'bar', 'should fail');
+    }, 'expected fail to throw an AssertionError');
+    err(() => {
+        expect.fail('foo', 'bar', 'should fail', 'equal');
+    }, 'expected fail to throw an AssertionError');
+}
+
+// ReSharper disable once InconsistentNaming
+function _true() {
+    expect(true).to.be.true;
+    true.should.be.true;
+    expect(false).to.not.be.true;
+    false.should.not.be.true;
+    expect(1).to.not.be.true;
+    (1).should.not.be.true;
+
+    err(() => {
+        expect('test').to.be.true;
+        'test'.should.be.true;
+    }, 'expected \'test\' to be true');
+}
+
+function ok() {
+    expect(true).to.be.ok;
+    true.should.be.ok;
+    expect(false).to.not.be.ok;
+    false.should.not.be.ok;
+    expect(1).to.be.ok;
+    (1).should.be.ok;
+    expect(0).to.not.be.ok;
+    (0).should.not.be.ok;
+
+    err(() => {
+        expect('').to.be.ok;
+        ''.should.be.ok;
+    }, 'expected \'\' to be truthy');
+
+    err(() => {
+        expect('test').to.not.be.ok;
+        'test'.should.not.be.ok;
+    }, 'expected \'test\' to be falsy');
+}
+
+function _false() {
+    expect(false).to.be.false;
+    false.should.be.false;
+    expect(true).to.not.be.false;
+    true.should.not.be.false;
+    expect(0).to.not.be.false;
+    (0).should.not.be.false;
+
+    err(() => {
+        expect('').to.be.false;
+        ''.should.be.false;
+    }, 'expected \'\' to be false');
+}
+
+function _null() {
+    expect(null).to.be.null;
+    should.equal(null, null);
+    expect(false).to.not.be.null;
+    false.should.not.be.null;
+
+    err(() => {
+        expect('').to.be.null;
+        ''.should.be.null;
+    }, 'expected \'\' to be null');
+}
+
+function _undefined() {
+    expect(undefined).to.be.undefined;
+    should.equal(undefined, undefined);
+    expect(null).to.not.be.undefined;
+    should.not.equal(null, undefined);
+
+    err(() => {
+        expect('').to.be.undefined;
+        ''.should.be.undefined;
+    }, 'expected \'\' to be undefined');
+}
+
+function _NaN() {
+    expect(NaN).to.be.NaN;
+    expect(12).to.be.not.NaN;
+    expect("NaN").to.be.not.NaN;
+    (NaN).should.be.NaN;
+    (12).should.be.not.NaN;
+    ("NaN").should.be.not.NaN;
+}
+
+function exist() {
+    var foo = 'bar';
+    expect(foo).to.exist;
+    should.exist(foo);
+    expect(void (0)).to.not.exist;
+    should.not.exist(void (0));
+}
+
+function argumentsTest() {
+    var args = arguments;
+    expect(args).to.be.arguments;
+    args.should.be.arguments;
+    expect([]).to.not.be.arguments;
+    [].should.not.be.arguments;
+    expect(args).to.be.an('arguments').and.be.arguments;
+    args.should.be.an('arguments').and.be.arguments;
+    expect([]).to.be.an('array').and.not.be.Arguments;
+    [].should.be.an('array').and.not.be.Arguments;
+}
+
+function equal() {
+    expect(undefined).to.equal(void (0));
+    should.equal(undefined, void (0));
+}
+
+function _typeof() {
+    expect('test').to.be.a('string');
+    'test'.should.be.a('string');
+
+    err(() => {
+        expect('test').to.not.be.a('string');
+        'test'.should.not.be.a('string');
+    }, 'expected \'test\' not to be a string');
+
+    expect(arguments).to.be.an('arguments');
+    arguments.should.be.an('arguments');
+
+    expect(5).to.be.a('number');
+    (5).should.be.a('number');
+
+    expect(new Number(1)).to.be.a('number');
+    (new Number(1)).should.be.a('number');
+    expect(Number(1)).to.be.a('number');
+    Number(1).should.be.a('number');
+    expect(true).to.be.a('boolean');
+    true.should.be.a('boolean');
+    expect(new Array()).to.be.a('array');
+    (new Array()).should.be.a('array');
+    expect(new Object()).to.be.a('object');
+    (new Object()).should.be.a('object');
+    expect({}).to.be.a('object');
+    ({}).should.be.a('object');
+    expect([]).to.be.a('array');
+    [].should.be.a('array');
+    expect(() => { }).to.be.a('function');
+    (() => { }).should.be.a('function');
+    expect(null).to.be.a('null');
+    // N.B. previous line has no should equivalent
+
+    err(() => {
+        expect(5).to.not.be.a('number', 'blah');
+        (5).should.not.be.a('number', 'blah');
+    }, 'blah: expected 5 not to be a number');
+}
+
+class Foo { }
+function _instanceof() {
+    expect(new Foo()).to.be.an.instanceof(Foo);
+    (new Foo()).should.be.an.instanceof(Foo);
+
+    err(() => {
+        expect(3).to.an.instanceof(Foo, 'blah');
+        (3).should.an.instanceof(Foo, 'blah');
+    }, 'blah: expected 3 to be an instance of Foo');
+}
+
+function within() {
+    expect(5).to.be.within(5, 10);
+    (5).should.be.within(5, 10);
+    expect(5).to.be.within(3, 6);
+    (5).should.be.within(3, 6);
+    expect(5).to.be.within(3, 5);
+    (5).should.be.within(3, 5);
+    expect(5).to.not.be.within(1, 3);
+    (5).should.not.be.within(1, 3);
+    expect('foo').to.have.length.within(2, 4);
+    'foo'.should.have.length.within(2, 4);
+    expect([1, 2, 3]).to.have.length.within(2, 4);
+    [1, 2, 3].should.have.length.within(2, 4);
+
+    err(() => {
+        expect(5).to.not.be.within(4, 6, 'blah');
+        (5).should.not.be.within(4, 6, 'blah');
+    }, 'blah: expected 5 to not be within 4..6', 'blah');
+
+    err(() => {
+        expect(10).to.be.within(50, 100, 'blah');
+        (10).should.be.within(50, 100, 'blah');
+    }, 'blah: expected 10 to be within 50..100');
+
+    err(() => {
+        expect('foo').to.have.length.within(5, 7, 'blah');
+        'foo'.should.have.length.within(5, 7, 'blah');
+    }, 'blah: expected \'foo\' to have a length within 5..7');
+
+    err(() => {
+        expect([1, 2, 3]).to.have.length.within(5, 7, 'blah');
+        [1, 2, 3].should.have.length.within(5, 7, 'blah');
+    }, 'blah: expected [ 1, 2, 3 ] to have a length within 5..7');
+}
+
+function above() {
+    expect(5).to.be.above(2);
+    (5).should.be.above(2);
+    expect(5).to.be.greaterThan(2);
+    (5).should.be.greaterThan(2);
+    expect(5).to.not.be.above(5);
+    (5).should.not.be.above(5);
+    expect(5).to.not.be.above(6);
+    (5).should.not.be.above(6);
+    expect('foo').to.have.length.above(2);
+    'foo'.should.have.length.above(2);
+    expect([1, 2, 3]).to.have.length.above(2);
+    [1, 2, 3].should.have.length.above(2);
+
+    err(() => {
+        expect(5).to.be.above(6, 'blah');
+        (5).should.be.above(6, 'blah');
+    }, 'blah: expected 5 to be above 6', 'blah');
+
+    err(() => {
+        expect(10).to.not.be.above(6, 'blah');
+        (10).should.not.be.above(6, 'blah');
+    }, 'blah: expected 10 to be at most 6');
+
+    err(() => {
+        expect('foo').to.have.length.above(4, 'blah');
+        'foo'.should.have.length.above(4, 'blah');
+    }, 'blah: expected \'foo\' to have a length above 4 but got 3');
+
+    err(() => {
+        expect([1, 2, 3]).to.have.length.above(4, 'blah');
+        [1, 2, 3].should.have.length.above(4, 'blah');
+    }, 'blah: expected [ 1, 2, 3 ] to have a length above 4 but got 3');
+}
+
+function least() {
+    expect(5).to.be.at.least(2);
+    (5).should.be.at.least(2);
+    expect(5).to.be.at.least(5);
+    (5).should.be.at.least(5);
+    expect(5).to.not.be.at.least(6);
+    (5).should.not.be.at.least(6);
+    expect('foo').to.have.length.of.at.least(2);
+    'foo'.should.have.length.of.at.least(2);
+    expect([1, 2, 3]).to.have.length.of.at.least(2);
+    [1, 2, 3].should.have.length.of.at.least(2);
+
+    err(() => {
+        expect(5).to.be.at.least(6, 'blah');
+        (5).should.be.at.least(6, 'blah');
+    }, 'blah: expected 5 to be at least 6', 'blah');
+
+    err(() => {
+        expect(10).to.not.be.at.least(6, 'blah');
+        (10).should.not.be.at.least(6, 'blah');
+    }, 'blah: expected 10 to be below 6');
+
+    err(() => {
+        expect('foo').to.have.length.of.at.least(4, 'blah');
+        'foo'.should.have.length.of.at.least(4, 'blah');
+    }, 'blah: expected \'foo\' to have a length at least 4 but got 3');
+
+    err(() => {
+        expect([1, 2, 3]).to.have.length.of.at.least(4, 'blah');
+        [1, 2, 3].should.have.length.of.at.least(4, 'blah');
+    }, 'blah: expected [ 1, 2, 3 ] to have a length at least 4 but got 3');
+
+    err(() => {
+        expect([1, 2, 3, 4]).to.not.have.length.of.at.least(4, 'blah');
+        [1, 2, 3, 4].should.not.have.length.of.at.least(4, 'blah');
+    }, 'blah: expected [ 1, 2, 3, 4 ] to have a length below 4');
+}
+
+function below() {
+    expect(2).to.be.below(5);
+    (2).should.be.below(5);
+    expect(2).to.be.lessThan(5);
+    (2).should.be.lessThan(5);
+    expect(2).to.not.be.below(2);
+    (2).should.not.be.below(2);
+    expect(2).to.not.be.below(1);
+    (2).should.not.be.below(1);
+    expect('foo').to.have.length.below(4);
+    'foo'.should.have.length.below(4);
+    expect([1, 2, 3]).to.have.length.below(4);
+    [1, 2, 3].should.have.length.below(4);
+
+    err(() => {
+        expect(6).to.be.below(5, 'blah');
+        (6).should.be.below(5, 'blah');
+    }, 'blah: expected 6 to be below 5');
+
+    err(() => {
+        expect(6).to.not.be.below(10, 'blah');
+        (6).should.not.be.below(10, 'blah');
+    }, 'blah: expected 6 to be at least 10');
+
+    err(() => {
+        expect('foo').to.have.length.below(2, 'blah');
+        'foo'.should.have.length.below(2, 'blah');
+    }, 'blah: expected \'foo\' to have a length below 2 but got 3');
+
+    err(() => {
+        expect([1, 2, 3]).to.have.length.below(2, 'blah');
+        [1, 2, 3].should.have.length.below(2, 'blah');
+    }, 'blah: expected [ 1, 2, 3 ] to have a length below 2 but got 3');
+}
+
+function most() {
+    expect(2).to.be.at.most(5);
+    (2).should.be.at.most(5);
+    expect(2).to.be.at.most(2);
+    (2).should.be.at.most(2);
+    expect(2).to.not.be.at.most(1);
+    (2).should.not.be.at.most(1);
+    expect(2).to.not.be.at.most(1);
+    (2).should.not.be.at.most(1);
+    expect('foo').to.have.length.of.at.most(4);
+    'foo'.should.have.length.of.at.most(4);
+    expect([1, 2, 3]).to.have.length.of.at.most(4);
+    [1, 2, 3].should.have.length.of.at.most(4);
+
+    err(() => {
+        expect(6).to.be.at.most(5, 'blah');
+        (6).should.be.at.most(5, 'blah');
+    }, 'blah: expected 6 to be at most 5');
+
+    err(() => {
+        expect(6).to.not.be.at.most(10, 'blah');
+        (6).should.not.be.at.most(10, 'blah');
+    }, 'blah: expected 6 to be above 10');
+
+    err(() => {
+        expect('foo').to.have.length.of.at.most(2, 'blah');
+        'foo'.should.have.length.of.at.most(2, 'blah');
+    }, 'blah: expected \'foo\' to have a length at most 2 but got 3');
+
+    err(() => {
+        expect([1, 2, 3]).to.have.length.of.at.most(2, 'blah');
+        [1, 2, 3].should.have.length.of.at.most(2, 'blah');
+    }, 'blah: expected [ 1, 2, 3 ] to have a length at most 2 but got 3');
+
+    err(() => {
+        expect([1, 2]).to.not.have.length.of.at.most(2, 'blah');
+        [1, 2].should.not.have.length.of.at.most(2, 'blah');
+    }, 'blah: expected [ 1, 2 ] to have a length above 2');
+}
+
+function match() {
+    expect('foobar').to.match(/^foo/);
+    'foobar'.should.match(/^foo/);
+    expect('foobar').to.not.match(/^bar/);
+    'foobar'.should.not.match(/^bar/);
+
+    expect('foobar').matches(/^foo/);
+    'foobar'.should.not.matches(/^bar/);
+
+    err(() => {
+        expect('foobar').to.match(/^bar/i, 'blah');
+        'foobar'.should.match(/^bar/i, 'blah');
+    }, 'blah: expected \'foobar\' to match /^bar/i');
+
+    err(() => {
+        expect('foobar').to.not.match(/^foo/i, 'blah');
+        'foobar'.should.not.match(/^foo/i, 'blah');
+    }, 'blah: expected \'foobar\' not to match /^foo/i');
+}
+
+function length2() {
+    expect('test').to.have.length(4);
+    'test'.should.have.length(4);
+    expect('test').to.not.have.length(3);
+    'test'.should.not.have.length(3);
+    expect([1, 2, 3]).to.have.length(3);
+    [1, 2, 3].should.have.length(3);
+
+    err(() => {
+        expect(4).to.have.length(3, 'blah');
+        (4).should.have.length(3, 'blah');
+    }, 'blah: expected 4 to have a property \'length\'');
+
+    err(() => {
+        expect('asd').to.not.have.length(3, 'blah');
+        'asd'.should.not.have.length(3, 'blah');
+    }, 'blah: expected \'asd\' to not have a length of 3');
+}
+
+function eql() {
+    expect('test').to.eql('test');
+    'test'.should.eql('test');
+    expect({ foo: 'bar' }).to.eql({ foo: 'bar' });
+    ({ foo: 'bar' }).should.eql({ foo: 'bar' });
+    expect(1).to.eql(1);
+    (1).should.eql(1);
+    expect('4').to.not.eql(4);
+    '4'.should.not.eql(4);
+
+    err(() => {
+        expect(4).to.eql(3, 'blah');
+        (4).should.eql(3, 'blah');
+    }, 'blah: expected 4 to deeply equal 3');
+}
+
+class Buffer {
+    constructor(arr: number[]) {
+    }
+}
+function buffer() {
+    expect(new Buffer([1])).to.eql(new Buffer([1]));
+    (new Buffer([1])).should.eql(new Buffer([1]));
+
+    err(() => {
+        expect(new Buffer([0])).to.eql(new Buffer([1]));
+        (new Buffer([0])).should.eql(new Buffer([1]));
+    }, 'expected <Buffer 00> to deeply equal <Buffer 01>');
+}
+
+function equal2() {
+    expect('test').to.equal('test');
+    'test'.should.equal('test');
+    should.equal('test', 'test');
+    expect(1).to.equal(1);
+    (1).should.equal(1);
+    should.equal(1, 1);
+
+    err(() => {
+        expect(4).to.equal(3, 'blah');
+        (4).should.equal(3, 'blah');
+        should.equal(4, 3, 'blah');
+    }, 'blah: expected 4 to equal 3');
+
+    err(() => {
+        expect('4').to.equal(4, 'blah');
+        '4'.should.equal(4, 'blah');
+        should.equal(4, 4, 'blah');
+    }, 'blah: expected \'4\' to equal 4');
+}
+
+function deepEqual() {
+    expect({ foo: 'bar' }).to.deep.equal({ foo: 'bar' });
+    ({ foo: 'bar' }).should.deep.equal({ foo: 'bar' });
+    expect({ foo: 'bar' }).not.to.deep.equal({ foo: 'baz' });
+}
+
+function deepEqual2() {
+    expect(/a/).to.deep.equal(/a/);
+    /a/.should.deep.equal(/a/);
+    expect(/a/).not.to.deep.equal(/b/);
+    expect(/a/).not.to.deep.equal({});
+    expect(/a/g).to.deep.equal(/a/g);
+    /a/g.should.deep.equal(/a/g);
+    expect(/a/g).not.to.deep.equal(/b/g);
+    expect(/a/i).to.deep.equal(/a/i);
+    /a/i.should.deep.equal(/a/i);
+    expect(/a/i).not.to.deep.equal(/b/i);
+    expect(/a/m).to.deep.equal(/a/m);
+    /a/m.should.deep.equal(/a/m);
+    expect(/a/m).not.to.deep.equal(/b/m);
+}
+
+// ReSharper disable once InconsistentNaming
+function deepEqual3() {
+    var a = new Date(1, 2, 3);
+    var b = new Date(4, 5, 6);
+    expect(a).to.deep.equal(a);
+    a.should.deep.equal(a);
+    expect(a).not.to.deep.equal(b);
+    a.should.not.deep.equal(b);
+    expect(a).not.to.deep.equal({});
+    a.should.not.deep.equal({});
+}
+
+function deepInclude() {
+    expect(['foo', 'bar']).to.deep.include(['bar', 'foo']);
+    ['foo', 'bar'].should.deep.include(['bar', 'foo']);
+    expect(['foo', 'bar']).not.to.deep.equal(['foo', 'baz']);
+    ['foo', 'bar'].should.not.deep.equal(['foo', 'baz']);
+}
+
+class FakeArgs {
+    length: number;
+}
+
+function empty() {
+    FakeArgs.prototype.length = 0;
+
+    expect('').to.be.empty;
+
+    ''.should.be.empty;
+    expect('foo').not.to.be.empty;
+    'foo'.should.not.be.empty;
+    expect([]).to.be.empty;
+    [].should.be.empty;
+    expect(['foo']).not.to.be.empty;
+    ['foo'].should.not.be.empty;
+    expect(new FakeArgs).to.be.empty;
+    (new FakeArgs).should.be.empty;
+    expect({ arguments: 0 }).not.to.be.empty;
+    ({ arguments: 0 }).should.not.be.empty;
+    expect({}).to.be.empty;
+    ({}).should.be.empty;
+    expect({ foo: 'bar' }).not.to.be.empty;
+    ({ foo: 'bar' }).should.not.be.empty;
+
+    err(() => {
+        expect('').not.to.be.empty;
+        ''.should.not.be.empty;
+    }, 'expected \'\' not to be empty');
+
+    err(() => {
+        expect('foo').to.be.empty;
+        'foo'.should.be.empty;
+        'foo'.should.be.empty;
+    }, 'expected \'foo\' to be empty');
+
+    err(() => {
+        expect([]).not.to.be.empty;
+        [].should.not.be.empty;
+    }, 'expected [] not to be empty');
+
+    err(() => {
+        expect(['foo']).to.be.empty;
+        ['foo'].should.be.empty;
+    }, 'expected [ \'foo\' ] to be empty');
+
+    err(() => {
+        expect(new FakeArgs).not.to.be.empty;
+        (new FakeArgs).should.not.be.empty;
+    }, 'expected { length: 0 } not to be empty');
+
+    err(() => {
+        expect({ arguments: 0 }).to.be.empty;
+        ({ arguments: 0 }).should.be.empty;
+    }, 'expected { arguments: 0 } to be empty');
+
+    err(() => {
+        expect({}).not.to.be.empty;
+        ({}).should.not.be.empty;
+    }, 'expected {} not to be empty');
+
+    err(() => {
+        expect({ foo: 'bar' }).to.be.empty;
+        ({ foo: 'bar' }).should.be.empty;
+    }, 'expected { foo: \'bar\' } to be empty');
+}
+
+function property() {
+    expect('test').to.have.property('length');
+    'test'.should.have.property('length');
+    expect(4).to.not.have.property('length');
+    (4).should.not.have.property('length');
+
+    expect({ 'foo.bar': 'baz' })
+        .to.have.property('foo.bar');
+    ({ 'foo.bar': 'baz' }).should.have.property('foo.bar');
+    expect({ foo: { bar: 'baz' } })
+        .to.not.have.property('foo.bar');
+    ({ foo: { bar: 'baz' } }).should.not.have.property('foo.bar');
+
+    err(() => {
+        expect('asd').to.have.property('foo');
+        'asd'.should.have.property('foo');
+    }, 'expected \'asd\' to have a property \'foo\'');
+    err(() => {
+        expect({ foo: { bar: 'baz' } })
+            .to.have.property('foo.bar');
+        ({ foo: { bar: 'baz' } }).should.have.property('foo.bar');
+    }, 'expected { foo: { bar: \'baz\' } } to have a property \'foo.bar\'');
+}
+
+function deepProperty() {
+    expect({ 'foo.bar': 'baz' })
+        .to.not.have.deep.property('foo.bar');
+    ({ 'foo.bar': 'baz' }).should
+        .not.have.deep.property('foo.bar');
+    expect({ foo: { bar: 'baz' } })
+        .to.have.deep.property('foo.bar');
+    ({ foo: { bar: 'baz' } }).should
+        .have.deep.property('foo.bar');
+
+    err(() => {
+        expect({ 'foo.bar': 'baz' })
+            .to.have.deep.property('foo.bar');
+        ({ 'foo.bar': 'baz' }).should
+            .have.deep.property('foo.bar');
+    }, 'expected { \'foo.bar\': \'baz\' } to have a deep property \'foo.bar\'');
+}
+
+function property2() {
+    expect('test').to.have.property('length', 4);
+    'test'.should.have.property('length', 4);
+    expect('asd').to.have.property('constructor', String);
+    'asd'.should.have.property('constructor', String);
+
+    err(() => {
+        expect('asd').to.have.property('length', 4, 'blah');
+        'asd'.should.have.property('length', 4, 'blah');
+    }, 'blah: expected \'asd\' to have a property \'length\' of 4, but got 3');
+
+    err(() => {
+        expect('asd').to.not.have.property('length', 3, 'blah');
+        'asd'.should.not.have.property('length', 3, 'blah');
+    }, 'blah: expected \'asd\' to not have a property \'length\' of 3');
+
+    err(() => {
+        expect('asd').to.not.have.property('foo', 3, 'blah');
+        'asd'.should.not.have.property('foo', 3, 'blah');
+    }, 'blah: \'asd\' has no property \'foo\'');
+
+    err(() => {
+        expect('asd').to.have.property('constructor', Number, 'blah');
+        'asd'.should.have.property('constructor', Number, 'blah');
+    }, 'blah: expected \'asd\' to have a property \'constructor\' of [Function: Number], but got [Function: String]');
+}
+
+function deepProperty2() {
+    expect({ foo: { bar: 'baz' } })
+        .to.have.deep.property('foo.bar', 'baz');
+    ({ foo: { bar: 'baz' } }).should
+        .have.deep.property('foo.bar', 'baz');
+
+    err(() => {
+        expect({ foo: { bar: 'baz' } })
+            .to.have.deep.property('foo.bar', 'quux', 'blah');
+        ({ foo: { bar: 'baz' } }).should
+            .have.deep.property('foo.bar', 'quux', 'blah');
+    }, 'blah: expected { foo: { bar: \'baz\' } } to have a deep property \'foo.bar\' of \'quux\', but got \'baz\'');
+    err(() => {
+        expect({ foo: { bar: 'baz' } })
+            .to.not.have.deep.property('foo.bar', 'baz', 'blah');
+        ({ foo: { bar: 'baz' } }).should
+            .not.have.deep.property('foo.bar', 'baz', 'blah');
+    }, 'blah: expected { foo: { bar: \'baz\' } } to not have a deep property \'foo.bar\' of \'baz\'');
+    err(() => {
+        expect({ foo: 5 })
+            .to.not.have.deep.property('foo.bar', 'baz', 'blah');
+        ({ foo: 5 }).should
+            .not.have.deep.property('foo.bar', 'baz', 'blah');
+    }, 'blah: { foo: 5 } has no deep property \'foo.bar\'');
+}
+
+function ownProperty() {
+    expect('test').to.have.ownProperty('length');
+    'test'.should.have.ownProperty('length');
+    expect('test').to.haveOwnProperty('length');
+    'test'.should.haveOwnProperty('length');
+    expect({ length: 12 }).to.have.ownProperty('length');
+    ({ length: 12 }).should.have.ownProperty('length');
+
+    err(() => {
+        expect({ length: 12 }).to.not.have.ownProperty('length', 'blah');
+        ({ length: 12 }).should.not.have.ownProperty('length', 'blah');
+    }, 'blah: expected { length: 12 } to not have own property \'length\'');
+}
+
+function ownPropertyDescriptor() {
+    expect('test').to.have.ownPropertyDescriptor('length');
+    expect('test').to.have.ownPropertyDescriptor('length', { enumerable: false, configurable: false, writable: false, value: 4 });
+    expect('test').not.to.have.ownPropertyDescriptor('length', { enumerable: false, configurable: false, writable: false, value: 3 });
+    expect('test').to.haveOwnPropertyDescriptor('length').to.have.property('enumerable', false);
+    expect('test').to.haveOwnPropertyDescriptor('length').to.contain.keys('value');
+
+    'test'.should.have.ownPropertyDescriptor('length');
+    'test'.should.have.ownPropertyDescriptor('length', { enumerable: false, configurable: false, writable: false, value: 4 });
+    'test'.should.not.have.ownPropertyDescriptor('length', { enumerable: false, configurable: false, writable: false, value: 3 });
+    'test'.should.haveOwnPropertyDescriptor('length').to.have.property('enumerable', false);
+    'test'.should.haveOwnPropertyDescriptor('length').to.contain.keys('value');
+}
+
+function string() {
+    expect('foobar').to.have.string('bar');
+    'foobar'.should.have.string('bar');
+    expect('foobar').to.have.string('foo');
+    'foobar'.should.have.string('foo');
+    expect('foobar').to.not.have.string('baz');
+    'foobar'.should.not.have.string('baz');
+
+    err(() => {
+        expect(3).to.have.string('baz');
+        (3).should.have.string('baz');
+    }, 'expected 3 to be a string');
+
+    err(() => {
+        expect('foobar').to.have.string('baz', 'blah');
+        'foobar'.should.have.string('baz', 'blah');
+    }, 'blah: expected \'foobar\' to contain \'baz\'');
+
+    err(() => {
+        expect('foobar').to.not.have.string('bar', 'blah');
+        'foobar'.should.not.have.string('bar', 'blah');
+    }, 'blah: expected \'foobar\' to not contain \'bar\'');
+}
+
+function include() {
+    expect(['foo', 'bar']).to.include('foo');
+    ['foo', 'bar'].should.include('foo');
+    expect(['foo', 'bar']).to.include('foo');
+    ['foo', 'bar'].should.include('foo');
+    expect(['foo', 'bar']).to.include('bar');
+    ['foo', 'bar'].should.include('bar');
+    expect([1, 2]).to.include(1);
+    [1, 2].should.include(1);
+    expect(['foo', 'bar']).to.not.include('baz');
+    ['foo', 'bar'].should.not.include('baz');
+    expect(['foo', 'bar']).to.not.include(1);
+    ['foo', 'bar'].should.not.include(1);
+    // alias
+
+    expect(['foo', 'bar']).includes('foo');
+    ['foo', 'bar'].should.includes('foo');
+
+    err(() => {
+        expect(['foo']).to.include('bar', 'blah');
+        ['foo'].should.include('bar', 'blah');
+    }, 'blah: expected [ \'foo\' ] to include \'bar\'');
+
+    err(() => {
+        expect(['bar', 'foo']).to.not.include('foo', 'blah');
+        ['bar', 'foo'].should.not.include('foo', 'blah');
+    }, 'blah: expected [ \'bar\', \'foo\' ] to not include \'foo\'');
+}
+
+function keys() {
+    expect({ foo: 1 }).to.have.keys(['foo']);
+    ({ foo: 1 }).should.have.keys(['foo']);
+    expect({ foo: 1, bar: 2 }).to.have.keys(['foo', 'bar']);
+    ({ foo: 1, bar: 2 }).should.have.keys(['foo', 'bar']);
+    expect({ foo: 1, bar: 2 }).to.have.keys('foo', 'bar');
+    ({ foo: 1, bar: 2 }).should.have.keys('foo', 'bar');
+    expect({ foo: 1, bar: 2, baz: 3 }).to.contain.keys('foo', 'bar');
+    ({ foo: 1, bar: 2, baz: 3 }).should.contain.keys('foo', 'bar');
+    expect({ foo: 1, bar: 2, baz: 3 }).to.contain.keys('bar', 'foo');
+    ({ foo: 1, bar: 2, baz: 3 }).should.contain.keys('bar', 'foo');
+    expect({ foo: 1, bar: 2, baz: 3 }).to.contain.keys('baz');
+    ({ foo: 1, bar: 2, baz: 3 }).should.contain.keys('baz');
+    // alias
+
+    expect({ foo: 1, bar: 2, baz: 3 }).contains.keys('baz');
+
+    expect({ foo: 1, bar: 2 }).to.have.all.keys(['foo', 'bar']);
+    expect({ foo: 1, bar: 2 }).to.have.any.keys(['foo', 'bar']);
+    ({ foo: 1, bar: 2, baz: 3 }).should.contain.all.keys('baz');
+    ({ foo: 1, bar: 2, baz: 3 }).should.contain.any.keys('baz');
+
+    expect({ foo: 1, bar: 2 }).to.contain.keys('foo');
+    ({ foo: 1, bar: 2 }).should.contain.keys('foo');
+    expect({ foo: 1, bar: 2 }).to.contain.keys('bar', 'foo');
+    ({ foo: 1, bar: 2 }).should.contain.keys('bar', 'foo');
+    expect({ foo: 1, bar: 2 }).to.contain.keys(['foo']);
+    ({ foo: 1, bar: 2 }).should.contain.keys(['foo']);
+    expect({ foo: 1, bar: 2 }).to.contain.keys(['bar']);
+    ({ foo: 1, bar: 2 }).should.contain.keys(['bar']);
+    expect({ foo: 1, bar: 2 }).to.contain.keys(['bar', 'foo']);
+    ({ foo: 1, bar: 2 }).should.contain.keys(['bar', 'foo']);
+
+    expect({ foo: 1, bar: 2 }).to.not.have.keys('baz');
+    ({ foo: 1, bar: 2 }).should.not.have.keys('baz');
+    expect({ foo: 1, bar: 2 }).to.not.have.keys('foo', 'baz');
+    ({ foo: 1, bar: 2 }).should.not.have.keys('foo', 'baz');
+    expect({ foo: 1, bar: 2 }).to.not.contain.keys('baz');
+    ({ foo: 1, bar: 2 }).should.not.contain.keys('baz');
+    expect({ foo: 1, bar: 2 }).to.not.contain.keys('foo', 'baz');
+    ({ foo: 1, bar: 2 }).should.not.contain.keys('foo', 'baz');
+    expect({ foo: 1, bar: 2 }).to.not.contain.keys('baz', 'foo');
+    ({ foo: 1, bar: 2 }).should.not.contain.keys('baz', 'foo');
+
+    err(() => {
+        expect({ foo: 1 }).to.have.keys();
+        ({ foo: 1 }).should.have.keys();
+    }, 'keys required');
+
+    err(() => {
+        expect({ foo: 1 }).to.have.keys([]);
+        ({ foo: 1 }).should.have.keys([]);
+    }, 'keys required');
+
+    err(() => {
+        expect({ foo: 1 }).to.not.have.keys([]);
+        ({ foo: 1 }).should.not.have.keys([]);
+    }, 'keys required');
+
+    err(() => {
+        expect({ foo: 1 }).to.contain.keys([]);
+        ({ foo: 1 }).should.contain.keys([]);
+    }, 'keys required');
+
+    err(() => {
+        expect({ foo: 1 }).to.have.keys(['bar']);
+        ({ foo: 1 }).should.have.keys(['bar']);
+    }, 'expected { foo: 1 } to have key \'bar\'');
+
+    err(() => {
+        expect({ foo: 1 }).to.have.keys(['bar', 'baz']);
+        ({ foo: 1 }).should.have.keys(['bar', 'baz']);
+    }, 'expected { foo: 1 } to have keys \'bar\', and \'baz\'');
+
+    err(() => {
+        expect({ foo: 1 }).to.have.keys(['foo', 'bar', 'baz']);
+        ({ foo: 1 }).should.have.keys(['foo', 'bar', 'baz']);
+    }, 'expected { foo: 1 } to have keys \'foo\', \'bar\', and \'baz\'');
+
+    err(() => {
+        expect({ foo: 1 }).to.not.have.keys(['foo']);
+        ({ foo: 1 }).should.not.have.keys(['foo']);
+    }, 'expected { foo: 1 } to not have key \'foo\'');
+
+    err(() => {
+        expect({ foo: 1 }).to.not.have.keys(['foo']);
+        ({ foo: 1 }).should.not.have.keys(['foo']);
+    }, 'expected { foo: 1 } to not have key \'foo\'');
+
+    err(() => {
+        expect({ foo: 1, bar: 2 }).to.not.have.keys(['foo', 'bar']);
+        ({ foo: 1, bar: 2 }).should.not.have.keys(['foo', 'bar']);
+    }, 'expected { foo: 1, bar: 2 } to not have keys \'foo\', and \'bar\'');
+
+    err(() => {
+        expect({ foo: 1 }).to.not.contain.keys(['foo']);
+        ({ foo: 1 }).should.not.contain.keys(['foo']);
+    }, 'expected { foo: 1 } to not contain key \'foo\'');
+
+    err(() => {
+        expect({ foo: 1 }).to.contain.keys('foo', 'bar');
+        ({ foo: 1 }).should.contain.keys('foo', 'bar');
+    }, 'expected { foo: 1 } to contain keys \'foo\', and \'bar\'');
+}
+
+function chaining() {
+    var tea = { name: 'chai', extras: ['milk', 'sugar', 'smile'] };
+    expect(tea).to.have.property('extras').with.lengthOf(3);
+    tea.should.have.property('extras').with.lengthOf(3);
+
+    err(() => {
+        expect(tea).to.have.property('extras').with.lengthOf(4);
+        tea.should.have.property('extras').with.lengthOf(4);
+    }, 'expected [ \'milk\', \'sugar\', \'smile\' ] to have a length of 4 but got 3');
+
+    expect(tea).to.be.a('object').and.have.property('name', 'chai');
+    tea.should.be.a('object').and.have.property('name', 'chai');
+}
+
+function exxtensible() {
+    expect({}).to.be.extensible;
+    expect(Object.preventExtensions({})).to.be.not.extensible;
+    ({}).should.be.extensible;
+    Object.preventExtensions({}).should.not.be.extensible;
+}
+function sealed() {
+    expect({}).to.be.not.sealed;
+    expect(Object.seal({})).to.be.sealed;
+    ({}).should.be.not.sealed;
+    Object.seal({}).should.be.sealed;
+}
+
+function frozen() {
+    expect({}).to.be.not.frozen;
+    expect(Object.freeze({})).to.be.frozen;
+    ({}).should.be.not.frozen;
+    Object.freeze({}).should.be.frozen;
+}
+
+
+class PoorlyConstructedError { }
+function _throw() {
+    // See GH-45: some poorly-constructed custom errors don't have useful names
+    // on either their constructor or their constructor prototype, but instead
+    // only set the name inside the constructor itself.
+    PoorlyConstructedError.prototype = Object.create(Error.prototype);
+
+    var specificError = new RangeError('boo');
+
+    var goodFn = () => { }
+        , badFn = () => { throw new Error('testing'); }
+        , refErrFn = () => { throw new ReferenceError('hello'); }
+        , ickyErrFn = () => { throw new PoorlyConstructedError(); }
+        , specificErrFn = () => { throw specificError; };
+
+    expect(goodFn).to.not.throw();
+    goodFn.should.not.throw();
+    should.not.throw(goodFn);
+    expect(goodFn).to.not.throw(Error);
+    goodFn.should.not.throw(Error);
+    should.not.throw(goodFn, Error);
+    expect(goodFn).to.not.throw(specificError);
+    goodFn.should.not.throw(specificError);
+    should.not.throw(goodFn, specificError);
+
+    expect(badFn).to.throw();
+    badFn.should.throw();
+    should.throw(badFn);
+    expect(badFn).to.throw(Error);
+    badFn.should.throw(Error);
+    should.throw(badFn, Error);
+    expect(badFn).to.not.throw(ReferenceError);
+    badFn.should.not.throw(ReferenceError);
+    should.not.throw(badFn, ReferenceError);
+    expect(badFn).to.not.throw(specificError);
+    badFn.should.not.throw(specificError);
+    should.not.throw(badFn, specificError);
+
+    expect(refErrFn).to.throw();
+    refErrFn.should.throw();
+    should.throw(refErrFn);
+    expect(refErrFn).to.throw(ReferenceError);
+    refErrFn.should.throw(ReferenceError);
+    should.throw(refErrFn, ReferenceError);
+    expect(refErrFn).to.throw(Error);
+    refErrFn.should.throw(Error);
+    should.throw(refErrFn, Error);
+    expect(refErrFn).to.not.throw(TypeError);
+    refErrFn.should.not.throw(TypeError);
+    should.not.throw(refErrFn, TypeError);
+    expect(refErrFn).to.not.throw(specificError);
+    refErrFn.should.not.throw(specificError);
+    should.not.throw(refErrFn, specificError);
+
+    expect(ickyErrFn).to.throw();
+    ickyErrFn.should.throw();
+    should.throw(ickyErrFn);
+    expect(ickyErrFn).to.throw(PoorlyConstructedError);
+    ickyErrFn.should.throw(PoorlyConstructedError);
+    should.throw(ickyErrFn, PoorlyConstructedError);
+    expect(ickyErrFn).to.throw(Error);
+    ickyErrFn.should.throw(Error);
+    should.throw(ickyErrFn, Error);
+    expect(ickyErrFn).to.not.throw(specificError);
+    ickyErrFn.should.not.throw(specificError);
+    should.not.throw(ickyErrFn, specificError);
+    expect(specificErrFn).to.throw(specificError);
+    specificErrFn.should.throw(specificError);
+    should.throw(ickyErrFn, specificError);
+
+    expect(badFn).to.throw(/testing/);
+    badFn.should.throw(/testing/);
+    should.throw(badFn, /testing/);
+    expect(badFn).to.not.throw(/hello/);
+    badFn.should.not.throw(/hello/);
+    should.not.throw(badFn, /hello/);
+    expect(badFn).to.throw('testing');
+    badFn.should.throw('testing');
+    should.throw(badFn, 'testing');
+    expect(badFn).to.not.throw('hello');
+    badFn.should.not.throw('hello');
+    should.not.throw(badFn, 'hello');
+
+    expect(badFn).to.throw(Error, /testing/);
+    badFn.should.throw(Error, /testing/);
+    should.throw(badFn, Error, /testing/);
+    expect(badFn).to.throw(Error, 'testing');
+    badFn.should.throw(Error, 'testing');
+    should.throw(badFn, Error, 'testing');
+
+    err(() => {
+        expect(goodFn).to.throw();
+        goodFn.should.throw();
+        should.throw(goodFn);
+    }, 'expected [Function] to throw an error');
+
+    err(() => {
+        expect(goodFn).to.throw(ReferenceError);
+        goodFn.should.throw(ReferenceError);
+        should.throw(goodFn, ReferenceError);
+    }, 'expected [Function] to throw ReferenceError');
+
+    err(() => {
+        expect(goodFn).to.throw(specificError);
+        goodFn.should.throw(specificError);
+        should.throw(goodFn, specificError);
+    }, 'expected [Function] to throw [RangeError: boo]');
+
+    err(() => {
+        expect(badFn).to.not.throw();
+        badFn.should.not.throw();
+        should.not.throw(badFn);
+    }, 'expected [Function] to not throw an error but [Error: testing] was thrown');
+
+    err(() => {
+        expect(badFn).to.throw(ReferenceError);
+        badFn.should.throw(ReferenceError);
+        should.throw(badFn, ReferenceError);
+    }, 'expected [Function] to throw \'ReferenceError\' but [Error: testing] was thrown');
+
+    err(() => {
+        expect(badFn).to.throw(specificError);
+        badFn.should.throw(specificError);
+        should.throw(badFn, specificError);
+    }, 'expected [Function] to throw [RangeError: boo] but [Error: testing] was thrown');
+
+    err(() => {
+        expect(badFn).to.not.throw(Error);
+        badFn.should.not.throw(Error);
+        should.not.throw(badFn, Error);
+    }, 'expected [Function] to not throw \'Error\' but [Error: testing] was thrown');
+
+    err(() => {
+        expect(refErrFn).to.not.throw(ReferenceError);
+        refErrFn.should.not.throw(ReferenceError);
+        should.not.throw(refErrFn, ReferenceError);
+    }, 'expected [Function] to not throw \'ReferenceError\' but [ReferenceError: hello] was thrown');
+
+    err(() => {
+        expect(badFn).to.throw(PoorlyConstructedError);
+        badFn.should.throw(PoorlyConstructedError);
+        should.throw(badFn, PoorlyConstructedError);
+    }, 'expected [Function] to throw \'PoorlyConstructedError\' but [Error: testing] was thrown');
+
+    err(() => {
+        expect(ickyErrFn).to.not.throw(PoorlyConstructedError);
+        ickyErrFn.should.not.throw(PoorlyConstructedError);
+        should.not.throw(ickyErrFn, PoorlyConstructedError);
+    }, /^(expected \[Function\] to not throw 'PoorlyConstructedError' but)(.*)(PoorlyConstructedError|\{ Object \()(.*)(was thrown)$/);
+
+    err(() => {
+        expect(ickyErrFn).to.throw(ReferenceError);
+        ickyErrFn.should.throw(ReferenceError);
+        should.throw(ickyErrFn, ReferenceError);
+    }, /^(expected \[Function\] to throw 'ReferenceError' but)(.*)(PoorlyConstructedError|\{ Object \()(.*)(was thrown)$/);
+
+    err(() => {
+        expect(specificErrFn).to.throw(new ReferenceError('eek'));
+        specificErrFn.should.throw(new ReferenceError('eek'));
+        should.throw(specificErrFn, new ReferenceError('eek'));
+    }, 'expected [Function] to throw [ReferenceError: eek] but [RangeError: boo] was thrown');
+
+    err(() => {
+        expect(specificErrFn).to.not.throw(specificError);
+        specificErrFn.should.not.throw(specificError);
+        should.not.throw(specificErrFn, specificError);
+    }, 'expected [Function] to not throw [RangeError: boo]');
+
+    err(() => {
+        expect(badFn).to.not.throw(/testing/);
+        badFn.should.not.throw(/testing/);
+        should.not.throw(badFn, /testing/);
+    }, 'expected [Function] to throw error not matching /testing/');
+
+    err(() => {
+        expect(badFn).to.throw(/hello/);
+        badFn.should.throw(/hello/);
+        should.throw(badFn, /hello/);
+    }, 'expected [Function] to throw error matching /hello/ but got \'testing\'');
+
+    err(() => {
+        expect(badFn).to.throw(Error, /hello/, 'blah');
+        badFn.should.throw(Error, /hello/, 'blah');
+        should.throw(badFn, Error, /hello/, 'blah');
+    }, 'blah: expected [Function] to throw error matching /hello/ but got \'testing\'');
+
+    err(() => {
+        expect(badFn).to.throw(Error, 'hello', 'blah');
+        badFn.should.throw(Error, 'hello', 'blah');
+        should.throw(badFn, Error, 'hello', 'blah');
+    }, 'blah: expected [Function] to throw error including \'hello\' but got \'testing\'');
+}
+
+function use() {
+    // ReSharper disable once InconsistentNaming
+    chai.use((_chai) => {
+        _chai.can.use.any();
+    });
+
+    // chain style: use mulptile plug-ins
+    let expect = chai
+        .use((_chai, util) => {})
+        .use((_chai, util) => {})
+        .expect;
+}
+
+class Klass {
+    val: number;
+    constructor() { this.val = 0; }
+    bar() { }
+
+    static baz() { }
+}
+
+function respondTo() {
+    var obj = new Klass();
+
+    expect(Klass).to.respondTo('bar');
+    expect(obj).respondsTo('bar');
+    Klass.should.respondTo('bar');
+    Klass.should.respondsTo('bar');
+    expect(Klass).to.not.respondTo('foo');
+    Klass.should.not.respondTo('foo');
+    expect(Klass).itself.to.respondTo('func');
+    expect(Klass).itself.not.to.respondTo('bar');
+
+    expect(obj).not.to.respondTo('foo');
+    obj.should.not.respondTo('foo');
+
+    err(() => {
+        expect(Klass).to.respondTo('baz', 'constructor');
+        Klass.should.respondTo('baz', 'constructor');
+    }, /^(constructor: expected)(.*)(\[Function: Klass\])(.*)(to respond to \'baz\')$/);
+
+    err(() => {
+        expect(obj).to.respondTo('baz', 'object');
+        obj.should.respondTo('baz', 'object');
+    }, /^(object: expected)(.*)(\{ foo: \[Function\] \}|\{ Object \()(.*)(to respond to \'baz\')$/);
+}
+
+function satisfy() {
+    function matcher(num: number) {
+        return num === 1;
+    }
+
+    expect(1).to.satisfy(matcher);
+    (1).should.satisfy(matcher);
+
+    err(() => {
+        expect(2).to.satisfy(matcher, 'blah');
+        (2).should.satisfy(matcher, 'blah');
+    }, 'blah: expected 2 to satisfy [Function: matcher]');
+}
+
+function closeTo() {
+    expect(1.5).to.be.closeTo(1.0, 0.5);
+    (1.5).should.be.closeTo(1.0, 0.5);
+    expect(10).to.be.closeTo(20, 20);
+    (10).should.be.closeTo(20, 20);
+    expect(-10).to.be.closeTo(20, 30);
+    (-10).should.be.closeTo(20, 30);
+
+    err(() => {
+        expect(2).to.be.closeTo(1.0, 0.5, 'blah');
+        (2).should.be.closeTo(1.0, 0.5, 'blah');
+    }, 'blah: expected 2 to be close to 1 +/- 0.5');
+
+    err(() => {
+        expect(-10).to.be.closeTo(20, 29, 'blah');
+        (-10).should.be.closeTo(20, 29, 'blah');
+    }, 'blah: expected -10 to be close to 20 +/- 29');
+}
+
+function approximately() {
+    expect(1.5).to.be.approximately(1.0, 0.5);
+    (1.5).should.be.approximately(1.0, 0.5);
+    expect(10).to.be.approximately(20, 20);
+    (10).should.be.approximately(20, 20);
+    expect(-10).to.be.approximately(20, 30);
+    (-10).should.be.approximately(20, 30);
+
+    err(() => {
+        expect(2).to.be.approximately(1.0, 0.5, 'blah');
+        (2).should.be.approximately(1.0, 0.5, 'blah');
+    }, 'blah: expected 2 to be close to 1 +/- 0.5');
+
+    err(() => {
+        expect(-10).to.be.approximately(20, 29, 'blah');
+        (-10).should.be.approximately(20, 29, 'blah');
+    }, 'blah: expected -10 to be close to 20 +/- 29');
+}
+
+function includeMembers() {
+    expect([1, 2, 3]).to.include.members([]);
+    [1, 2, 3].should.include.members([]);
+
+    expect([1, 2, 3]).to.include.members([3, 2]);
+
+    [1, 2, 3].should.include.members([3, 2]);
+
+    expect([1, 2, 3]).to.not.include.members([8, 4]);
+
+    [1, 2, 3].should.not.include.members([8, 4]);
+
+    expect([1, 2, 3]).to.not.include.members([1, 2, 3, 4]);
+
+    [1, 2, 3].should.not.include.members([1, 2, 3, 4]);
+}
+
+function sameMembers() {
+    expect([5, 4]).to.have.same.members([4, 5]);
+    [5, 4].should.have.same.members([4, 5]);
+    expect([5, 4]).to.have.same.members([5, 4]);
+    [5, 4].should.have.same.members([5, 4]);
+
+    expect([5, 4]).to.not.have.same.members([]);
+    [5, 4].should.not.have.same.members([]);
+    expect([5, 4]).to.not.have.same.members([6, 3]);
+    [5, 4].should.not.have.same.members([6, 3]);
+    expect([5, 4]).to.not.have.same.members([5, 4, 2]);
+    [5, 4].should.not.have.same.members([5, 4, 2]);
+
+    assert.sameMembers([5, 4], [4, 5]);
+}
+function sameDeepMembers() {
+    expect([{ id: 5 }, { id: 4 }]).to.have.same.deep.members([{ id: 4 }, { id: 5 }]);
+    [{ id: 5 }, { id: 4 }].should.have.same.deep.members([{ id: 4 }, { id: 5 }]);
+    expect([{ id: 5 }, { id: 4 }]).to.have.same.members([{ id: 5 }, { id: 4 }]);
+    [{ id: 5 }, { id: 4 }].should.have.same.members([{ id: 5 }, { id: 4 }]);
+
+    expect([{ id: 5 }, { id: 4 }]).to.not.have.same.members([]);
+    [{ id: 5 }, { id: 4 }].should.not.have.same.members([]);
+    expect([{ id: 5 }, { id: 4 }]).to.not.have.same.members([{ id: 6 }, { id: 3 }]);
+    [{ id: 5 }, { id: 4 }].should.not.have.same.members([{ id: 6 }, { id: 3 }]);
+    expect([{ id: 5 }, { id: 4 }]).to.not.have.same.members([{ id: 5 }, { id: 4 }, { id: 2 }]);
+    [{ id: 5 }, { id: 4 }].should.not.have.same.members([{ id: 5 }, { id: 4 }, { id: 2 }]);
+
+    assert.sameDeepMembers([{ id: 5 }, { id: 4 }], [{ id: 4 }, { id: 5 }]);
+}
+
+function members() {
+    expect([5, 4]).members([4, 5]);
+    expect([5, 4]).members([5, 4]);
+
+    expect([5, 4]).not.members([]);
+    expect([5, 4]).not.members([6, 3]);
+    expect([5, 4]).not.members([5, 4, 2]);
+}
+
+function increaseDecreaseChange() {
+    var obj = { val: 10 };
+    var inc = () => { obj.val++; };
+    var dec = () => { obj.val--; };
+    var same = () => { };
+
+    expect(inc).to.increase(obj, "val");
+    expect(inc).increases(obj, "val");
+    expect(inc).to.change(obj, "val");
+
+    expect(dec).to.decrease(obj, "val");
+    expect(dec).decreases(obj, "val");
+    expect(dec).to.change(obj, "val");
+    expect(dec).changes(obj, "val");
+
+    expect(inc).to.not.decrease(obj, "val");
+    expect(dec).to.not.increase(obj, "val");
+    expect(same).to.not.increase(obj, "val");
+    expect(same).to.not.decrease(obj, "val");
+    expect(same).to.not.change(obj, "val");
+
+    inc.should.increase(obj, "val");
+    inc.should.change(obj, "val");
+
+    dec.should.decrease(obj, "val");
+    dec.should.change(obj, "val");
+
+    inc.should.not.decrease(obj, "val");
+    dec.should.not.increase(obj, "val");
+    same.should.not.change(obj, "val");
+}
+
+function oneOf() {
+    var obj = { z: 3 };
+
+    expect(5).to.be.oneOf([1, 5, 4]);
+    expect('z').to.be.oneOf(['x', 'y', 'z']);
+    expect(obj).to.be.oneOf([obj]);
+
+    expect(5).to.not.be.oneOf([1, -12, 4]);
+    expect(5).to.not.be.oneOf([1, [5], 4]);
+    expect('z').to.not.be.oneOf(['w', 'x', 'y']);
+    expect('z').to.not.be.oneOf(['x', 'y', ['z']]);
+    expect(obj).to.not.be.oneOf([{ z: 3 }]);
+}
+
+//tdd
+declare function suite(description: string, action: Function): void;
+declare function test(description: string, action: Function): void;
+
+interface FieldObj {
+    field: any;
+}
+
+class CrashyObject {
+    inspect(): void {
+        throw new Error('Arg\'s inspect() called even though the test passed');
+    }
+}
+
+suite('assert', () => {
+
+    test('assert', () => {
+        var foo = 'bar';
+        assert(foo === 'bar', 'expected foo to equal `bar`');
+
+        err(() => {
+            assert(foo === 'baz', 'expected foo to equal `bar`');
+        }, 'expected foo to equal `bar`');
+    });
+
+    test('isTrue', () => {
+        assert.isTrue(true);
+
+        err(() => {
+            assert.isTrue(false);
+        }, 'expected false to be true');
+
+        err(() => {
+            assert.isTrue(1);
+        }, 'expected 1 to be true');
+
+        err(() => {
+            assert.isTrue('test');
+        }, 'expected \'test\' to be true');
+    });
+
+    test('ok', () => {
+        assert.ok(true);
+        assert.ok(1);
+        assert.ok('test');
+        assert.isOk(true);
+        assert.isOk(1);
+        assert.isOk('test');
+
+        err(() => {
+            assert.ok(false);
+        }, 'expected false to be truthy');
+
+        err(() => {
+            assert.ok(0);
+        }, 'expected 0 to be truthy');
+
+        err(() => {
+            assert.ok('');
+        }, 'expected \'\' to be truthy');
+    });
+
+    test('notOk', () => {
+        assert.notOk(false);
+        assert.notOk(0);
+        assert.notOk('');
+        assert.isNotOk(false);
+        assert.isNotOk(0);
+        assert.isNotOk('');
+
+        err(() => {
+            assert.notOk(true);
+        }, 'expected true to be falsy');
+
+        err(() => {
+            assert.notOk(1);
+        }, 'expected 1 to be falsy');
+
+        err(() => {
+            assert.notOk('test');
+        }, 'expected \'test\' to be falsy');
+    });
+
+    test('isFalse', () => {
+        assert.isFalse(false);
+
+        err(() => {
+            assert.isFalse(true);
+        }, 'expected true to be false');
+
+        err(() => {
+            assert.isFalse(0);
+        }, 'expected 0 to be false');
+    });
+
+    test('equal', () => {
+        assert.equal(void (0), undefined);
+    });
+
+    test('typeof / notTypeOf', () => {
+        assert.typeOf('test', 'string');
+        assert.typeOf(true, 'boolean');
+        assert.typeOf(5, 'number');
+
+        err(() => {
+            assert.typeOf(5, 'string');
+        }, 'expected 5 to be a string');
+
+    });
+
+    test('notTypeOf', () => {
+        assert.notTypeOf('test', 'number');
+
+        err(() => {
+            assert.notTypeOf(5, 'number');
+        }, 'expected 5 not to be a number');
+    });
+
+    test('instanceOf', () => {
+        assert.instanceOf(new Foo(), Foo);
+
+        err(() => {
+            assert.instanceOf(5, Foo);
+        }, 'expected 5 to be an instance of Foo');
+        assert.instanceOf(new CrashyObject(), CrashyObject);
+    });
+
+    test('notInstanceOf', () => {
+        assert.notInstanceOf(new Foo(), String);
+
+        err(() => {
+            assert.notInstanceOf(new Foo(), Foo);
+        }, 'expected {} to not be an instance of Foo');
+    });
+
+    test('isObject', () => {
+        assert.isObject({});
+        assert.isObject(new Foo());
+
+        err(() => {
+            assert.isObject(true);
+        }, 'expected true to be an object');
+
+        err(() => {
+            assert.isObject(Foo);
+        }, 'expected [Function: Foo] to be an object');
+
+        err(() => {
+            assert.isObject('foo');
+        }, 'expected \'foo\' to be an object');
+    });
+
+    test('isNotObject', () => {
+        assert.isNotObject(5);
+
+        err(() => {
+            assert.isNotObject({});
+        }, 'expected {} not to be an object');
+    });
+
+    test('notEqual', () => {
+        assert.notEqual(3, 4);
+
+        err(() => {
+            assert.notEqual(5, 5);
+        }, 'expected 5 to not equal 5');
+    });
+
+    test('strictEqual', () => {
+        assert.strictEqual('foo', 'foo');
+        assert.strictEqual(5, 5);
+    });
+
+    test('notStrictEqual', () => {
+        assert.notStrictEqual('5', '5');
+        assert.notStrictEqual(5, 5);
+    });
+
+    test('deepEqual', () => {
+        assert.deepEqual({ tea: 'chai' }, { tea: 'chai' });
+
+        err(() => {
+            assert.deepEqual({ tea: 'chai' }, { tea: 'black' });
+        }, 'expected { tea: \'chai\' } to deeply equal { tea: \'black\' }');
+
+        var obja = Object.create({ tea: 'chai' })
+            , objb = Object.create({ tea: 'chai' });
+
+        assert.deepEqual(obja, objb);
+
+        var obj1 = Object.create({ tea: 'chai' })
+            , obj2 = Object.create({ tea: 'black' });
+
+        err(() => {
+            assert.deepEqual(obj1, obj2);
+        }, 'expected { tea: \'chai\' } to deeply equal { tea: \'black\' }');
+    });
+
+    test('deepEqual (ordering)', () => {
+        var a = { a: 'b', c: 'd' }
+            , b = { c: 'd', a: 'b' };
+        assert.deepEqual(a, b);
+    });
+
+    test('deepEqual (circular)', () => {
+        var circularObject: any = {}
+            , secondCircularObject: any = {};
+        circularObject.field = circularObject;
+        secondCircularObject.field = secondCircularObject;
+
+        assert.deepEqual(circularObject, secondCircularObject);
+
+        err(() => {
+            secondCircularObject.field2 = secondCircularObject;
+            assert.deepEqual(circularObject, secondCircularObject);
+        }, 'expected { field: [Circular] } to deeply equal { Object (field, field2) }');
+    });
+
+    test('notDeepEqual', () => {
+        assert.notDeepEqual({ tea: 'jasmine' }, { tea: 'chai' });
+        err(() => {
+            assert.notDeepEqual({ tea: 'chai' }, { tea: 'chai' });
+        }, 'expected { tea: \'chai\' } to not deeply equal { tea: \'chai\' }');
+    });
+
+    test('notDeepEqual (circular)', () => {
+        var circularObject: any = {}
+            , secondCircularObject: any = { tea: 'jasmine' };
+        circularObject.field = circularObject;
+        secondCircularObject.field = secondCircularObject;
+
+        assert.notDeepEqual(circularObject, secondCircularObject);
+
+        err(() => {
+            delete secondCircularObject.tea;
+            assert.notDeepEqual(circularObject, secondCircularObject);
+        }, 'expected { field: [Circular] } to not deeply equal { field: [Circular] }');
+    });
+
+    test('isNull', () => {
+        assert.isNull(null);
+
+        err(() => {
+            assert.isNull(undefined);
+        }, 'expected undefined to equal null');
+    });
+
+    test('isNotNull', () => {
+        assert.isNotNull(undefined);
+
+        err(() => {
+            assert.isNotNull(null);
+        }, 'expected null to not equal null');
+    });
+
+    test('isUndefined', () => {
+        assert.isUndefined(undefined);
+
+        err(() => {
+            assert.isUndefined(null);
+        }, 'expected null to equal undefined');
+    });
+
+    test('isDefined', () => {
+        assert.isDefined(null);
+
+        err(() => {
+            assert.isDefined(undefined);
+        }, 'expected undefined to not equal undefined');
+    });
+
+    test('isNaN', () => {
+        assert.isNaN(NaN);
+
+        err(() => {
+            assert.isNaN(12);
+        }, 'expected 12 to be NaN');
+    });
+
+    test('isNotNaN', () => {
+        assert.isNotNaN(12);
+
+        err(() => {
+            assert.isNotNaN(NaN);
+        }, 'expected NaN to not NaN');
+    });
+
+    test('isFunction', () => {
+        var func = () => {
+        };
+        assert.isFunction(func);
+
+        err(() => {
+            assert.isFunction({});
+        }, 'expected {} to be a function');
+    });
+
+    test('isNotFunction', () => {
+        assert.isNotFunction(5);
+
+        err(() => {
+            assert.isNotFunction(() => {
+            });
+        }, 'expected [Function] not to be a function');
+    });
+
+    test('isArray', () => {
+        assert.isArray([]);
+        assert.isArray(new Array<any>());
+
+        err(() => {
+            assert.isArray({});
+        }, 'expected {} to be an array');
+    });
+
+    test('isNotArray', () => {
+        assert.isNotArray(3);
+
+        err(() => {
+            assert.isNotArray([]);
+        }, 'expected [] not to be an array');
+
+        err(() => {
+            assert.isNotArray(new Array<any>());
+        }, 'expected [] not to be an array');
+    });
+
+    test('isString', () => {
+        assert.isString('Foo');
+        assert.isString(new String('foo'));
+
+        err(() => {
+            assert.isString(1);
+        }, 'expected 1 to be a string');
+    });
+
+    test('isNotString', () => {
+        assert.isNotString(3);
+        assert.isNotString(['hello']);
+
+        err(() => {
+            assert.isNotString('hello');
+        }, 'expected \'hello\' not to be a string');
+    });
+
+    test('isNumber', () => {
+        assert.isNumber(1);
+        assert.isNumber(Number('3'));
+
+        err(() => {
+            assert.isNumber('1');
+        }, 'expected \'1\' to be a number');
+    });
+
+    test('isNotNumber', () => {
+        assert.isNotNumber('hello');
+        assert.isNotNumber([5]);
+
+        err(() => {
+            assert.isNotNumber(4);
+        }, 'expected 4 not to be a number');
+    });
+
+    test('isBoolean', () => {
+        assert.isBoolean(true);
+        assert.isBoolean(false);
+
+        err(() => {
+            assert.isBoolean('1');
+        }, 'expected \'1\' to be a boolean');
+    });
+
+    test('isNotBoolean', () => {
+        assert.isNotBoolean('true');
+
+        err(() => {
+            assert.isNotBoolean(true);
+        }, 'expected true not to be a boolean');
+
+        err(() => {
+            assert.isNotBoolean(false);
+        }, 'expected false not to be a boolean');
+    });
+
+    test('include', () => {
+        assert.include('foobar', 'bar');
+        assert.include([1, 2, 3], 3);
+
+        err(() => {
+            assert.include('foobar', 'baz');
+        }, 'expected \'foobar\' to contain \'baz\'');
+
+        // Commented out because Typescript is able to report this type error
+        // err(() => {
+        //     assert.include(undefined, 'bar');
+        // }, 'expected an array or string');
+    });
+
+    test('notInclude', () => {
+        assert.notInclude('foobar', 'baz');
+        assert.notInclude([1, 2, 3], 4);
+
+        err(() => {
+            assert.notInclude('foobar', 'bar');
+        }, 'expected \'foobar\' to not contain \'bar\'');
+
+      // Commented out because Typescript is able to report this type error
+      // err(() => {
+      //       assert.notInclude(undefined, 'bar');
+      //   }, 'expected an array or string');
+    });
+
+    test('lengthOf', () => {
+        assert.lengthOf([1, 2, 3], 3);
+        assert.lengthOf('foobar', 6);
+
+        err(() => {
+            assert.lengthOf('foobar', 5);
+        }, 'expected \'foobar\' to have a length of 5 but got 6');
+    });
+
+    test('match', () => {
+        assert.match('foobar', /^foo/);
+        assert.notMatch('foobar', /^bar/);
+
+        err(() => {
+            assert.match('foobar', /^bar/i);
+        }, 'expected \'foobar\' to match /^bar/i');
+
+        err(() => {
+            assert.notMatch('foobar', /^foo/i);
+        }, 'expected \'foobar\' not to match /^foo/i');
+    });
+
+    test('property', () => {
+        var obj = { foo: { bar: 'baz' } };
+        var simpleObj = { foo: 'bar' };
+        assert.property(obj, 'foo');
+        assert.deepProperty(obj, 'foo.bar');
+        assert.notProperty(obj, 'baz');
+        assert.notProperty(obj, 'foo.bar');
+        assert.notDeepProperty(obj, 'foo.baz');
+        assert.deepPropertyVal(obj, 'foo.bar', 'baz');
+        assert.deepPropertyNotVal(obj, 'foo.bar', 'flow');
+
+        err(() => {
+            assert.property(obj, 'baz');
+        }, 'expected { foo: { bar: \'baz\' } } to have a property \'baz\'');
+
+        err(() => {
+            assert.deepProperty(obj, 'foo.baz');
+        }, 'expected { foo: { bar: \'baz\' } } to have a deep property \'foo.baz\'');
+
+        err(() => {
+            assert.notProperty(obj, 'foo');
+        }, 'expected { foo: { bar: \'baz\' } } to not have property \'foo\'');
+
+        err(() => {
+            assert.notDeepProperty(obj, 'foo.bar');
+        }, 'expected { foo: { bar: \'baz\' } } to not have deep property \'foo.bar\'');
+
+        err(() => {
+            assert.propertyVal(simpleObj, 'foo', 'ball');
+        }, 'expected { foo: \'bar\' } to have a property \'foo\' of \'ball\', but got \'bar\'');
+
+        err(() => {
+            assert.deepPropertyVal(obj, 'foo.bar', 'ball');
+        }, 'expected { foo: { bar: \'baz\' } } to have a deep property \'foo.bar\' of \'ball\', but got \'baz\'');
+
+        err(() => {
+            assert.propertyNotVal(simpleObj, 'foo', 'bar');
+        }, 'expected { foo: \'bar\' } to not have a property \'foo\' of \'bar\'');
+
+        err(() => {
+            assert.deepPropertyNotVal(obj, 'foo.bar', 'baz');
+        }, 'expected { foo: { bar: \'baz\' } } to not have a deep property \'foo.bar\' of \'baz\'');
+    });
+
+    test('throws', () => {
+        assert.throws(() => {
+            throw new Error('foo');
+        });
+        assert.throws(() => {
+            throw new Error('bar');
+        }, 'bar');
+        assert.throws(() => {
+            throw new Error('bar');
+        }, /bar/);
+        assert.throws(() => {
+            throw new Error('bar');
+        }, Error);
+        assert.throws(() => {
+            throw new Error('bar');
+        }, Error, 'bar');
+
+        err(() => {
+            assert.throws(() => {
+                throw new Error('foo');
+            }, TypeError);
+        }, 'expected [Function] to throw \'TypeError\' but [Error: foo] was thrown');
+
+        err(() => {
+            assert.throws(() => {
+                throw new Error('foo');
+            }, 'bar');
+        }, 'expected [Function] to throw error including \'bar\' but got \'foo\'');
+
+        err(() => {
+            assert.throws(() => {
+                throw new Error('foo');
+            }, Error, 'bar');
+        }, 'expected [Function] to throw error including \'bar\' but got \'foo\'');
+
+        err(() => {
+            assert.throws(() => {
+                throw new Error('foo');
+            }, TypeError, 'bar');
+        }, 'expected [Function] to throw \'TypeError\' but [Error: foo] was thrown');
+
+        err(() => {
+            assert.throws(() => {
+            });
+        }, 'expected [Function] to throw an error');
+
+        err(() => {
+            assert.throws(() => {
+                throw new Error('');
+            }, 'bar');
+        }, 'expected [Function] to throw error including \'bar\' but got \'\'');
+
+        err(() => {
+            assert.throws(() => {
+                throw new Error('');
+            }, /bar/);
+        }, 'expected [Function] to throw error matching /bar/ but got \'\'');
+    });
+
+    test('doesNotThrow', () => {
+        assert.doesNotThrow(() => {
+        });
+        assert.doesNotThrow(() => {
+        }, 'foo');
+
+        err(() => {
+            assert.doesNotThrow(() => {
+                throw new Error('foo');
+            });
+        }, 'expected [Function] to not throw an error but [Error: foo] was thrown');
+    });
+
+    test('ifError', () => {
+        assert.ifError(false);
+        assert.ifError(null);
+        assert.ifError(undefined);
+
+        err(() => {
+            assert.ifError('foo');
+        }, 'expected \'foo\' to be falsy');
+    });
+
+    test('operator', () => {
+        assert.operator(1, '<', 2);
+        assert.operator(2, '>', 1);
+        assert.operator(1, '==', 1);
+        assert.operator(1, '<=', 1);
+        assert.operator(1, '>=', 1);
+        assert.operator(1, '!=', 2);
+        assert.operator(1, '!==', 2);
+
+        err(() => {
+            assert.operator(1, '=', 2);
+        }, 'Invalid operator "="');
+
+        err(() => {
+            assert.operator(2, '<', 1);
+        }, 'expected 2 to be < 1');
+
+        err(() => {
+            assert.operator(1, '>', 2);
+        }, 'expected 1 to be > 2');
+
+        err(() => {
+            assert.operator(1, '==', 2);
+        }, 'expected 1 to be == 2');
+
+        err(() => {
+            assert.operator(2, '<=', 1);
+        }, 'expected 2 to be <= 1');
+
+        err(() => {
+            assert.operator(1, '>=', 2);
+        }, 'expected 1 to be >= 2');
+
+        err(() => {
+            assert.operator(1, '!=', 1);
+        }, 'expected 1 to be != 1');
+
+        err(() => {
+            assert.operator(1, '!==', '1');
+        }, 'expected 1 to be !== \'1\'');
+    });
+
+    test('closeTo', () => {
+        assert.closeTo(1.5, 1.0, 0.5);
+        assert.closeTo(10, 20, 20);
+        assert.closeTo(-10, 20, 30);
+
+        err(() => {
+            assert.closeTo(2, 1.0, 0.5);
+        }, 'expected 2 to be close to 1 +/- 0.5');
+
+        err(() => {
+            assert.closeTo(-10, 20, 29);
+        }, 'expected -10 to be close to 20 +/- 29');
+    });
+
+    test('approximately', () => {
+        assert.approximately(1.5, 1.0, 0.5);
+        assert.approximately(10, 20, 20);
+        assert.approximately(-10, 20, 30);
+
+        err(() => {
+            assert.approximately(2, 1.0, 0.5);
+        }, 'expected 2 to be close to 1 +/- 0.5');
+
+        err(() => {
+            assert.approximately(-10, 20, 29);
+        }, 'expected -10 to be close to 20 +/- 29');
+    });
+
+    test('members', () => {
+        assert.includeMembers([1, 2, 3], [2, 3]);
+        assert.includeMembers([1, 2, 3], []);
+        assert.includeMembers([1, 2, 3], [3]);
+
+        err(() => {
+            assert.includeMembers([5, 6], [7, 8]);
+        }, 'expected [ 5, 6 ] to be a superset of [ 7, 8 ]');
+
+        err(() => {
+            assert.includeMembers([5, 6], [5, 6, 0]);
+        }, 'expected [ 5, 6 ] to be a superset of [ 5, 6, 0 ]');
+    });
+
+    test('memberEquals', () => {
+        assert.sameMembers([], []);
+        assert.sameMembers([1, 2, 3], [3, 2, 1]);
+        assert.sameMembers([4, 2], [4, 2]);
+
+        err(() => {
+            assert.sameMembers([], [1, 2]);
+        }, 'expected [] to have the same members as [ 1, 2 ]');
+
+        err(() => {
+            assert.sameMembers([1, 54], [6, 1, 54]);
+        }, 'expected [ 1, 54 ] to have the same members as [ 6, 1, 54 ]');
+    });
+
+
+    test('isAbove', () => {
+        assert.isAbove(10, 5);
+
+        err(() => {
+            assert.isAbove(1, 5);
+        }, 'expected 1 to be above 5');
+        err(() => {
+            assert.isAbove(5, 5);
+        }, 'expected 5 to be above 5');
+    });
+
+    test('isBelow', () => {
+        assert.isBelow(5, 10);
+
+        err(() => {
+            assert.isBelow(5, 1);
+        }, 'expected 5 to be above 1');
+        err(() => {
+            assert.isBelow(5, 5);
+        }, 'expected 5 to be below 5');
+    });
+
+    test('extensible', () => { assert.extensible({}); });
+    test('isExtensible', () => { assert.isExtensible({}); });
+    test('notExtensible', () => { assert.notExtensible(Object.preventExtensions({})); });
+    test('isNotExtensible', () => { assert.isNotExtensible(Object.preventExtensions({})); });
+
+    test('sealed', () => { assert.sealed(Object.seal({})); });
+    test('isSealed', () => { assert.isSealed(Object.seal({})); });
+    test('notSealed', () => { assert.notSealed({}); });
+    test('isNotSealed', () => { assert.isNotSealed({}); });
+
+    test('frozen', () => { assert.frozen(Object.freeze({})); });
+    test('isFrozen', () => { assert.isFrozen(Object.freeze({})); });
+    test('notFrozen', () => { assert.notFrozen({}); });
+    test('isNotFrozen', () => { assert.isNotFrozen({}); });
+
+    test('isNotTrue', () => {
+        assert.isNotTrue(false);
+
+        err(() => {
+            assert.isNotTrue(true);
+        }, 'expected true to not be true');
+    });
+
+    test('isNotFalse', () => {
+        assert.isNotFalse(true);
+
+        err(() => {
+            assert.isNotFalse(false);
+        }, 'expected false to not be false');
+    });
+
+    test('isAtLeast', () => {
+        assert.isAtLeast(5, 3);
+        assert.isAtLeast(5, 5);
+
+        err(() => {
+            assert.isAtLeast(3, 5);
+        }, 'expected 3 to be greater than or equal to 5');
+    });
+
+    test('isAtMost', () => {
+        assert.isAtMost(3, 5);
+        assert.isAtMost(5, 5);
+
+        err(() => {
+            assert.isAtMost(5, 3);
+        }, 'expected 5 to be less than or equal to 3');
+    });
+
+    test('oneOf', () => {
+        var obj = { z: 3 };
+
+        assert.oneOf(5, [1, 5, 4]);
+        assert.oneOf('z', ['x', 'y', 'z']);
+        assert.oneOf(obj, [obj]);
+
+        err(() => {
+            assert.oneOf(5, [1, [5], 4]);
+        }, 'expected 5 to be one of [1, [5], 4]');
+        err(() => {
+            assert.oneOf('z', ['w', 'x', 'y']);
+        }, 'expected "z" to be one of [w, x, y]');
+        err(() => {
+            assert.oneOf(obj, [{ z: 3 }]);
+        }, 'expected { z: 3 } to be one of [{ z: 3 }]');
+    });
+});

--- a/test/typings/assert.ts
+++ b/test/typings/assert.ts
@@ -1,0 +1,12 @@
+import { assert } from 'chai';
+
+let foo = 'bar';
+let tea = { 
+  flavors: [ 'Mint', 'Chai', 'Floral' ] 
+};
+
+assert.typeOf(foo, 'string');
+assert.equal(foo, 'bar');
+assert.lengthOf(foo, 3);
+assert.property(tea, 'flavors');
+assert.lengthOf(tea.flavors, 3);

--- a/test/typings/assertion-error.ts
+++ b/test/typings/assertion-error.ts
@@ -1,0 +1,10 @@
+import chai = require('chai');
+
+const assertionError = new chai.AssertionError(
+  'Expected `foo` to be `bar`',
+  {actual: 'foo', expected: 'bar'},
+);
+
+const message: string = assertionError.message;
+const actual: string = assertionError.actual;
+const expected: string = assertionError.expected;

--- a/test/typings/expect.ts
+++ b/test/typings/expect.ts
@@ -1,0 +1,11 @@
+import { expect } from 'chai';
+
+let foo = 'bar';
+let tea = { 
+  flavors: [ 'Mint', 'Chai', 'Floral' ] 
+};
+
+expect(foo).to.be.a('string');
+expect(foo).to.equal('bar');
+expect(foo).to.have.length(3);
+expect(tea).to.have.property('flavors').with.length(3);

--- a/test/typings/should.ts
+++ b/test/typings/should.ts
@@ -1,0 +1,13 @@
+import { should } from 'chai';
+
+should();
+
+let foo = 'bar';
+let tea = { 
+  flavors: [ 'Mint', 'Chai', 'Floral' ] 
+};
+
+foo.should.be.a('string');
+foo.should.equal('bar');
+foo.should.have.length(3);
+tea.should.have.property('flavors').with.length(3);

--- a/test/typings/tsconfig.json
+++ b/test/typings/tsconfig.json
@@ -1,0 +1,63 @@
+{
+  "compilerOptions": {
+    "allowJs": false,
+    "allowSyntheticDefaultImports": false,
+    "allowUnreachableCode": false,
+    "allowUnusedLabels": false,
+    "alwaysStrict": true,
+    "baseUrl": "../..",
+    "charset": "utf8",
+    "checkJs": false,
+    "declaration": true,
+    "disableSizeLimit": false,
+    "downlevelIteration": false,
+    "emitBOM": false,
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "forceConsistentCasingInFileNames": true,
+    "importHelpers": false,
+    "inlineSourceMap": false,
+    "inlineSources": false,
+    "isolatedModules": false,
+    "lib": [
+      "es2017"
+    ],
+    "locale": "en-us",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "newLine": "lf",
+    "noEmit": true,
+    "noEmitHelpers": false,
+    "noEmitOnError": true,
+    "noErrorTruncation": true,
+    "noFallthroughCasesInSwitch": true,
+    "noImplicitAny": true,
+    "noImplicitReturns": true,
+    "noImplicitThis": true,
+    "noStrictGenericChecks": false,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "noLib": false,
+    "noResolve": false,
+    "paths": {
+      "chai": [
+        "lib/chai.d.ts"
+      ]
+    },
+    "preserveConstEnums": true,
+    "removeComments": false,
+    "rootDir": "",
+    "skipLibCheck": false,
+    "sourceMap": true,
+    "strict": true,
+    "strictNullChecks": true,
+    "suppressExcessPropertyErrors": false,
+    "suppressImplicitAnyIndexErrors": false,
+    "target": "es2017",
+    "traceResolution": false
+  },
+  "include": [
+    "./**/*.ts"
+  ],
+  "exclude": []
+}


### PR DESCRIPTION
This commit adds type definitions for Chai. These type definitions are
based on the types from DefinitelyTyped. They enable Typescript users
to use the library directly and serve as documentation.

The main changes from the DT version are:
- Use external module style
- Use `AssertionError` types from `assertion-error`
- Fix global modification of objects with `should`

The types can be improved in further PRs.

This commit also adds tests for the type definitions. It tries to
compile (in noEmit mode) the files in `test/typings` using the type
definitions. This adds `typescript` as a new dev dependency.

For maintenance and semver, the types should be treated as
documentation. They should be kept up-to-date with the code, especially
when breaking changes occur (wrong documentation is worse than
incomplete documentation), see discussion in #1092.
[Help with type definitions][ts-declarations]

- Closes chaijs/chai#650 (original issue)
- See chaijs/chai#822 (previous PR with merge conflicts)
- Closes chaijs/chai#1092 (superseded by this PR)

cc @JoshuaKGoldberg @unional 

[ts-declarations]: https://www.typescriptlang.org/docs/handbook/declaration-files/introduction.html