### PR TITLE
.lengthOf for Maps and Sets

### DIFF
--- a/lib/chai/core/assertions.js
+++ b/lib/chai/core/assertions.js
@@ -1102,8 +1102,8 @@ module.exports = function (chai, _) {
    *     expect(2).to.equal(2); // Recommended
    *     expect(2).to.be.above(1); // Not recommended
    *
-   * Add `.lengthOf` earlier in the chain to assert that the value of the
-   * target's `length` property is greater than the given number `n`.
+   * Add `.lengthOf` earlier in the chain to assert that the target's `length`
+   * or `size` is greater than the given number `n`.
    *
    *     expect('foo').to.have.lengthOf(3); // Recommended
    *     expect('foo').to.have.lengthOf.above(2); // Not recommended
@@ -1207,9 +1207,8 @@ module.exports = function (chai, _) {
    *     expect(2).to.be.at.least(1); // Not recommended
    *     expect(2).to.be.at.least(2); // Not recommended
    *
-   * Add `.lengthOf` earlier in the chain to assert that the value of the
-   * target's `length` property is greater than or equal to the given number
-   * `n`.
+   * Add `.lengthOf` earlier in the chain to assert that the target's `length`
+   * or `size` is greater than or equal to the given number `n`.
    *
    *     expect('foo').to.have.lengthOf(3); // Recommended
    *     expect('foo').to.have.lengthOf.at.least(2); // Not recommended
@@ -1309,8 +1308,8 @@ module.exports = function (chai, _) {
    *     expect(1).to.equal(1); // Recommended
    *     expect(1).to.be.below(2); // Not recommended
    *
-   * Add `.lengthOf` earlier in the chain to assert that the value of the
-   * target's `length` property is less than the given number `n`.
+   * Add `.lengthOf` earlier in the chain to assert that the target's `length`
+   * or `size` is less than the given number `n`.
    *
    *     expect('foo').to.have.lengthOf(3); // Recommended
    *     expect('foo').to.have.lengthOf.below(4); // Not recommended
@@ -1414,8 +1413,8 @@ module.exports = function (chai, _) {
    *     expect(1).to.be.at.most(2); // Not recommended
    *     expect(1).to.be.at.most(1); // Not recommended
    *
-   * Add `.lengthOf` earlier in the chain to assert that the value of the
-   * target's `length` property is less than or equal to the given number `n`.
+   * Add `.lengthOf` earlier in the chain to assert that the target's `length`
+   * or `size` is less than or equal to the given number `n`.
    *
    *     expect('foo').to.have.lengthOf(3); // Recommended
    *     expect('foo').to.have.lengthOf.at.most(4); // Not recommended
@@ -1518,9 +1517,9 @@ module.exports = function (chai, _) {
    *     expect(2).to.be.within(2, 3); // Not recommended
    *     expect(2).to.be.within(1, 2); // Not recommended
    *
-   * Add `.lengthOf` earlier in the chain to assert that the value of the
-   * target's `length` property is greater than or equal to the given number
-   * `start`, and less than or equal to the given number `finish`.
+   * Add `.lengthOf` earlier in the chain to assert that the target's `length`
+   * or `size` is greater than or equal to the given number `start`, and less
+   * than or equal to the given number `finish`.
    *
    *     expect('foo').to.have.lengthOf(3); // Recommended
    *     expect('foo').to.have.lengthOf.within(2, 4); // Not recommended
@@ -2042,16 +2041,13 @@ module.exports = function (chai, _) {
   /**
    * ### .lengthOf(n[, msg])
    *
-   * Asserts that the target's `length` property is equal to the given number
+   * Asserts that the target's `length` or `size` is equal to the given number
    * `n`.
    *
    *     expect([1, 2, 3]).to.have.lengthOf(3);
    *     expect('foo').to.have.lengthOf(3);
-   *
-   * When the target is a map or set, asserts that the target's `size` property.
-   *
-   *     expect(new Set([1, 2])).to.hove.lengthOf(2);
-   *     expect(new Map([['a', 1], ['b', 2]])).to.hove.lengthOf(2);
+   *     expect(new Set([1, 2, 3])).to.have.lengthOf(3);
+   *     expect(new Map([['a', 1], ['b', 2], ['c', 3]])).to.have.lengthOf(3);
    *
    * Add `.not` earlier in the chain to negate `.lengthOf`. However, it's often
    * best to assert that the target's `length` property is equal to its expected
@@ -2125,7 +2121,7 @@ module.exports = function (chai, _) {
     }
 
     this.assert(
-      itemsCount == n
+        itemsCount == n
       , 'expected #{this} to have a ' + descriptor + ' of #{exp} but got #{act}'
       , 'expected #{this} to not have a ' + descriptor + ' of #{act}'
       , n

--- a/lib/chai/core/assertions.js
+++ b/lib/chai/core/assertions.js
@@ -1147,7 +1147,7 @@ module.exports = function (chai, _) {
       , errorMessage
       , shouldThrow = true;
 
-    if (doLength) {
+    if (doLength && objType !== 'map' && objType !== 'set') {
       new Assertion(obj, flagMsg, ssfi, true).to.have.property('length');
     }
 
@@ -1167,13 +1167,20 @@ module.exports = function (chai, _) {
     }
 
     if (doLength) {
-      var len = obj.length;
+      var descriptor = 'length'
+        , itemsCount;
+      if (objType === 'map' || objType === 'set') {
+        descriptor = 'size';
+        itemsCount = obj.size;
+      } else {
+        itemsCount = obj.length;
+      }
       this.assert(
-          len > n
-        , 'expected #{this} to have a length above #{exp} but got #{act}'
-        , 'expected #{this} to not have a length above #{exp}'
+          itemsCount > n
+        , 'expected #{this} to have a ' + descriptor + ' above #{exp} but got #{act}'
+        , 'expected #{this} to not have a ' + descriptor + ' above #{exp}'
         , n
-        , len
+        , itemsCount
       );
     } else {
       this.assert(
@@ -1244,7 +1251,7 @@ module.exports = function (chai, _) {
       , errorMessage
       , shouldThrow = true;
 
-    if (doLength) {
+    if (doLength && objType !== 'map' && objType !== 'set') {
       new Assertion(obj, flagMsg, ssfi, true).to.have.property('length');
     }
 
@@ -1264,13 +1271,20 @@ module.exports = function (chai, _) {
     }
 
     if (doLength) {
-      var len = obj.length;
+      var descriptor = 'length'
+        , itemsCount;
+      if (objType === 'map' || objType === 'set') {
+        descriptor = 'size';
+        itemsCount = obj.size;
+      } else {
+        itemsCount = obj.length;
+      }
       this.assert(
-          len >= n
-        , 'expected #{this} to have a length at least #{exp} but got #{act}'
-        , 'expected #{this} to have a length below #{exp}'
+          itemsCount >= n
+        , 'expected #{this} to have a ' + descriptor + ' at least #{exp} but got #{act}'
+        , 'expected #{this} to have a ' + descriptor + ' below #{exp}'
         , n
-        , len
+        , itemsCount
       );
     } else {
       this.assert(
@@ -1340,7 +1354,7 @@ module.exports = function (chai, _) {
       , errorMessage
       , shouldThrow = true;
 
-    if (doLength) {
+    if (doLength && objType !== 'map' && objType !== 'set') {
       new Assertion(obj, flagMsg, ssfi, true).to.have.property('length');
     }
 
@@ -1360,13 +1374,20 @@ module.exports = function (chai, _) {
     }
 
     if (doLength) {
-      var len = obj.length;
+      var descriptor = 'length'
+        , itemsCount;
+      if (objType === 'map' || objType === 'set') {
+        descriptor = 'size';
+        itemsCount = obj.size;
+      } else {
+        itemsCount = obj.length;
+      }
       this.assert(
-          len < n
-        , 'expected #{this} to have a length below #{exp} but got #{act}'
-        , 'expected #{this} to not have a length below #{exp}'
+          itemsCount < n
+        , 'expected #{this} to have a ' + descriptor + ' below #{exp} but got #{act}'
+        , 'expected #{this} to not have a ' + descriptor + ' below #{exp}'
         , n
-        , len
+        , itemsCount
       );
     } else {
       this.assert(
@@ -1436,7 +1457,7 @@ module.exports = function (chai, _) {
       , errorMessage
       , shouldThrow = true;
 
-    if (doLength) {
+    if (doLength && objType !== 'map' && objType !== 'set') {
       new Assertion(obj, flagMsg, ssfi, true).to.have.property('length');
     }
 
@@ -1456,13 +1477,20 @@ module.exports = function (chai, _) {
     }
 
     if (doLength) {
-      var len = obj.length;
+      var descriptor = 'length'
+        , itemsCount;
+      if (objType === 'map' || objType === 'set') {
+        descriptor = 'size';
+        itemsCount = obj.size;
+      } else {
+        itemsCount = obj.length;
+      }
       this.assert(
-          len <= n
-        , 'expected #{this} to have a length at most #{exp} but got #{act}'
-        , 'expected #{this} to have a length above #{exp}'
+          itemsCount <= n
+        , 'expected #{this} to have a ' + descriptor + ' at most #{exp} but got #{act}'
+        , 'expected #{this} to have a ' + descriptor + ' above #{exp}'
         , n
-        , len
+        , itemsCount
       );
     } else {
       this.assert(
@@ -1536,7 +1564,7 @@ module.exports = function (chai, _) {
           ? start.toUTCString() + '..' + finish.toUTCString()
           : start + '..' + finish;
 
-    if (doLength) {
+    if (doLength && objType !== 'map' && objType !== 'set') {
       new Assertion(obj, flagMsg, ssfi, true).to.have.property('length');
     }
 
@@ -1556,11 +1584,18 @@ module.exports = function (chai, _) {
     }
 
     if (doLength) {
-      var len = obj.length;
+      var descriptor = 'length'
+        , itemsCount;
+      if (objType === 'map' || objType === 'set') {
+        descriptor = 'size';
+        itemsCount = obj.size;
+      } else {
+        itemsCount = obj.length;
+      }
       this.assert(
-          len >= start && len <= finish
-        , 'expected #{this} to have a length within ' + range
-        , 'expected #{this} to not have a length within ' + range
+          itemsCount >= start && itemsCount <= finish
+        , 'expected #{this} to have a ' + descriptor + ' within ' + range
+        , 'expected #{this} to not have a ' + descriptor + ' within ' + range
       );
     } else {
       this.assert(
@@ -2013,6 +2048,11 @@ module.exports = function (chai, _) {
    *     expect([1, 2, 3]).to.have.lengthOf(3);
    *     expect('foo').to.have.lengthOf(3);
    *
+   * When the target is a map or set, asserts that the target's `size` property.
+   *
+   *     expect(new Set([1, 2])).to.hove.lengthOf(2);
+   *     expect(new Map([['a', 1], ['b', 2]])).to.hove.lengthOf(2);
+   *
    * Add `.not` earlier in the chain to negate `.lengthOf`. However, it's often
    * best to assert that the target's `length` property is equal to its expected
    * value, rather than not equal to one of many unexpected values.
@@ -2067,17 +2107,29 @@ module.exports = function (chai, _) {
   function assertLength (n, msg) {
     if (msg) flag(this, 'message', msg);
     var obj = flag(this, 'object')
+      , objType = _.type(obj).toLowerCase()
       , flagMsg = flag(this, 'message')
-      , ssfi = flag(this, 'ssfi');
-    new Assertion(obj, flagMsg, ssfi, true).to.have.property('length');
-    var len = obj.length;
+      , ssfi = flag(this, 'ssfi')
+      , descriptor = 'length'
+      , itemsCount;
+
+    switch (objType) {
+      case 'map':
+      case 'set':
+        descriptor = 'size';
+        itemsCount = obj.size;
+        break;
+      default:
+        new Assertion(obj, flagMsg, ssfi, true).to.have.property('length');
+        itemsCount = obj.length;
+    }
 
     this.assert(
-        len == n
-      , 'expected #{this} to have a length of #{exp} but got #{act}'
-      , 'expected #{this} to not have a length of #{act}'
+      itemsCount == n
+      , 'expected #{this} to have a ' + descriptor + ' of #{exp} but got #{act}'
+      , 'expected #{this} to not have a ' + descriptor + ' of #{act}'
       , n
-      , len
+      , itemsCount
     );
   }
 

--- a/lib/chai/interface/assert.js
+++ b/lib/chai/interface/assert.js
@@ -1664,10 +1664,12 @@ module.exports = function (chai, util) {
   /**
    * ### .lengthOf(object, length, [message])
    *
-   * Asserts that `object` has a `length` property with the expected value.
+   * Asserts that `object` has a `length` or `size` with the expected value.
    *
    *     assert.lengthOf([1,2,3], 3, 'array has length of 3');
    *     assert.lengthOf('foobar', 6, 'string has length of 6');
+   *     assert.lengthOf(new Set([1,2,3]), 3, 'set has size of 3');
+   *     assert.lengthOf(new Map([['a',1],['b',2],['c',3]]), 3, 'map has size of 3');
    *
    * @name lengthOf
    * @param {Mixed} object

--- a/test/assert.js
+++ b/test/assert.js
@@ -1388,6 +1388,34 @@ describe('assert', function () {
     err(function () {
       assert.lengthOf(1, 5);
      }, "expected 1 to have property \'length\'");
+
+    if (typeof Map === 'function') {
+      assert.lengthOf(new Map, 0);
+
+      var map = new Map;
+      map.set('a', 1);
+      map.set('b', 2);
+
+      assert.lengthOf(map, 2);
+
+      err(function(){
+        assert.lengthOf(map, 3, 'blah');
+      }, "blah: expected {} to have a size of 3 but got 2");
+    }
+
+    if (typeof Set === 'function') {
+      assert.lengthOf(new Set, 0);
+
+      var set = new Set;
+      set.add(1);
+      set.add(2);
+
+      assert.lengthOf(set, 2);
+
+      err(function(){
+        assert.lengthOf(set, 3, 'blah');
+      }, "blah: expected {} to have a size of 3 but got 2");
+    }
   });
 
   it('match', function () {

--- a/test/expect.js
+++ b/test/expect.js
@@ -558,6 +558,48 @@ describe('expect', function () {
     err(function () {
       expect(1).to.have.lengthOf.within(5, 7, 'blah');
     }, "blah: expected 1 to have property 'length'");
+
+    if (typeof Map === 'function') {
+      expect(new Map).to.have.length.within(0, 0);
+      expect(new Map).to.have.lengthOf.within(0, 0);
+
+      var map = new Map;
+      map.set('a', 1);
+      map.set('b', 2);
+      map.set('c', 3);
+
+      expect(map).to.have.length.within(2, 4);
+      expect(map).to.have.lengthOf.within(2, 4);
+
+      err(function () {
+        expect(map).to.have.length.within(5, 7, 'blah');
+      }, "blah: expected {} to have a size within 5..7");
+
+      err(function () {
+        expect(map).to.have.lengthOf.within(5, 7, 'blah');
+      }, "blah: expected {} to have a size within 5..7");
+    }
+
+    if (typeof Set === 'function') {
+      expect(new Set).to.have.length.within(0, 0);
+      expect(new Set).to.have.lengthOf.within(0, 0);
+
+      var set = new Set;
+      set.add(1);
+      set.add(2);
+      set.add(3);
+
+      expect(set).to.have.length.within(2, 4);
+      expect(set).to.have.lengthOf.within(2, 4);
+
+      err(function () {
+        expect(set).to.have.length.within(5, 7, 'blah');
+      }, "blah: expected {} to have a size within 5..7");
+
+      err(function () {
+        expect(set).to.have.lengthOf.within(5, 7, 'blah');
+      }, "blah: expected {} to have a size within 5..7");
+    }
   });
 
   it('within(start, finish) (dates)', function(){
@@ -691,6 +733,48 @@ describe('expect', function () {
     err(function () {
       expect(1).to.have.lengthOf.above(0, 'blah');
     }, "blah: expected 1 to have property 'length'");
+
+    if (typeof Map === 'function') {
+      expect(new Map).to.have.length.above(-1);
+      expect(new Map).to.have.lengthOf.above(-1);
+
+      var map = new Map;
+      map.set('a', 1);
+      map.set('b', 2);
+      map.set('c', 3);
+
+      expect(map).to.have.length.above(2);
+      expect(map).to.have.lengthOf.above(2);
+
+      err(function () {
+        expect(map).to.have.length.above(5, 'blah');
+      }, "blah: expected {} to have a size above 5 but got 3");
+
+      err(function () {
+        expect(map).to.have.lengthOf.above(5, 'blah');
+      }, "blah: expected {} to have a size above 5 but got 3");
+    }
+
+    if (typeof Set === 'function') {
+      expect(new Set).to.have.length.above(-1);
+      expect(new Set).to.have.lengthOf.above(-1);
+
+      var set = new Set;
+      set.add(1);
+      set.add(2);
+      set.add(3);
+
+      expect(set).to.have.length.above(2);
+      expect(set).to.have.lengthOf.above(2);
+
+      err(function () {
+        expect(set).to.have.length.above(5, 'blah');
+      }, "blah: expected {} to have a size above 5 but got 3");
+
+      err(function () {
+        expect(set).to.have.lengthOf.above(5, 'blah');
+      }, "blah: expected {} to have a size above 5 but got 3");
+    }
   });
 
   it('above(n) (dates)', function(){
@@ -816,6 +900,48 @@ describe('expect', function () {
     err(function () {
       expect(1).to.have.lengthOf.at.least(0, 'blah');
     }, "blah: expected 1 to have property 'length'");
+
+    if (typeof Map === 'function') {
+      expect(new Map).to.have.length.of.at.least(0);
+      expect(new Map).to.have.lengthOf.at.least(0);
+
+      var map = new Map;
+      map.set('a', 1);
+      map.set('b', 2);
+      map.set('c', 3);
+
+      expect(map).to.have.length.of.at.least(3);
+      expect(map).to.have.lengthOf.at.least(3);
+
+      err(function () {
+        expect(map).to.have.length.of.at.least(4, 'blah');
+      }, "blah: expected {} to have a size at least 4 but got 3");
+
+      err(function () {
+        expect(map).to.have.lengthOf.at.least(4, 'blah');
+      }, "blah: expected {} to have a size at least 4 but got 3");
+    }
+
+    if (typeof Set === 'function') {
+      expect(new Set).to.have.length.of.at.least(0);
+      expect(new Set).to.have.lengthOf.at.least(0);
+
+      var set = new Set;
+      set.add(1);
+      set.add(2);
+      set.add(3);
+
+      expect(set).to.have.length.of.at.least(3);
+      expect(set).to.have.lengthOf.at.least(3);
+
+      err(function () {
+        expect(set).to.have.length.of.at.least(4, 'blah');
+      }, "blah: expected {} to have a size at least 4 but got 3");
+
+      err(function () {
+        expect(set).to.have.lengthOf.at.least(4, 'blah');
+      }, "blah: expected {} to have a size at least 4 but got 3");
+    }
   });
 
   it('below(n)', function(){
@@ -895,6 +1021,48 @@ describe('expect', function () {
     err(function () {
       expect(1).to.have.lengthOf.below(0, 'blah');
     }, "blah: expected 1 to have property 'length'");
+
+    if (typeof Map === 'function') {
+      expect(new Map).to.have.length.below(1);
+      expect(new Map).to.have.lengthOf.below(1);
+
+      var map = new Map;
+      map.set('a', 1);
+      map.set('b', 2);
+      map.set('c', 3);
+
+      expect(map).to.have.length.below(4);
+      expect(map).to.have.lengthOf.below(4);
+
+      err(function () {
+        expect(map).to.have.length.below(2, 'blah');
+      }, "blah: expected {} to have a size below 2 but got 3");
+
+      err(function () {
+        expect(map).to.have.lengthOf.below(2, 'blah');
+      }, "blah: expected {} to have a size below 2 but got 3");
+    }
+
+    if (typeof Set === 'function') {
+      expect(new Set).to.have.length.below(1);
+      expect(new Set).to.have.lengthOf.below(1);
+
+      var set = new Set;
+      set.add(1);
+      set.add(2);
+      set.add(3);
+
+      expect(set).to.have.length.below(4);
+      expect(set).to.have.lengthOf.below(4);
+
+      err(function () {
+        expect(set).to.have.length.below(2, 'blah');
+      }, "blah: expected {} to have a size below 2 but got 3");
+
+      err(function () {
+        expect(set).to.have.lengthOf.below(2, 'blah');
+      }, "blah: expected {} to have a size below 2 but got 3");
+    }
   });
 
   it('below(n) (dates)', function(){
@@ -1024,6 +1192,48 @@ describe('expect', function () {
     err(function () {
       expect(1).to.have.lengthOf.at.most(0, 'blah');
     }, "blah: expected 1 to have property 'length'");
+
+    if (typeof Map === 'function') {
+      expect(new Map).to.have.length.of.at.most(0);
+      expect(new Map).to.have.lengthOf.at.most(0);
+
+      var map = new Map;
+      map.set('a', 1);
+      map.set('b', 2);
+      map.set('c', 3);
+
+      expect(map).to.have.length.of.at.most(3);
+      expect(map).to.have.lengthOf.at.most(3);
+
+      err(function () {
+        expect(map).to.have.length.of.at.most(2, 'blah');
+      }, "blah: expected {} to have a size at most 2 but got 3");
+
+      err(function () {
+        expect(map).to.have.lengthOf.at.most(2, 'blah');
+      }, "blah: expected {} to have a size at most 2 but got 3");
+    }
+
+    if (typeof Set === 'function') {
+      expect(new Set).to.have.length.of.at.most(0);
+      expect(new Set).to.have.lengthOf.at.most(0);
+
+      var set = new Set;
+      set.add(1);
+      set.add(2);
+      set.add(3);
+
+      expect(set).to.have.length.of.at.most(3);
+      expect(set).to.have.lengthOf.at.most(3);
+
+      err(function () {
+        expect(set).to.have.length.of.at.most(2, 'blah');
+      }, "blah: expected {} to have a size at most 2 but got 3");
+
+      err(function () {
+        expect(set).to.have.lengthOf.at.most(2, 'blah');
+      }, "blah: expected {} to have a size at most 2 but got 3");
+    }
   });
 
   it('most(n) (dates)', function(){
@@ -1128,6 +1338,48 @@ describe('expect', function () {
     err(function(){
       expect('asd').to.not.have.lengthOf(3, 'blah');
     }, "blah: expected 'asd' to not have a length of 3");
+
+    if (typeof Map === 'function') {
+      expect(new Map).to.have.length(0);
+      expect(new Map).to.have.lengthOf(0);
+
+      var map = new Map;
+      map.set('a', 1);
+      map.set('b', 2);
+      map.set('c', 3);
+
+      expect(map).to.have.length(3);
+      expect(map).to.have.lengthOf(3);
+
+      err(function(){
+        expect(map).to.not.have.length(3, 'blah');
+      }, "blah: expected {} to not have a size of 3");
+
+      err(function(){
+        expect(map).to.not.have.lengthOf(3, 'blah');
+      }, "blah: expected {} to not have a size of 3");
+    }
+
+    if (typeof Set === 'function') {
+      expect(new Set).to.have.length(0);
+      expect(new Set).to.have.lengthOf(0);
+
+      var set = new Set;
+      set.add(1);
+      set.add(2);
+      set.add(3);
+
+      expect(set).to.have.length(3);
+      expect(set).to.have.lengthOf(3);
+
+      err(function(){
+        expect(set).to.not.have.length(3, 'blah');
+      }, "blah: expected {} to not have a size of 3");
+
+      err(function(){
+        expect(set).to.not.have.lengthOf(3, 'blah');;
+      }, "blah: expected {} to not have a size of 3");
+    }
   });
 
   it('eql(val)', function(){

--- a/test/should.js
+++ b/test/should.js
@@ -560,6 +560,48 @@ describe('should', function() {
     err(function () {
       (1).should.have.lengthOf.within(5,7, 'blah');
     }, "blah: expected 1 to have property 'length'");
+
+    if (typeof Map === 'function') {
+      (new Map).should.have.length.within(0, 0);
+      (new Map).should.have.lengthOf.within(0, 0);
+
+      var map = new Map;
+      map.set('a', 1);
+      map.set('b', 2);
+      map.set('c', 3);
+
+      map.should.have.length.within(2, 4);
+      map.should.have.lengthOf.within(2, 4);
+
+      err(function () {
+        map.should.have.length.within(5, 7, 'blah');
+      }, "blah: expected {} to have a size within 5..7");
+
+      err(function () {
+        map.should.have.lengthOf.within(5, 7, 'blah');
+      }, "blah: expected {} to have a size within 5..7");
+    }
+
+    if (typeof Set === 'function') {
+      (new Set).should.have.length.within(0, 0);
+      (new Set).should.have.lengthOf.within(0, 0);
+
+      var set = new Set;
+      set.add(1);
+      set.add(2);
+      set.add(3);
+
+      set.should.have.length.within(2, 4);
+      set.should.have.lengthOf.within(2, 4);
+
+      err(function () {
+        set.should.have.length.within(5, 7, 'blah');
+      }, "blah: expected {} to have a size within 5..7");
+
+      err(function () {
+        set.should.have.lengthOf.within(5, 7, 'blah');
+      }, "blah: expected {} to have a size within 5..7");
+    }
   });
 
   it('within(start, finish) (dates)', function(){
@@ -665,6 +707,48 @@ describe('should', function() {
     err(function () {
       (1).should.have.lengthOf.above(0, 'blah');
     }, "blah: expected 1 to have property 'length'");
+
+    if (typeof Map === 'function') {
+      (new Map).should.have.length.above(-1);
+      (new Map).should.have.lengthOf.above(-1);
+
+      var map = new Map;
+      map.set('a', 1);
+      map.set('b', 2);
+      map.set('c', 3);
+
+      map.should.have.length.above(2);
+      map.should.have.lengthOf.above(2);
+
+      err(function () {
+        map.should.have.length.above(5, 'blah');
+      }, "blah: expected {} to have a size above 5 but got 3");
+
+      err(function () {
+        map.should.have.lengthOf.above(5, 'blah');
+      }, "blah: expected {} to have a size above 5 but got 3");
+    }
+
+    if (typeof Set === 'function') {
+      (new Set).should.have.length.above(-1);
+      (new Set).should.have.lengthOf.above(-1);
+
+      var set = new Set;
+      set.add(1);
+      set.add(2);
+      set.add(3);
+
+      set.should.have.length.above(2);
+      set.should.have.lengthOf.above(2);
+
+      err(function () {
+        set.should.have.length.above(5, 'blah');
+      }, "blah: expected {} to have a size above 5 but got 3");
+
+      err(function () {
+        set.should.have.lengthOf.above(5, 'blah');
+      }, "blah: expected {} to have a size above 5 but got 3");
+    }
   });
 
   it('above(n) (dates)', function(){
@@ -745,6 +829,48 @@ describe('should', function() {
     err(function () {
       (1).should.not.be.at.least(null, 'blah');
     }, "blah: the argument to least must be a number");
+
+    if (typeof Map === 'function') {
+      (new Map).should.have.length.of.at.least(0);
+      (new Map).should.have.lengthOf.at.least(0);
+
+      var map = new Map;
+      map.set('a', 1);
+      map.set('b', 2);
+      map.set('c', 3);
+
+      map.should.have.length.of.at.least(3);
+      map.should.have.lengthOf.at.least(3);
+
+      err(function () {
+        map.should.have.length.of.at.least(4, 'blah');
+      }, "blah: expected {} to have a size at least 4 but got 3");
+
+      err(function () {
+        map.should.have.lengthOf.at.least(4, 'blah');
+      }, "blah: expected {} to have a size at least 4 but got 3");
+    }
+
+    if (typeof Set === 'function') {
+      (new Set).should.have.length.of.at.least(0);
+      (new Set).should.have.lengthOf.at.least(0);
+
+      var set = new Set;
+      set.add(1);
+      set.add(2);
+      set.add(3);
+
+      set.should.have.length.of.at.least(3);
+      set.should.have.lengthOf.at.least(3);
+
+      err(function () {
+        set.should.have.length.of.at.least(4, 'blah');
+      }, "blah: expected {} to have a size at least 4 but got 3");
+
+      err(function () {
+        set.should.have.lengthOf.at.least(4, 'blah');
+      }, "blah: expected {} to have a size at least 4 but got 3");
+    }
   });
 
   it('below(n)', function(){
@@ -792,6 +918,48 @@ describe('should', function() {
     err(function () {
       (1).should.have.lengthOf.below(0, 'blah');
     }, "blah: expected 1 to have property 'length'");
+
+    if (typeof Map === 'function') {
+      (new Map).should.have.length.below(1);
+      (new Map).should.have.lengthOf.below(1);
+
+      var map = new Map;
+      map.set('a', 1);
+      map.set('b', 2);
+      map.set('c', 3);
+
+      map.should.have.length.below(4);
+      map.should.have.lengthOf.below(4);
+
+      err(function () {
+        map.should.have.length.below(2, 'blah');
+      }, "blah: expected {} to have a size below 2 but got 3");
+
+      err(function () {
+        map.should.have.lengthOf.below(2, 'blah');
+      }, "blah: expected {} to have a size below 2 but got 3");
+    }
+
+    if (typeof Set === 'function') {
+      (new Set).should.have.length.below(1);
+      (new Set).should.have.lengthOf.below(1);
+
+      var set = new Set;
+      set.add(1);
+      set.add(2);
+      set.add(3);
+
+      set.should.have.length.below(4);
+      set.should.have.lengthOf.below(4);
+
+      err(function () {
+        set.should.have.length.below(2, 'blah');
+      }, "blah: expected {} to have a size below 2 but got 3");
+
+      err(function () {
+        set.should.have.lengthOf.below(2, 'blah');
+      }, "blah: expected {} to have a size below 2 but got 3");
+    }
   });
 
   it('below(n) (dates)', function(){
@@ -880,6 +1048,48 @@ describe('should', function() {
     err(function () {
       (1).should.have.lengthOf.at.most(0, 'blah');
     }, "blah: expected 1 to have property 'length'");
+
+    if (typeof Map === 'function') {
+      (new Map).should.have.length.of.at.most(0);
+      (new Map).should.have.lengthOf.at.most(0);
+
+      var map = new Map;
+      map.set('a', 1);
+      map.set('b', 2);
+      map.set('c', 3);
+
+      map.should.have.length.of.at.most(3);
+      map.should.have.lengthOf.at.most(3);
+
+      err(function () {
+        map.should.have.length.of.at.most(2, 'blah');
+      }, "blah: expected {} to have a size at most 2 but got 3");
+
+      err(function () {
+        map.should.have.lengthOf.at.most(2, 'blah');
+      }, "blah: expected {} to have a size at most 2 but got 3");
+    }
+
+    if (typeof Set === 'function') {
+      (new Set).should.have.length.of.at.most(0);
+      (new Set).should.have.lengthOf.at.most(0);
+
+      var set = new Set;
+      set.add(1);
+      set.add(2);
+      set.add(3);
+
+      set.should.have.length.of.at.most(3);
+      set.should.have.lengthOf.at.most(3);
+
+      err(function () {
+        set.should.have.length.of.at.most(2, 'blah');
+      }, "blah: expected {} to have a size at most 2 but got 3");
+
+      err(function () {
+        set.should.have.lengthOf.at.most(2, 'blah');
+      }, "blah: expected {} to have a size at most 2 but got 3");
+    }
   });
 
   it('most(n) (dates)', function(){
@@ -971,6 +1181,48 @@ describe('should', function() {
     err(function(){
       'asd'.should.not.have.lengthOf(3, 'blah');
     }, "blah: expected 'asd' to not have a length of 3");
+
+    if (typeof Map === 'function') {
+      (new Map).should.have.length(0);
+      (new Map).should.have.lengthOf(0);
+
+      var map = new Map;
+      map.set('a', 1);
+      map.set('b', 2);
+      map.set('c', 3);
+
+      map.should.have.length(3);
+      map.should.have.lengthOf(3);
+
+      err(function(){
+        map.should.not.have.length(3, 'blah');
+      }, "blah: expected {} to not have a size of 3");
+
+      err(function(){
+        map.should.not.have.lengthOf(3, 'blah');
+      }, "blah: expected {} to not have a size of 3");
+    }
+
+    if (typeof Set === 'function') {
+      (new Set).should.have.length(0);
+      (new Set).should.have.lengthOf(0);
+
+      var set = new Set;
+      set.add(1);
+      set.add(2);
+      set.add(3);
+
+      set.should.have.length(3);
+      set.should.have.lengthOf(3);
+
+      err(function(){
+        set.should.not.have.length(3, 'blah');
+      }, "blah: expected {} to not have a size of 3");
+
+      err(function(){
+        set.should.not.have.lengthOf(3, 'blah');;
+      }, "blah: expected {} to not have a size of 3");
+    }
   });
 
   it('eql(val)', function(){


### PR DESCRIPTION
As described in [#1110](https://github.com/chaijs/chai/issues/1110), this PR adds support for Map and Set to .lengthOf and chains such as .above, .below, .least, .most and  .within.
I have not added alias 'size' to .lengthOf this time so as not to fix some exist test cases (Levenshtein distance between 'size' and 'pizza' used in the test cases is close). Will you give me some feedback on the above?
Feel free to point out possible mistakes. Thanks!