### PR TITLE
WIP: Overhaul `.throw`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,10 @@ language: node_js
 addons:
   sauce_connect: true
 node_js:
- - 4 # to be removed 2018-04-30
  - 6 # to be removed 2019-04-01
  - 8 # to be removed 2019-12-31
- - 9 # to be removed 2018-06-30
+ - 10 # to be removed 2021-04-30
+ - 11 # to be removed 2019-06-30
  - lts/* # safety net; don't remove
  - node # safety net; don't remove
 

--- a/lib/chai/core/assertions.js
+++ b/lib/chai/core/assertions.js
@@ -2447,130 +2447,214 @@ module.exports = function (chai, _) {
   Assertion.addMethod('keys', assertKeys);
   Assertion.addMethod('key', assertKeys);
 
+  // TODO: Document and move to utilities
+  function createErrCriteria(errLike, errMsgMatcher, negate) {
+    var cri = {
+      errLike: errLike,
+      errLikeType: _.type(errLike).toLowerCase(),
+      errMsgMatcher: errMsgMatcher,
+      errMsgMatcherType: _.type(errMsgMatcher).toLowerCase(),
+    };
+
+    // Short-circuit if no criteria is defined.
+    if (cri.errLikeType === 'undefined' &&
+        cri.errMsgMatcherType === 'undefined') {
+      return cri;
+    }
+
+    if (negate) {
+      throw TypeError('errLike and errMsgMatcher must both be undefined when' +
+                      ' negate is true');
+    }
+
+    if (cri.errMsgMatcherType === 'undefined') {
+      // Handle `errMsgMatcher` being passed as the first argument.
+      if (cri.errLikeType === 'string' || cri.errLikeType === 'regexp') {
+        cri.errMsgMatcher = cri.errLike;
+        cri.errMsgMatcherType = cri.errLikeType;
+        cri.errLike = undefined;
+        cri.errLikeType = 'undefined';
+      }
+      return cri;
+    }
+
+    if (cri.errLikeType !== 'function') {
+      throw TypeError('errLike must be a function when errMsgMatcher is' +
+                      ' defined');
+    }
+
+    if (cri.errMsgMatcherType !== 'string' &&
+        cri.errMsgMatcherType !== 'regexp') {
+      throw TypeError('errMsgMatcher must be a string or regexp when' +
+                      ' defined');
+    }
+
+    return cri;
+  }
+
+  // TODO: Document and move to utilities
+  function assertErrCriteria(err, cri, flagMsg, ssfi) {
+    // Short-circuit if no criteria is defined.
+    if (cri.errLikeType === 'undefined' &&
+        cri.errMsgMatcherType === 'undefined') {
+      return;
+    }
+
+    // When `errLike` is the `String` constructor, and `errMsgMatcher` is a
+    // string or regex, assert that the error is a string (as opposed to an
+    // object with a `.message` property) that contains or matches
+    // `errMsgMatcher`.
+    if (cri.errLike === String) {
+      if (cri.errMsgMatcherType === 'string') {
+        new Assertion(err, flagMsg, ssfi, true)
+          .contains.string(cri.errMsgMatcher);
+        return;
+      } else if (cri.errMsgMatcherType === 'regexp') {
+        new Assertion(err, flagMsg, ssfi, true)
+          .is.a('string').that.matches(cri.errMsgMatcher);
+        return;
+      }
+    }
+
+    if (cri.errLikeType === 'function') {
+      new Assertion(err, flagMsg, ssfi, true).is.an.instanceof(cri.errLike);
+    } else if (cri.errLikeType !== 'undefined') {
+      new Assertion(err, flagMsg, ssfi, true).deep.equals(cri.errLike);
+    }
+
+    if (cri.errMsgMatcherType === 'string') {
+      new Assertion(err, flagMsg, ssfi, true)
+        .has.property('message').that.contains.string(cri.errMsgMatcher);
+    } else if (cri.errMsgMatcherType === 'regexp') {
+      new Assertion(err, flagMsg, ssfi, true)
+        .has.property('message').that.matches(cri.errMsgMatcher);
+    }
+  }
+
   /**
-   * ### .throw([errorLike], [errMsgMatcher], [msg])
+   * ### .throw([errLike[, errMsgMatcher[, msg]]])
+   * ### .throw([errMsgMatcher[, msg]])
    *
-   * When no arguments are provided, `.throw` invokes the target function and
-   * asserts that an error is thrown.
+   * When invoked without any arguments, `.throw` invokes the target function
+   * and asserts that it throws.
    *
-   *     var badFn = function () { throw new TypeError('Illegal salmon!'); };
+   *     var badFn = function () { throw TypeError('Illegal salmon!'); };
    *
    *     expect(badFn).to.throw();
    *
-   * When one argument is provided, and it's an error constructor, `.throw`
-   * invokes the target function and asserts that an error is thrown that's an
-   * instance of that error constructor.
+   * When invoked with one argument, and it's a function (typically a
+   * constructor), `.throw` invokes the target function and asserts that it
+   * throws an instance of that constructor.
    *
-   *     var badFn = function () { throw new TypeError('Illegal salmon!'); };
+   *     var badFn = function () { throw TypeError('Illegal salmon!'); };
    *
    *     expect(badFn).to.throw(TypeError);
    *
-   * When one argument is provided, and it's an error instance, `.throw` invokes
-   * the target function and asserts that an error is thrown that's strictly
-   * (`===`) equal to that error instance.
+   * When invoked with one argument, and it's a string or regular expression,
+   * `.throw` invokes the target function and asserts that it throws an object
+   * with a `.message` property that contains or matches that string or regular
+   * expression.
    *
-   *     var err = new TypeError('Illegal salmon!');
-   *     var badFn = function () { throw err; };
-   *
-   *     expect(badFn).to.throw(err);
-   *
-   * When one argument is provided, and it's a string, `.throw` invokes the
-   * target function and asserts that an error is thrown with a message that
-   * contains that string.
-   *
-   *     var badFn = function () { throw new TypeError('Illegal salmon!'); };
+   *     var badFn = function () { throw TypeError('Illegal salmon!'); };
    *
    *     expect(badFn).to.throw('salmon');
-   *
-   * When one argument is provided, and it's a regular expression, `.throw`
-   * invokes the target function and asserts that an error is thrown with a
-   * message that matches that regular expression.
-   *
-   *     var badFn = function () { throw new TypeError('Illegal salmon!'); };
-   *
    *     expect(badFn).to.throw(/salmon/);
    *
-   * When two arguments are provided, and the first is an error instance or
-   * constructor, and the second is a string or regular expression, `.throw`
-   * invokes the function and asserts that an error is thrown that fulfills both
-   * conditions as described above.
+   * When invoked with one argument, and it's anything other than a function,
+   * string, or regular expression, `.throw` invokes the target function and
+   * asserts that it throws a value that's deeply equal to that argument. See
+   * the `deep-eql` project page for info on the deep equality algorithm:
+   * https://github.com/chaijs/deep-eql.
    *
-   *     var err = new TypeError('Illegal salmon!');
-   *     var badFn = function () { throw err; };
+   *     var badFn = function () { throw TypeError('Illegal salmon!'); };
+   *
+   *     expect(badFn).to.throw(TypeError('Illegal salmon!'));
+   *
+   * When invoked with two arguments, and the first is a function (typically a
+   * constructor), and the second is a string or regular expression, `.throw`
+   * invokes the target function and asserts that it throws an object that's an
+   * instance of that constructor, which has a `.message` property that contains
+   * or matches that string or regular expression.
+   *
+   *     var badFn = function () { throw TypeError('Illegal salmon!'); };
    *
    *     expect(badFn).to.throw(TypeError, 'salmon');
    *     expect(badFn).to.throw(TypeError, /salmon/);
-   *     expect(badFn).to.throw(err, 'salmon');
-   *     expect(badFn).to.throw(err, /salmon/);
    *
-   * Add `.not` earlier in the chain to negate `.throw`.
+   * An exception to the "two argument" behavior described above is when the
+   * first argument is the `String` constructor. In this case, `.throw` invokes
+   * the target function and asserts that it throws a string that contains or
+   * matches the second argument, rather than checking the `.message` property
+   * of the thrown value.
    *
-   *     var goodFn = function () {};
+   *     var badFn = function () { throw 'Illegal salmon!'; };
    *
-   *     expect(goodFn).to.not.throw();
-   *
-   * However, it's dangerous to negate `.throw` when providing any arguments.
-   * The problem is that it creates uncertain expectations by asserting that the
-   * target either doesn't throw an error, or that it throws an error but of a
-   * different type than the given type, or that it throws an error of the given
-   * type but with a message that doesn't include the given string. It's often
-   * best to identify the exact output that's expected, and then write an
-   * assertion that only accepts that exact output.
-   *
-   * When the target isn't expected to throw an error, it's often best to assert
-   * exactly that.
-   *
-   *     var goodFn = function () {};
-   *
-   *     expect(goodFn).to.not.throw(); // Recommended
-   *     expect(goodFn).to.not.throw(ReferenceError, 'x'); // Not recommended
-   *
-   * When the target is expected to throw an error, it's often best to assert
-   * that the error is of its expected type, and has a message that includes an
-   * expected string, rather than asserting that it doesn't have one of many
-   * unexpected types, and doesn't have a message that includes some string.
-   *
-   *     var badFn = function () { throw new TypeError('Illegal salmon!'); };
-   *
-   *     expect(badFn).to.throw(TypeError, 'salmon'); // Recommended
-   *     expect(badFn).to.not.throw(ReferenceError, 'x'); // Not recommended
+   *     expect(badFn).to.throw(String, 'salmon');
+   *     expect(badFn).to.throw(String, /salmon/);
    *
    * `.throw` changes the target of any assertions that follow in the chain to
-   * be the error object that's thrown.
+   * be the object that's thrown. This allows you to perform assertions on the
+   * thrown object.
    *
-   *     var err = new TypeError('Illegal salmon!');
+   *     var err = TypeError('Illegal salmon!');
    *     err.code = 42;
    *     var badFn = function () { throw err; };
    *
    *     expect(badFn).to.throw(TypeError).with.property('code', 42);
    *
+   * When invoked without any arguments, `.throw` can be negated by adding
+   * `.not` earlier in the chain. However, `.throw` cannot be negated when
+   * invoking it with one or more arguments. Doing so would create uncertain
+   * expectations by asserting that the target function either doesn't throw, or
+   * that it throws but the thrown value doesn't match the criteria described by
+   * one or more of the arguments.
+   *
+   * When the target function isn't expected to throw, it's best to assert
+   * exactly that.
+   *
+   *     var goodFn = function () {};
+   *
+   *     expect(goodFn).to.not.throw();
+   *
+   * When the target function is expected to throw, it's often best to assert
+   * that it throws a value that matches some criteria, rather than asserting
+   * that the target function throws a value that doesn't match some criteria.
+   *
+   *     var badFn = function () { throw TypeError('Illegal salmon!'); };
+   *
+   *     expect(badFn).to.throw(TypeError, 'salmon'); // Recommended
+   *     expect(badFn).to.throw(TypeError('Illegal salmon!')); // Recommended
+   *     expect(badFn).to.not.throw(ReferenceError); // Not supported
+   *     // Supported but not recommended:
+   *     expect(badFn).to.throw().but.not.an.instanceof(ReferenceError);
+   *
    * `.throw` accepts an optional `msg` argument which is a custom error message
    * to show when the assertion fails. The message can also be given as the
-   * second argument to `expect`. When not providing two arguments, always use
-   * the second form.
+   * second argument to `expect`. When not invoking `.throw` with two arguments,
+   * always use the second form.
    *
    *     var goodFn = function () {};
    *
    *     expect(goodFn).to.throw(TypeError, 'x', 'nooo why fail??');
    *     expect(goodFn, 'nooo why fail??').to.throw();
    *
-   * Due to limitations in ES5, `.throw` may not always work as expected when
-   * using a transpiler such as Babel or TypeScript. In particular, it may
-   * produce unexpected results when subclassing the built-in `Error` object and
-   * then passing the subclassed constructor to `.throw`. See your transpiler's
-   * docs for details:
+   * Due to limitations in ES5, using `.throw` with arguments may not always
+   * work as expected when using a transpiler such as Babel or TypeScript. In
+   * particular, it may produce unexpected results when subclassing the built-in
+   * `Error` constructor and then passing the subclassed constructor to
+   * `.throw`. See your transpiler's docs for details:
    *
    * - ([Babel](https://babeljs.io/docs/usage/caveats/#classes))
    * - ([TypeScript](https://github.com/Microsoft/TypeScript/wiki/Breaking-Changes#extending-built-ins-like-error-array-and-map-may-no-longer-work))
    *
-   * Beware of some common mistakes when using the `throw` assertion. One common
-   * mistake is to accidentally invoke the function yourself instead of letting
-   * the `throw` assertion invoke the function for you. For example, when
-   * testing if a function named `fn` throws, provide `fn` instead of `fn()` as
-   * the target for the assertion.
+   * Beware of some common mistakes when using `.throw`. One common mistake is
+   * to accidentally invoke the function yourself instead of letting `.throw`
+   * invoke the function for you. For example, when testing if a function named
+   * `fn` throws, provide `fn` instead of `fn()` as the target for the
+   * assertion.
    *
-   *     expect(fn).to.throw();     // Good! Tests `fn` as desired
-   *     expect(fn()).to.throw();   // Bad! Tests result of `fn()`, not `fn`
+   *     expect(fn).to.throw();   // Good! Tests `fn` as desired
+   *     expect(fn()).to.throw(); // Bad! Tests result of `fn()`, not `fn`
    *
    * If you need to assert that your function `fn` throws when passed certain
    * arguments, then wrap a call to `fn` inside of another function.
@@ -2586,16 +2670,28 @@ module.exports = function (chai, _) {
    * method or function call inside of another function. Another solution is to
    * use `bind`.
    *
-   *     expect(function () { cat.meow(); }).to.throw();  // Function expression
-   *     expect(() => cat.meow()).to.throw();             // ES6 arrow function
-   *     expect(cat.meow.bind(cat)).to.throw();           // Bind
+   *     expect(function () { cat.meow(); }).to.throw(); // Function expression
+   *     expect(() => cat.meow()).to.throw();            // ES6 arrow function
+   *     expect(cat.meow.bind(cat)).to.throw();          // Bind
    *
    * Finally, it's worth mentioning that it's a best practice in JavaScript to
-   * only throw `Error` and derivatives of `Error` such as `ReferenceError`,
-   * `TypeError`, and user-defined objects that extend `Error`. No other type of
-   * value will generate a stack trace when initialized. With that said, the
-   * `throw` assertion does technically support any type of value being thrown,
-   * not just `Error` and its derivatives.
+   * only throw `Error` instances. This includes `Error` instances created from
+   * subclassed `Error` constructors such as `ReferenceError`, `TypeError`, and
+   * user-defined constructors that extend `Error`. No other type of value will
+   * generate a stack trace when initialized. With that said, `.throw` supports
+   * any type of thrown value.
+   *
+   *     function NonErrorConstructor(message) {
+   *       this.message = message;
+   *     }
+   *     var nonErrorObject = new NonErrorConstructor('Illegal salmon!');
+   *     var badFn = function () { throw nonErrorObject; };
+   *
+   *     // Assert thrown value is an instance of `NonErrorConstructor` with a
+   *     // `.message` property that contains "salmon":
+   *     expect(badFn).to.throw(NonErrorConstructor, 'salmon');
+   *     // Assert thrown value is deeply equal to the given object:
+   *     expect(badFn).to.throw(new NonErrorConstructor('Illegal salmon!'));
    *
    * The aliases `.throws` and `.Throw` can be used interchangeably with
    * `.throw`.
@@ -2603,7 +2699,7 @@ module.exports = function (chai, _) {
    * @name throw
    * @alias throws
    * @alias Throw
-   * @param {Error|ErrorConstructor} errorLike
+   * @param {Error|ErrorConstructor} errLike
    * @param {String|RegExp} errMsgMatcher error message
    * @param {String} msg _optional_
    * @see https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Error#Error_types
@@ -2612,131 +2708,47 @@ module.exports = function (chai, _) {
    * @api public
    */
 
