### PR TITLE
Adding operator attribute to assertion error

### DIFF
--- a/lib/chai/assertion.js
+++ b/lib/chai/assertion.js
@@ -138,11 +138,20 @@ module.exports = function (_chai, util) {
     if (!ok) {
       msg = util.getMessage(this, arguments);
       var actual = util.getActual(this, arguments);
-      throw new AssertionError(msg, {
-          actual: actual
+      var assertionErrorObjectProperties = {
+        actual: actual
         , expected: expected
         , showDiff: showDiff
-      }, (config.includeStack) ? this.assert : flag(this, 'ssfi'));
+      };
+
+      var operator = util.getOperator(this, arguments);
+      if (operator) {
+        assertionErrorObjectProperties.operator = operator;
+      }
+
+      throw new AssertionError(msg,
+        assertionErrorObjectProperties,
+        (config.includeStack) ? this.assert : flag(this, 'ssfi'));
     }
   };
 

--- a/lib/chai/utils/getOperator.js
+++ b/lib/chai/utils/getOperator.js
@@ -1,0 +1,58 @@
+/*!
+ * Module dependencies
+ */
+
+var inspect = require('./inspect');
+var config = require('../config');
+var flag = require('./flag');
+
+function isObjectType(obj) {
+  var str = inspect(obj),
+    type = Object.prototype.toString.call(obj);
+
+  if (config.truncateThreshold && str.length >= config.truncateThreshold) {
+    return (
+      type === '[object Function]' ||
+      type === '[object Array]' ||
+      type === '[object Object]'
+    );
+  }
+
+  return false;
+}
+
+/**
+ * ### .getGetOperator(message)
+ *
+ * Extract the operator from error message.
+ * Operator defined is based on below link
+ * https://nodejs.org/api/assert.html#assert_assert.
+ *
+ * Returns the `operator` or `undefined` value for an Assertion.
+ *
+ * @param {Object} object (constructed Assertion)
+ * @param {Arguments} chai.Assertion.prototype.assert arguments
+ * @namespace Utils
+ * @name getGetOperator
+ * @api public
+ */
+
+module.exports = function getOperator(obj, args) {
+  var negate = flag(obj, 'negate'),
+    expected = args[3],
+    msg = negate ? args[2] : args[1];
+
+  if (typeof msg === 'function') msg = msg();
+
+  msg = msg || '';
+  if (/\shave\s/.test(msg)) {
+    return undefined;
+  }
+
+  var isObject = isObjectType(expected);
+  if (/\snot\s/.test(msg)) {
+    return isObject ? 'notDeepStrictEqual' : 'notStrictEqual';
+  }
+
+  return isObject ? 'deepStrictEqual' : 'strictEqual';
+};

--- a/lib/chai/utils/index.js
+++ b/lib/chai/utils/index.js
@@ -170,3 +170,9 @@ exports.isProxyEnabled = require('./isProxyEnabled');
  */
 
 exports.isNaN = require('./isNaN');
+
+/*!
+ * getOperator method
+ */
+
+exports.getOperator = require('./getOperator');


### PR DESCRIPTION
This is an attempt to add `operator` property for the `AssertionError`.
(As per the issue https://github.com/chaijs/chai/issues/1252)
Operators are as follows.
- https://nodejs.org/api/assert.html#assert_assert_deepstrictequal_actual_expected_message
- https://nodejs.org/api/assert.html#assert_assert_notdeepstrictequal_actual_expected_message
- https://nodejs.org/api/assert.html#assert_assert_strictequal_actual_expected_message
- https://nodejs.org/api/assert.html#assert_assert_notstrictequal_actual_expected_message

Please give me feedback on this draft PR.
Thank you.