### PR TITLE
chore: remove Opera from Sauce config

### DIFF
--- a/sauce.browsers.js
+++ b/sauce.browsers.js
@@ -24,15 +24,6 @@ exports['SL_Chrome'] = {
  };
 
 /*!
- * Opera
- */
-
-exports['SL_Opera'] = {
-    base: 'SauceLabs'
-  , browserName: 'opera'
-};
-
-/*!
  * Internet Explorer
  */
 


### PR DESCRIPTION
Sauce Labs stopped supporting Opera on 2017-09-29. Reference:
https://wiki.saucelabs.com/pages/viewpage.action?pageId=70074721

As a result, our Travis builds have been failing since September.