### PR TITLE
imrove assert message for inherited classes

### DIFF
--- a/lib/chai/utils/objDisplay.js
+++ b/lib/chai/utils/objDisplay.js
@@ -40,7 +40,7 @@ module.exports = function objDisplay(obj) {
         , kstr = keys.length > 2
           ? keys.splice(0, 2).join(', ') + ', ...'
           : keys.join(', ');
-      return '{ Object (' + kstr + ') }';
+      return '{ ' + obj.constructor.name + ' (' + kstr + ') }';
     } else {
       return str;
     }

--- a/test/globalErr.js
+++ b/test/globalErr.js
@@ -52,7 +52,7 @@ describe('globalErr', function () {
   it('should throw if object val\'s props are not included in error object', function () {
     err(function () {
       err(function () { throw new Err('cat') }, {text: 'cat'});
-    }, /expected { Object \(message, showDiff(, \.\.\.)*\) } to have property \'text\'/);
+    }, /expected { AssertionError \(message, showDiff(, \.\.\.)*\) } to have property \'text\'/);
 
     err(function () {
       err(function () { throw new Err('cat') }, {message: 'dog'});


### PR DESCRIPTION
For such cases:
 
`expect(key).to.be.instanceof(ParamedKey);`

before:
```
AssertionError: expected { Object (name, value) } to be an instance of ParamedKey
```

after:
```
AssertionError: expected { Key (name, value) } to be an instance of ParamedKey
```