### PR TITLE
Add delta message to closeTo() error

### DIFF
--- a/chai.js
+++ b/chai.js
@@ -3311,8 +3311,9 @@ module.exports = function (chai, _) {
     new Assertion(obj, flagMsg, ssfi, true).is.a('number');
     if (typeof expected !== 'number' || typeof delta !== 'number') {
       flagMsg = flagMsg ? flagMsg + ': ' : '';
+      var deltaMessage = delta === undefined ? ", and a delta is required" : "";
       throw new AssertionError(
-          flagMsg + 'the arguments to closeTo or approximately must be numbers',
+          flagMsg + 'the arguments to closeTo or approximately must be numbers' + deltaMessage,
           undefined,
           ssfi
       );

--- a/lib/chai/core/assertions.js
+++ b/lib/chai/core/assertions.js
@@ -2950,8 +2950,9 @@ module.exports = function (chai, _) {
     new Assertion(obj, flagMsg, ssfi, true).is.a('number');
     if (typeof expected !== 'number' || typeof delta !== 'number') {
       flagMsg = flagMsg ? flagMsg + ': ' : '';
+      var deltaMessage = delta === undefined ? ", and a delta is required" : "";
       throw new AssertionError(
-          flagMsg + 'the arguments to closeTo or approximately must be numbers',
+          flagMsg + 'the arguments to closeTo or approximately must be numbers' + deltaMessage,
           undefined,
           ssfi
       );

--- a/test/assert.js
+++ b/test/assert.js
@@ -1848,6 +1848,10 @@ describe('assert', function () {
     err(function() {
       assert.closeTo(1.5, 1.0, true, 'blah');
     }, "blah: the arguments to closeTo or approximately must be numbers");
+
+    err(function() {
+      assert.closeTo(1.5, 1.0, undefined, 'blah');
+    }, "blah: the arguments to closeTo or approximately must be numbers, and a delta is required");
   });
 
   it('approximately', function(){
@@ -1874,6 +1878,10 @@ describe('assert', function () {
     err(function() {
       assert.approximately(1.5, 1.0, true, 'blah');
     }, "blah: the arguments to closeTo or approximately must be numbers");
+
+    err(function() {
+      assert.approximately(1.5, 1.0, undefined, 'blah');
+    }, "blah: the arguments to closeTo or approximately must be numbers, and a delta is required");
   });
 
   it('sameMembers', function() {

--- a/test/expect.js
+++ b/test/expect.js
@@ -3239,6 +3239,10 @@ describe('expect', function () {
     err(function() {
       expect(1.5, 'blah').to.be.closeTo(1.0, true);
     }, "blah: the arguments to closeTo or approximately must be numbers");
+
+    err(function() {
+      expect(1.5, 'blah').to.be.closeTo(1.0);
+    }, "blah: the arguments to closeTo or approximately must be numbers, and a delta is required");
   });
 
   it('approximately', function(){
@@ -3265,6 +3269,10 @@ describe('expect', function () {
     err(function() {
       expect(1.5).to.be.approximately(1.0, true);
     }, "the arguments to closeTo or approximately must be numbers");
+
+    err(function() {
+      expect(1.5).to.be.approximately(1.0);
+    }, "the arguments to closeTo or approximately must be numbers, and a delta is required");
   });
 
   it('oneOf', function() {

--- a/test/should.js
+++ b/test/should.js
@@ -2796,6 +2796,10 @@ describe('should', function() {
     err(function() {
       (1.5).should.be.closeTo(1.0, true, 'blah');
     }, "blah: the arguments to closeTo or approximately must be numbers");
+
+    err(function() {
+      (1.5).should.be.closeTo(1.0, undefined, 'blah');
+    }, "blah: the arguments to closeTo or approximately must be numbers, and a delta is required");
   });
 
   it('approximately', function(){
@@ -2816,6 +2820,10 @@ describe('should', function() {
     err(function() {
       (1.5).should.be.approximately(1.0, true);
     }, "the arguments to closeTo or approximately must be numbers");
+
+    err(function() {
+      (1.5).should.be.approximately(1.0);
+    }, "the arguments to closeTo or approximately must be numbers, and a delta is required");
   });
 
   it('include.members', function() {


### PR DESCRIPTION
This makes validation messaging a little more user-friendly for a particular assertion call mistake:

    expect(someValue).to.be.closeTo(50.0);

Currently, the messaging just says that all args must be numbers. This adds a direction to check the `delta` arg if it is not provided.

I spent way too long troubleshooting this locally and just want to save someone else some time.