-  function assertThrows (errorLike, errMsgMatcher, msg) {
+  function assertThrows (errLike, errMsgMatcher, msg) {
     if (msg) flag(this, 'message', msg);
-    var obj = flag(this, 'object')
-      , ssfi = flag(this, 'ssfi')
-      , flagMsg = flag(this, 'message')
-      , negate = flag(this, 'negate') || false;
+    var obj = flag(this, 'object');
+    var ssfi = flag(this, 'ssfi');
+    var flagMsg = flag(this, 'message');
+    var negate = flag(this, 'negate');
+
+    var cri = createErrCriteria(errLike, errMsgMatcher, negate);
+
     new Assertion(obj, flagMsg, ssfi, true).is.a('function');
 
-    if (errorLike instanceof RegExp || typeof errorLike === 'string') {
-      errMsgMatcher = errorLike;
-      errorLike = null;
-    }
-
+    // Note that any type of value can be thrown (even `undefined`) so it's
+    // unreliable to use the value of `caughtErr` to determine if an error was
+    // thrown. Instead, track if an error was thrown using a separate boolean.
+    var wasErrThrown = false;
     var caughtErr;
     try {
       obj();
     } catch (err) {
+      wasErrThrown = true;
       caughtErr = err;
     }
 
-    // If we have the negate flag enabled and at least one valid argument it means we do expect an error
-    // but we want it to match a given set of criteria
-    var everyArgIsUndefined = errorLike === undefined && errMsgMatcher === undefined;
+    this.assert(
+      wasErrThrown,
+      'expected #{this} to throw',
+      'expected #{this} to not throw but #{act} was thrown',
+      errLike || errMsgMatcher,
+      caughtErr
+    );
 
-    // If we've got the negate flag enabled and both args, we should only fail if both aren't compatible
-    // See Issue #551 and PR #683@GitHub
-    var everyArgIsDefined = Boolean(errorLike && errMsgMatcher);
-    var errorLikeFail = false;
-    var errMsgMatcherFail = false;
-
-    // Checking if error was thrown
-    if (everyArgIsUndefined || !everyArgIsUndefined && !negate) {
-      // We need this to display results correctly according to their types
-      var errorLikeString = 'an error';
-      if (errorLike instanceof Error) {
-        errorLikeString = '#{exp}';
-      } else if (errorLike) {
-        errorLikeString = _.checkError.getConstructorName(errorLike);
-      }
-
-      this.assert(
-          caughtErr
-        , 'expected #{this} to throw ' + errorLikeString
-        , 'expected #{this} to not throw an error but #{act} was thrown'
-        , errorLike && errorLike.toString()
-        , (caughtErr instanceof Error ?
-            caughtErr.toString() : (typeof caughtErr === 'string' ? caughtErr : caughtErr &&
-                                    _.checkError.getConstructorName(caughtErr)))
-      );
-    }
-
-    if (errorLike && caughtErr) {
-      // We should compare instances only if `errorLike` is an instance of `Error`
-      if (errorLike instanceof Error) {
-        var isCompatibleInstance = _.checkError.compatibleInstance(caughtErr, errorLike);
-
-        if (isCompatibleInstance === negate) {
-          // These checks were created to ensure we won't fail too soon when we've got both args and a negate
-          // See Issue #551 and PR #683@GitHub
-          if (everyArgIsDefined && negate) {
-            errorLikeFail = true;
-          } else {
-            this.assert(
-                negate
-              , 'expected #{this} to throw #{exp} but #{act} was thrown'
-              , 'expected #{this} to not throw #{exp}' + (caughtErr && !negate ? ' but #{act} was thrown' : '')
-              , errorLike.toString()
-              , caughtErr.toString()
-            );
-          }
-        }
-      }
-
-      var isCompatibleConstructor = _.checkError.compatibleConstructor(caughtErr, errorLike);
-      if (isCompatibleConstructor === negate) {
-        if (everyArgIsDefined && negate) {
-            errorLikeFail = true;
-        } else {
-          this.assert(
-              negate
-            , 'expected #{this} to throw #{exp} but #{act} was thrown'
-            , 'expected #{this} to not throw #{exp}' + (caughtErr ? ' but #{act} was thrown' : '')
-            , (errorLike instanceof Error ? errorLike.toString() : errorLike && _.checkError.getConstructorName(errorLike))
-            , (caughtErr instanceof Error ? caughtErr.toString() : caughtErr && _.checkError.getConstructorName(caughtErr))
-          );
-        }
-      }
-    }
-
-    if (caughtErr && errMsgMatcher !== undefined && errMsgMatcher !== null) {
-      // Here we check compatible messages
-      var placeholder = 'including';
-      if (errMsgMatcher instanceof RegExp) {
-        placeholder = 'matching'
-      }
-
-      var isCompatibleMessage = _.checkError.compatibleMessage(caughtErr, errMsgMatcher);
-      if (isCompatibleMessage === negate) {
-        if (everyArgIsDefined && negate) {
-            errMsgMatcherFail = true;
-        } else {
-          this.assert(
-            negate
-            , 'expected #{this} to throw error ' + placeholder + ' #{exp} but got #{act}'
-            , 'expected #{this} to throw error not ' + placeholder + ' #{exp}'
-            ,  errMsgMatcher
-            ,  _.checkError.getMessage(caughtErr)
-          );
-        }
-      }
-    }
-
-    // If both assertions failed and both should've matched we throw an error
-    if (errorLikeFail && errMsgMatcherFail) {
-      this.assert(
-        negate
-        , 'expected #{this} to throw #{exp} but #{act} was thrown'
-        , 'expected #{this} to not throw #{exp}' + (caughtErr ? ' but #{act} was thrown' : '')
-        , (errorLike instanceof Error ? errorLike.toString() : errorLike && _.checkError.getConstructorName(errorLike))
-        , (caughtErr instanceof Error ? caughtErr.toString() : caughtErr && _.checkError.getConstructorName(caughtErr))
-      );
-    }
-
+    // Set the caught error as the target of future assertions.
     flag(this, 'object', caughtErr);
-  };
+
+    assertErrCriteria(
+      caughtErr,
+      cri,
+      flagMsg,
+      ssfi
+    );
+  }
 
   Assertion.addMethod('throw', assertThrows);
   Assertion.addMethod('throws', assertThrows);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1363,9 +1363,9 @@
       "dev": true
     },
     "deep-eql": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
