### PR TITLE
Fix unbalanced quotes in assert.notInclude example

### DIFF
--- a/lib/chai/interface/assert.js
+++ b/lib/chai/interface/assert.js
@@ -946,8 +946,8 @@ module.exports = function (chai, util) {
    * the absence of a value in an array, a substring in a string, or a subset of
    * properties in an object.
    *
-   *     assert.notInclude([1,2,3], 4, 'array doesn't contain value');
-   *     assert.notInclude('foobar', 'baz', 'string doesn't contain substring');
+   *     assert.notInclude([1,2,3], 4, "array doesn't contain value");
+   *     assert.notInclude('foobar', 'baz', "string doesn't contain substring");
    *     assert.notInclude({ foo: 'bar', hello: 'universe' }, { foo: 'baz' }, 'object doesn't contain property');
    *
    * Strict equality (===) is used. When asserting the absence of a value in an


### PR DESCRIPTION
This pull request fixes two lines in the example for `assert.notInclude` using single quotes around the string but also including a single quote in the string:

```js
'this doesn't work'
```

I have changed the erroneous examples to use double quotes around the string instead, so there is no longer a syntax error:

```js
"this doesn't break!"
```