### PR TITLE
fix: remove Chai frames from `.deep.equal` stack

### DIFF
--- a/lib/chai/core/assertions.js
+++ b/lib/chai/core/assertions.js
@@ -1016,7 +1016,10 @@ module.exports = function (chai, _) {
     if (msg) flag(this, 'message', msg);
     var obj = flag(this, 'object');
     if (flag(this, 'deep')) {
-      return this.eql(val);
+      var prevLockSsfi = flag(this, 'lockSsfi');
+      flag(this, 'lockSsfi', true);
+      this.eql(val);
+      flag(this, 'lockSsfi', prevLockSsfi);
     } else {
       this.assert(
           val === obj

--- a/test/expect.js
+++ b/test/expect.js
@@ -1181,6 +1181,22 @@ describe('expect', function () {
   it('deep.equal(val)', function(){
     expect({ foo: 'bar' }).to.deep.equal({ foo: 'bar' });
     expect({ foo: 'bar' }).not.to.deep.equal({ foo: 'baz' });
+
+    err(function(){
+      expect({foo: 'bar'}).to.deep.equal({foo: 'baz'}, 'blah');
+    }, "blah: expected { foo: 'bar' } to deeply equal { foo: 'baz' }");
+
+    err(function(){
+      expect({foo: 'bar'}, 'blah').to.deep.equal({foo: 'baz'});
+    }, "blah: expected { foo: 'bar' } to deeply equal { foo: 'baz' }");
+
+    err(function(){
+      expect({foo: 'bar'}).to.not.deep.equal({foo: 'bar'}, 'blah');
+    }, "blah: expected { foo: 'bar' } to not deeply equal { foo: 'bar' }");
+
+    err(function(){
+      expect({foo: 'bar'}, 'blah').to.not.deep.equal({foo: 'bar'});
+    }, "blah: expected { foo: 'bar' } to not deeply equal { foo: 'bar' }");
   });
 
   it('deep.equal(/regexp/)', function(){

--- a/test/should.js
+++ b/test/should.js
@@ -1022,6 +1022,19 @@ describe('should', function() {
     }, "blah: expected '4' to equal 4");
   });
 
+  it('deep.equal(val)', function(){
+    ({ foo: 'bar' }).should.deep.equal({ foo: 'bar' });
+    ({ foo: 'bar' }).should.not.deep.equal({ foo: 'baz' });
+
+    err(function(){
+      ({foo: 'bar'}).should.deep.equal({foo: 'baz'}, 'blah');
+    }, "blah: expected { foo: 'bar' } to deeply equal { foo: 'baz' }");
+
+    err(function(){
+      ({foo: 'bar'}).should.not.deep.equal({foo: 'bar'}, 'blah');
+    }, "blah: expected { foo: 'bar' } to not deeply equal { foo: 'bar' }");
+  });
+
   it('empty', function(){
     function FakeArgs() {};
     FakeArgs.prototype.length = 0;


### PR DESCRIPTION
I noticed implementation frames in the `.deep.equal` stack trace that @keithamus posted in [this comment](https://github.com/chaijs/chai/issues/1120#issuecomment-357504842). Those frames were present because `.deep.equal` called `.eql` internally without locking the SSFI first. There weren't any tests verifying error messages and stack traces (via `err(fn, msg)`) for `.deep.equal`.