-      "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.0.0.tgz",
+      "integrity": "sha512-GxJC5MOg2KyQlv6WiUF/VAnMj4MWnYiXo4oLgeptOELVoknyErb4Z8+5F/IM/K4g9/80YzzatxmWcyRwUseH0A==",
       "requires": {
         "type-detect": "^4.0.0"
       }
@@ -2126,7 +2126,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2528,7 +2529,8 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2583,6 +2585,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2626,12 +2629,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "test": "make test"
   },
   "engines": {
-    "node": ">=4"
+    "node": ">=6"
   },
   "dependencies": {
     "assertion-error": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "assertion-error": "^1.1.0",
     "check-error": "^1.0.2",
-    "deep-eql": "^3.0.1",
+    "deep-eql": "^4.0.0",
     "get-func-name": "^2.0.0",
     "pathval": "^1.1.0",
     "type-detect": "^4.0.5"

--- a/test/configuration.js
+++ b/test/configuration.js
@@ -774,7 +774,7 @@ describe('configuration', function () {
       it('should not use proxy', function() {
         chai.config.useProxy = false;
 
-        expect(readNoExistentProperty).to.not.throw('Invalid Chai property: tue');
+        expect(readNoExistentProperty).to.not.throw();
       });
     });
   });

--- a/test/expect.js
+++ b/test/expect.js
@@ -2981,174 +2981,239 @@ describe('expect', function () {
     expect(badFn).to.throw(Error).with.property('message', 'testing');
   });
 
