### PR TITLE
allow addChainableMethod when chainingBehavior = true, it set as method

### DIFF
--- a/lib/chai/utils/addChainableMethod.js
+++ b/lib/chai/utils/addChainableMethod.js
@@ -72,8 +72,8 @@ var call  = Function.prototype.call,
 
 module.exports = function addChainableMethod(ctx, name, method, chainingBehavior) {
   if (chainingBehavior === true) {
-    chainingBehavior = method
-  } else ifif (typeof chainingBehavior !== 'function') {
+    chainingBehavior = method;
+  } else if (typeof chainingBehavior !== 'function') {
     chainingBehavior = function () { };
   }
 

--- a/lib/chai/utils/addChainableMethod.js
+++ b/lib/chai/utils/addChainableMethod.js
@@ -71,7 +71,9 @@ var call  = Function.prototype.call,
  */
 
 module.exports = function addChainableMethod(ctx, name, method, chainingBehavior) {
-  if (typeof chainingBehavior !== 'function') {
+  if (chainingBehavior === true) {
+    chainingBehavior = method
+  } else ifif (typeof chainingBehavior !== 'function') {
     chainingBehavior = function () { };
   }
 


### PR DESCRIPTION
> this allow when we wanna get both effect of `addProperty` and `addMethod`/`addChainableMethod`

current

```ts
	let fn = function (v)
	{
		utils.expectTypes(this, ['number']);

		let obj = utils.flag(this, 'object');

		this.assert(
			isInt(obj)
			, 'expected #{this} to be an integer'
			, 'expected #{this} to not be an integer'
			, obj,
		);

		if (typeof v !== 'undefined')
		{
			new chai.Assertion(obj).to.be.deep.equal(v);
		}
	}

	Assertion.addChainableMethod('integer', fn, fn);
```

after

```ts
	let fn = function (v)
	{
		utils.expectTypes(this, ['number']);

		let obj = utils.flag(this, 'object');

		this.assert(
			isInt(obj)
			, 'expected #{this} to be an integer'
			, 'expected #{this} to not be an integer'
			, obj,
		);

		if (typeof v !== 'undefined')
		{
			new chai.Assertion(obj).to.be.deep.equal(v);
		}
	}

	Assertion.addChainableMethod('integer', fn, true);
```