### PR TITLE
feat(assertions): add 'still' language chain

### DIFF
--- a/lib/chai/core/assertions.js
+++ b/lib/chai/core/assertions.js
@@ -33,16 +33,17 @@ module.exports = function (chai, _) {
    * - same
    * - but
    * - does
+   * - still
    *
    * @name language chains
    * @namespace BDD
    * @api public
    */
 
-  [ 'to', 'be', 'been'
-  , 'is', 'and', 'has', 'have'
-  , 'with', 'that', 'which', 'at'
-  , 'of', 'same', 'but', 'does' ].forEach(function (chain) {
+  [ 'to', 'be', 'been', 'is'
+  , 'and', 'has', 'have', 'with'
+  , 'that', 'which', 'at', 'of'
+  , 'same', 'but', 'does', 'still' ].forEach(function (chain) {
     Assertion.addProperty(chain);
   });
 

--- a/test/expect.js
+++ b/test/expect.js
@@ -230,10 +230,10 @@ describe('expect', function () {
       expect([1, 2, 3])[chain].contains(1);
     }
 
-    [ 'to', 'be', 'been'
-    , 'is', 'and', 'has', 'have'
-    , 'with', 'that', 'which', 'at'
-    , 'of', 'same', 'but', 'does' ].forEach(test);
+    [ 'to', 'be', 'been', 'is'
+    , 'and', 'has', 'have', 'with'
+    , 'that', 'which', 'at', 'of'
+    , 'same', 'but', 'does', 'still' ].forEach(test);
   });
 
   describe("fail", function() {

--- a/test/should.js
+++ b/test/should.js
@@ -227,10 +227,10 @@ describe('should', function() {
       [1, 2, 3].should[chain].contains(1);
     }
 
-    [ 'to', 'be', 'been'
-    , 'is', 'and', 'has', 'have'
-    , 'with', 'that', 'which', 'at'
-    , 'of', 'same', 'but', 'does' ].forEach(test);
+    [ 'to', 'be', 'been', 'is'
+    , 'and', 'has', 'have', 'with'
+    , 'that', 'which', 'at', 'of'
+    , 'same', 'but', 'does', 'still' ].forEach(test);
   });
 
   describe("fail", function() {


### PR DESCRIPTION
To increase readability it's sometimes desirable to have a `still` language chain. Take this simplified test for example:

```js
it('should have a length property that does not decrease below zero with excessive popping', () => {
  const array = [1, 2];
  array.pop();
  expect(array).to.have.lengthOf(1);
  array.pop();
  expect(array).to.have.lengthOf(0);
  array.pop();
  expect(array).to.still.have.lengthOf(0);
  array.pop();
  array.pop();
  array.pop();
  expect(array).to.still.have.lengthOf(0);
});
```

For my use case, it was easy enough to add an in-file helper with the following:
```js
chai.use(({Assertion}) => Assertion.addProperty('still'));
```

But I thought I'd throw in a quick PR in case the maintainers agree this fits with the scope of the project.

Let me know if you'd like me to bump the version for a minor release and I'll add it to the PR (I'm familiar w/ the [contributing guidelines](https://github.com/chaijs/chai/blob/master/CONTRIBUTING.md)).

I'll happily submit a corresponding PR to update the docs if this PR is accepted.