-  it('throw', function () {
-    // See GH-45: some poorly-constructed custom errors don't have useful names
-    // on either their constructor or their constructor prototype, but instead
-    // only set the name inside the constructor itself.
-    var PoorlyConstructedError = function () {
-      this.name = 'PoorlyConstructedError';
-    };
-    PoorlyConstructedError.prototype = Object.create(Error.prototype);
-
-    function CustomError(message) {
-        this.name = 'CustomError';
-        this.message = message;
+  describe("throw", function () {
+    function FakeError(message) {
+      this.message = message;
     }
-    CustomError.prototype = Error.prototype;
+    var goodFn = function () {};
+    var badFnErr = function () { throw Error("Illegal salmon!"); };
+    var badFnTypeErr = function () { throw TypeError("Illegal salmon!"); };
+    var badFnFakeErr = function () { throw new FakeError("Illegal salmon!"); };
+    var badFnObj = function () { throw {a: 1}; };
+    var badFnStr = function () { throw "Illegal salmon!"; };
 
-    var specificError = new RangeError('boo');
-
-    var goodFn = function () { 1==1; }
-      , badFn = function () { throw new Error('testing'); }
-      , refErrFn = function () { throw new ReferenceError('hello'); }
-      , ickyErrFn = function () { throw new PoorlyConstructedError(); }
-      , specificErrFn = function () { throw specificError; }
-      , customErrFn = function() { throw new CustomError('foo'); }
-      , emptyErrFn = function () { throw new Error(); }
-      , emptyStringErrFn = function () { throw new Error(''); };
-
-    expect(goodFn).to.not.throw();
-    expect(goodFn).to.not.throw(Error);
-    expect(goodFn).to.not.throw(specificError);
-    expect(badFn).to.throw();
-    expect(badFn).to.throw(Error);
-    expect(badFn).to.not.throw(ReferenceError);
-    expect(badFn).to.not.throw(specificError);
-    expect(refErrFn).to.throw();
-    expect(refErrFn).to.throw(ReferenceError);
-    expect(refErrFn).to.throw(Error);
-    expect(refErrFn).to.not.throw(TypeError);
-    expect(refErrFn).to.not.throw(specificError);
-    expect(ickyErrFn).to.throw();
-    expect(ickyErrFn).to.throw(PoorlyConstructedError);
-    expect(ickyErrFn).to.throw(Error);
-    expect(ickyErrFn).to.not.throw(specificError);
-    expect(specificErrFn).to.throw(specificError);
-
-    expect(goodFn).to.not.throw('testing');
-    expect(goodFn).to.not.throw(/testing/);
-    expect(badFn).to.throw(/testing/);
-    expect(badFn).to.not.throw(/hello/);
-    expect(badFn).to.throw('testing');
-    expect(badFn).to.not.throw('hello');
-    expect(emptyStringErrFn).to.throw('');
-    expect(emptyStringErrFn).to.not.throw('testing');
-    expect(badFn).to.throw('');
-
-    expect(badFn).to.throw(Error, /testing/);
-    expect(badFn).to.throw(Error, 'testing');
-    expect(emptyErrFn).to.not.throw(Error, 'testing');
-
-    expect(badFn).to.not.throw(Error, 'I am the wrong error message');
-    expect(badFn).to.not.throw(TypeError, 'testing');
-
-    err(function(){
-      expect(goodFn, 'blah').to.throw();
-    }, /^blah: expected \[Function(: goodFn)*\] to throw an error$/);
-
-    err(function(){
-      expect(goodFn, 'blah').to.throw(ReferenceError);
-    }, /^blah: expected \[Function(: goodFn)*\] to throw ReferenceError$/);
-
-    err(function(){
-      expect(goodFn, 'blah').to.throw(specificError);
-    }, /^blah: expected \[Function(: goodFn)*\] to throw 'RangeError: boo'$/);
-
-    err(function(){
-      expect(badFn, 'blah').to.not.throw();
-    }, /^blah: expected \[Function(: badFn)*\] to not throw an error but 'Error: testing' was thrown$/);
-
-    err(function(){
-      expect(badFn, 'blah').to.throw(ReferenceError);
-    }, /^blah: expected \[Function(: badFn)*\] to throw 'ReferenceError' but 'Error: testing' was thrown$/);
-
-    err(function(){
-      expect(badFn, 'blah').to.throw(specificError);
-    }, /^blah: expected \[Function(: badFn)*\] to throw 'RangeError: boo' but 'Error: testing' was thrown$/);
-
-    err(function(){
-      expect(badFn, 'blah').to.not.throw(Error);
-    }, /^blah: expected \[Function(: badFn)*\] to not throw 'Error' but 'Error: testing' was thrown$/);
-
-    err(function(){
-      expect(refErrFn, 'blah').to.not.throw(ReferenceError);
-    }, /^blah: expected \[Function(: refErrFn)*\] to not throw 'ReferenceError' but 'ReferenceError: hello' was thrown$/);
-
-    err(function(){
-      expect(badFn, 'blah').to.throw(PoorlyConstructedError);
-    }, /^blah: expected \[Function(: badFn)*\] to throw 'PoorlyConstructedError' but 'Error: testing' was thrown$/);
-
-    err(function(){
-      expect(ickyErrFn, 'blah').to.not.throw(PoorlyConstructedError);
-    }, /^blah: (expected \[Function(: ickyErrFn)*\] to not throw 'PoorlyConstructedError' but)(.*)(PoorlyConstructedError|\{ Object \()(.*)(was thrown)$/);
-
-    err(function(){
-      expect(ickyErrFn, 'blah').to.throw(ReferenceError);
-    }, /^blah: (expected \[Function(: ickyErrFn)*\] to throw 'ReferenceError' but)(.*)(PoorlyConstructedError|\{ Object \()(.*)(was thrown)$/);
-
-    err(function(){
-      expect(specificErrFn, 'blah').to.throw(new ReferenceError('eek'));
-    }, /^blah: expected \[Function(: specificErrFn)*\] to throw 'ReferenceError: eek' but 'RangeError: boo' was thrown$/);
-
-    err(function(){
-      expect(specificErrFn, 'blah').to.not.throw(specificError);
-    }, /^blah: expected \[Function(: specificErrFn)*\] to not throw 'RangeError: boo'$/);
-
-    err(function (){
-      expect(badFn, 'blah').to.not.throw(/testing/);
-    }, /^blah: expected \[Function(: badFn)*\] to throw error not matching \/testing\/$/);
-
-    err(function () {
-      expect(badFn, 'blah').to.throw(/hello/);
-    }, /^blah: expected \[Function(: badFn)*\] to throw error matching \/hello\/ but got 'testing'$/);
-
-    err(function () {
-      expect(badFn).to.throw(Error, /hello/, 'blah');
-    }, /^blah: expected \[Function(: badFn)*\] to throw error matching \/hello\/ but got 'testing'$/);
-
-    err(function () {
-      expect(badFn, 'blah').to.throw(Error, /hello/);
-    }, /^blah: expected \[Function(: badFn)*\] to throw error matching \/hello\/ but got 'testing'$/);
-
-    err(function () {
-      expect(badFn).to.throw(Error, 'hello', 'blah');
-    }, /^blah: expected \[Function(: badFn)*\] to throw error including 'hello' but got 'testing'$/);
-
-    err(function () {
-      expect(badFn, 'blah').to.throw(Error, 'hello');
-    }, /^blah: expected \[Function(: badFn)*\] to throw error including 'hello' but got 'testing'$/);
-
-    err(function () {
-      expect(customErrFn, 'blah').to.not.throw();
-    }, /^blah: expected \[Function(: customErrFn)*\] to not throw an error but 'CustomError: foo' was thrown$/);
-
-    err(function(){
-      expect(badFn).to.not.throw(Error, 'testing', 'blah');
-    }, /^blah: expected \[Function(: badFn)*\] to not throw 'Error' but 'Error: testing' was thrown$/);
-
-    err(function(){
-      expect(badFn, 'blah').to.not.throw(Error, 'testing');
-    }, /^blah: expected \[Function(: badFn)*\] to not throw 'Error' but 'Error: testing' was thrown$/);
-
-    err(function(){
-      expect(emptyStringErrFn).to.not.throw(Error, '', 'blah');
-    }, /^blah: expected \[Function(: emptyStringErrFn)*\] to not throw 'Error' but 'Error' was thrown$/);
-
-    err(function(){
-      expect(emptyStringErrFn, 'blah').to.not.throw(Error, '');
-    }, /^blah: expected \[Function(: emptyStringErrFn)*\] to not throw 'Error' but 'Error' was thrown$/);
-
-    err(function(){
-      expect(emptyStringErrFn, 'blah').to.not.throw('');
-    }, /^blah: expected \[Function(: emptyStringErrFn)*\] to throw error not including ''$/);
-
-    err(function () {
-      expect({}, 'blah').to.throw();
-    }, "blah: expected {} to be a function");
-
-    err(function () {
-      expect({}).to.throw(Error, 'testing', 'blah');
-    }, "blah: expected {} to be a function");
+    describe("invoked with no args", function () {
+      describe("normal", function () {
+        it("passes when target throws", function () {
+          expect(badFnErr).to.throw();
+        });
+        it("fails when target doesn't throw", function () {
+          err(function () {
+            expect(goodFn, 'blah').to.throw();
+          }, /^blah: expected \[Function(: goodFn)*\] to throw$/);
+        });
+      });
+      describe("negated", function () {
+        it("passes when target doesn't throw", function () {
+          expect(goodFn).to.not.throw();
+        });
+        it("fails when target throws", function () {
+          err(function () {
+            expect(badFnErr, 'blah').to.not.throw();
+          }, /^blah: expected \[Function(: badFnErr)*\] to not throw but \[Error: Illegal salmon!\] was thrown$/);
+        });
+      });
+    });
+    describe("invoked with one arg, a function", function () {
+      it("passes when target throws an instance of function (Error)", function () {
+        expect(badFnErr).to.throw(Error);
+      });
+      it("passes when target throws an instance of function (TypeError)", function () {
+        expect(badFnTypeErr).to.throw(TypeError);
+      });
+      it("passes when target throws an instance of function (FakeError)", function () {
+        expect(badFnFakeErr).to.throw(FakeError);
+      });
+      it("fails when target doesn't throw", function () {
+        err(function () {
+          expect(goodFn, 'blah').to.throw(Error);
+        }, /^blah: expected \[Function(: goodFn)*\] to throw$/);
+      });
+      it("fails when target throws but not an instance of function", function () {
+        err(function () {
+          expect(badFnTypeErr, 'blah').to.throw(ReferenceError);
+        }, /^blah: expected \[TypeError: Illegal salmon!\] to be an instance of ReferenceError$/);
+      });
+    });
+    describe("invoked with one arg, a string", function () {
+      it("passes when target throws an object with `.message` property that contains string", function () {
+        expect(badFnErr).to.throw('salmon');
+      });
+      it("fails when target doesn't throw", function () {
+        err(function () {
+          expect(goodFn, 'blah').to.throw('salmon');
+        }, /^blah: expected \[Function(: goodFn)*\] to throw$/);
+      });
+      it("fails when target throws but not an object with `.message` property", function () {
+        err(function () {
+          expect(badFnObj, 'blah').to.throw('salmon');
+        }, /^blah: expected { a: 1 } to have property 'message'$/);
+      });
+      it("fails when target throws but not an object with `.message` property that contains string", function () {
+        err(function () {
+          expect(badFnErr, 'blah').to.throw('trout');
+        }, /^blah: expected 'Illegal salmon!' to contain 'trout'$/);
+      });
+    });
+    describe("invoked with one arg, a regexp", function () {
+      it("passes when target throws an object with `.message` property that matches regexp", function () {
+        expect(badFnErr).to.throw(/salmon/);
+      });
+      it("fails when target doesn't throw", function () {
+        err(function () {
+          expect(goodFn, 'blah').to.throw(/salmon/);
+        }, /^blah: expected \[Function(: goodFn)*\] to throw$/);
+      });
+      it("fails when target throws but not an object with `.message` property", function () {
+        err(function () {
+          expect(badFnObj, 'blah').to.throw(/salmon/);
+        }, /^blah: expected { a: 1 } to have property 'message'$/);
+      });
+      it("fails when target throws but not an object with `.message` property that matches regexp", function () {
+        err(function () {
+          expect(badFnErr, 'blah').to.throw(/trout/);
+        }, /^blah: expected 'Illegal salmon!' to match \/trout\/$/);
+      });
+    });
+    describe("invoked with one arg, a non-(function|string|regexp)", function () {
+      it("passes when target throws a value that's deeply equal to the arg (TypeError)", function () {
+        expect(badFnTypeErr).to.throw(TypeError('Illegal salmon!'));
+      });
+      it("passes when target throws a value that's deeply equal to the arg (FakeError)", function () {
+        expect(badFnFakeErr).to.throw(new FakeError('Illegal salmon!'));
+      });
+      it("passes when target throws a value that's deeply equal to the arg ({a: 1})", function () {
+        expect(badFnObj).to.throw({a: 1});
+      });
+      it("fails when target doesn't throw", function () {
+        err(function () {
+          expect(goodFn, 'blah').to.throw(TypeError('Illegal salmon!'));
+        }, /^blah: expected \[Function(: goodFn)*\] to throw$/);
+      });
+      it("fails when target throws but not a value that's deeply equal to the arg (TypeError)", function () {
+        err(function () {
+          expect(badFnTypeErr, 'blah')
+            .to.throw(ReferenceError('Illegal salmon!'));
+        }, /^blah: expected \[TypeError: Illegal salmon!\] to deeply equal \[ReferenceError: Illegal salmon!\]$/);
+      });
+      it("fails when target throws but not a value that's deeply equal to the arg (FakeError)", function () {
+        err(function () {
+          expect(badFnFakeErr, 'blah')
+            .to.throw(new FakeError('Illegal trout!'));
+        }, /^blah: expected { message: 'Illegal salmon!' } to deeply equal { message: 'Illegal trout!' }$/);
+      });
+      it("fails when target throws but not a value that's deeply equal to the arg ({a: 1})", function () {
+        err(function () {
+          expect(badFnObj, 'blah').to.throw({b: 2});
+        }, /^blah: expected { a: 1 } to deeply equal { b: 2 }$/);
+      });
+    });
+    describe("invoked with two args, a function (other than `String`) and a string", function () {
+      it("passes when target throws an instance of function with `.message` property that contains string", function () {
+        expect(badFnTypeErr).to.throw(TypeError, 'salmon');
+      });
+      it("fails when target doesn't throw", function () {
+        err(function () {
+          expect(goodFn, 'blah').to.throw(TypeError, 'salmon');
+        }, /^blah: expected \[Function(: goodFn)*\] to throw$/);
+      });
+      it("fails when target throws but not an instance of function", function () {
+        err(function () {
+          expect(badFnTypeErr, 'blah').to.throw(ReferenceError, 'salmon');
+        }, /^blah: expected \[TypeError: Illegal salmon!\] to be an instance of ReferenceError$/);
+      });
+      it("fails when target throws an instance of function but not with `.message` property that contains string", function () {
+        err(function () {
+          expect(badFnTypeErr, 'blah').to.throw(TypeError, 'trout');
+        }, /^blah: expected 'Illegal salmon!' to contain 'trout'$/);
+      });
+    });
+    describe("invoked with two args, a function (other than `String`) and a regexp", function () {
+      it("passes when target throws an instance of function with `.message` property that matches regexp", function () {
+        expect(badFnTypeErr).to.throw(TypeError, /salmon/);
+      });
+      it("fails when target doesn't throw", function () {
+        err(function () {
+          expect(goodFn, 'blah').to.throw(TypeError, /salmon/);
+        }, /^blah: expected \[Function(: goodFn)*\] to throw$/);
+      });
+      it("fails when target throws but not an instance of function", function () {
+        err(function () {
+          expect(badFnTypeErr, 'blah').to.throw(ReferenceError, /salmon/);
+        }, /^blah: expected \[TypeError: Illegal salmon!\] to be an instance of ReferenceError$/);
+      });
+      it("fails when target throws an instance of function but not with `.message` property that matches regexp", function () {
+        err(function () {
+          expect(badFnTypeErr, 'blah').to.throw(TypeError, /trout/);
+        }, /^blah: expected 'Illegal salmon!' to match \/trout\/$/);
+      });
+    });
+    describe("invoked with two args, the `String` constructor and a string", function () {
+      it("passes when target throws a string that contains string", function () {
+        expect(badFnStr).to.throw(String, 'salmon');
+      });
+      it("fails when target doesn't throw", function () {
+        err(function () {
+          expect(goodFn, 'blah').to.throw(String, 'salmon');
+        }, /^blah: expected \[Function(: goodFn)*\] to throw$/);
+      });
+      it("fails when target throws but not a string", function () {
+        err(function () {
+          expect(badFnErr, 'blah').to.throw(String, 'salmon');
+        }, /^blah: expected \[Error: Illegal salmon!\] to be a string$/);
+      });
+      it("fails when target throws a string that doesn't contain string", function () {
+        err(function () {
+          expect(badFnStr, 'blah').to.throw(String, 'trout');
+        }, /^blah: expected 'Illegal salmon!' to contain 'trout'$/);
+      });
+    });
+    describe("invoked with two args, the `String` constructor and a regexp", function () {
+      it("passes when target throws a string that matches regexp", function () {
+        expect(badFnStr).to.throw(String, /salmon/);
+      });
+      it("fails when target doesn't throw", function () {
+        err(function () {
+          expect(goodFn, 'blah').to.throw(String, /salmon/);
+        }, /^blah: expected \[Function(: goodFn)*\] to throw$/);
+      });
+      it("fails when target throws but not a string", function () {
+        err(function () {
+          expect(badFnErr, 'blah').to.throw(String, /salmon/);
+        }, /^blah: expected \[Error: Illegal salmon!\] to be a string$/);
+      });
+      it("fails when target throws a string that doesn't match regexp", function () {
+        err(function () {
+          expect(badFnStr, 'blah').to.throw(String, /trout/);
+        }, /^blah: expected 'Illegal salmon!' to match \/trout\/$/);
+      });
+    });
+    describe("invoked with invalid args", function () {
+      describe("normal", function () {
+        it("fails when errMsgMatcher is defined but errLike isn't a function", function () {
+          err(function () {
+            expect(badFnErr).to.throw(TypeError(), 'salmon');
+          }, /^errLike must be a function when errMsgMatcher is defined$/, true);
+        });
+        it("fails when errMsgMatcher is defined but not a string or regexp", function () {
+          err(function () {
+            expect(badFnErr).to.throw(TypeError, {a: 1});
+          }, /^errMsgMatcher must be a string or regexp when defined$/, true);
+        });
+      });
+      describe("negated", function () {
+        it("fails when errLike is defined", function () {
+          err(function () {
+            expect(badFnErr).to.not.throw(TypeError);
+          }, /^errLike and errMsgMatcher must both be undefined when negate is true$/, true);
+        });
+        it("fails when errMsgMatcher is defined", function () {
+          err(function () {
+            expect(badFnErr).to.not.throw(undefined, 'salmon');
+          }, /^errLike and errMsgMatcher must both be undefined when negate is true$/, true);
+        });
+      });
+    });
   });
 
   it('respondTo', function(){

--- a/test/should.js
+++ b/test/should.js
@@ -293,11 +293,7 @@ describe('should', function() {
 
     err(function () {
       should.Throw(function () { throw new Error('error!') }, Error, 'needed user!', 'blah');
-    }, "blah: expected [Function] to throw error including 'needed user!' but got 'error!'");
-
-    err(function () {
-      should.not.Throw(function () { throw new Error('error!') }, Error, 'error!', 'blah');
-    }, "blah: expected [Function] to not throw 'Error' but 'Error: error!' was thrown");
+    }, "blah: expected 'error!' to contain 'needed user!'");
   });
 
   it('true', function(){


### PR DESCRIPTION
I've been thinking lately about https://github.com/chaijs/check-error/pull/18. I think some of my decisions in that PR were wrong; in particular, dropping support for checking non-`Error` instances. Although only throwing instances of `Error` (including subclassed errors, like `TypeError`) is a best practice, it's not an important enough issue to justify enforcing that best practice on users in the form of a breaking change. However, there are other issues that are important enough to justify breaking changes:

1. Eliminating the ambiguity of `.throw('waffles')`; currently it asserts that the target function throws either a string that contains "waffles", or an object that has a `.message` property that contains "waffles". Users typically have only one of those scenarios in mind when writing the assertion, and it's an unwelcome surprise for the assertion to pass given the other scenario.

2. Eliminating the ambiguity of `.not.throw(someCriteria)`; currently it asserts that the target function either doesn't throw, or it throws but the thrown value doesn't match one or more of the given criteria. Again, users typically have only one of those scenarios in mind when writing the assertion.

3. Eliminating a reasonable-looking but actually-meaningless assertion from always passing; currently `expect(myFn).to.throw` silently passes, regardless of whether or not `myFn` throws, because `.throw` is only a method-based assertion. This is an unwelcome surprise for users of an assertion library that makes use of property-based assertions (e.g., `.true`). (I'm opposed to jumping to the opposite extreme of removing all property-based assertions from Chai; despite these types of problems, I think property-based assertions are a critical part of Chai's identity and appeal for many users.)

4. Replacing the seldom-used `.throw(ErrorInstance)` behavior, which currently checks if the thrown value is strictly (`===`) equal to `ErrorInstance`, with more useful behavior of checking that the thrown value is deeply equal to `ErrorInstance`. This change was enabled by https://github.com/chaijs/deep-eql/pull/59. 

This PR demonstrates the changes I have in mind in the form of an update to the docs for `.throw`. I believe that implementing these changes would significantly simplify the code (and possibly eliminate the need for a separate `check-error` module altogether), as most of the complexity of the current implementation is caused by handling the ambiguity of the first two issues described above. It'd also lead to the creation of a similar `.error` assertion.

Questions:

1. What are your thoughts on these changes in general?
2. How do you feel about a major release for these changes (and to drop Node v4 and old IE support) prior to the release of anything related to the work being done in the `new-chai` repo?
3. Are the changes suggested here compatible with the work being done in the `new-chai` repo?