### PR TITLE
Adding operator attribute to assertion error

### DIFF
--- a/chai.js
+++ b/chai.js
@@ -95,7 +95,7 @@ exports.use(should);
 var assert = require('./chai/interface/assert');
 exports.use(assert);
 
-},{"./chai/assertion":3,"./chai/config":4,"./chai/core/assertions":5,"./chai/interface/assert":6,"./chai/interface/expect":7,"./chai/interface/should":8,"./chai/utils":23,"assertion-error":34}],3:[function(require,module,exports){
+},{"./chai/assertion":3,"./chai/config":4,"./chai/core/assertions":5,"./chai/interface/assert":6,"./chai/interface/expect":7,"./chai/interface/should":8,"./chai/utils":22,"assertion-error":33}],3:[function(require,module,exports){
 /*!
  * chai
  * http://chaijs.com
@@ -236,20 +236,11 @@ module.exports = function (_chai, util) {
     if (!ok) {
       msg = util.getMessage(this, arguments);
       var actual = util.getActual(this, arguments);
-      var assertionErrorObjectProperties = {
-        actual: actual
+      throw new AssertionError(msg, {
+          actual: actual
         , expected: expected
         , showDiff: showDiff
-      };
-
-      var operator = util.getOperator(this, arguments);
-      if (operator) {
-        assertionErrorObjectProperties.operator = operator;
-      }
-
-      throw new AssertionError(msg,
-        assertionErrorObjectProperties,
-        (config.includeStack) ? this.assert : flag(this, 'ssfi'));
+      }, (config.includeStack) ? this.assert : flag(this, 'ssfi'));
     }
   };
 
@@ -7712,7 +7703,7 @@ module.exports = function addChainableMethod(ctx, name, method, chainingBehavior
   });
 };
 
-},{"../../chai":2,"./addLengthGuard":10,"./flag":15,"./proxify":31,"./transferFlags":33}],10:[function(require,module,exports){
+},{"../../chai":2,"./addLengthGuard":10,"./flag":15,"./proxify":30,"./transferFlags":32}],10:[function(require,module,exports){
 var fnLengthDesc = Object.getOwnPropertyDescriptor(function () {}, 'length');
 
 /*!
@@ -7844,7 +7835,7 @@ module.exports = function addMethod(ctx, name, method) {
   ctx[name] = proxify(methodWrapper, name);
 };
 
-},{"../../chai":2,"./addLengthGuard":10,"./flag":15,"./proxify":31,"./transferFlags":33}],12:[function(require,module,exports){
+},{"../../chai":2,"./addLengthGuard":10,"./flag":15,"./proxify":30,"./transferFlags":32}],12:[function(require,module,exports){
 /*!
  * Chai - addProperty utility
  * Copyright(c) 2012-2014 Jake Luer <jake@alogicalparadox.com>
@@ -7918,7 +7909,7 @@ module.exports = function addProperty(ctx, name, getter) {
   });
 };
 
-},{"../../chai":2,"./flag":15,"./isProxyEnabled":26,"./transferFlags":33}],13:[function(require,module,exports){
+},{"../../chai":2,"./flag":15,"./isProxyEnabled":25,"./transferFlags":32}],13:[function(require,module,exports){
 /*!
  * Chai - compareByInspect utility
  * Copyright(c) 2011-2016 Jake Luer <jake@alogicalparadox.com>
@@ -7951,7 +7942,7 @@ module.exports = function compareByInspect(a, b) {
   return inspect(a) < inspect(b) ? -1 : 1;
 };
 
-},{"./inspect":24}],14:[function(require,module,exports){
+},{"./inspect":23}],14:[function(require,module,exports){
 /*!
  * Chai - expectTypes utility
  * Copyright(c) 2012-2014 Jake Luer <jake@alogicalparadox.com>
@@ -8004,7 +7995,7 @@ module.exports = function expectTypes(obj, types) {
   }
 };
 
-},{"./flag":15,"assertion-error":34,"type-detect":39}],15:[function(require,module,exports){
+},{"./flag":15,"assertion-error":33,"type-detect":38}],15:[function(require,module,exports){
 /*!
  * Chai - flag utility
  * Copyright(c) 2012-2014 Jake Luer <jake@alogicalparadox.com>
@@ -8141,76 +8132,7 @@ module.exports = function getMessage(obj, args) {
   return flagMsg ? flagMsg + ': ' + msg : msg;
 };
 
-},{"./flag":15,"./getActual":16,"./objDisplay":27}],19:[function(require,module,exports){
-/*!
- * Module dependencies
- */
-
-var inspect = require('./inspect');
-var config = require('../config');
-var flag = require('./flag');
-
-function isObjectType(obj) {
-  var str = inspect(obj),
-    type = Object.prototype.toString.call(obj);
-
-  if (config.truncateThreshold && str.length >= config.truncateThreshold) {
-    return (
-      type === '[object Function]' ||
-      type === '[object Array]' ||
-      type === '[object Object]'
-    );
-  }
-
-  return false;
-}
-
-/**
- * ### .getGetOperator(message)
- *
- * Extract the operator from error message.
- * Operator defined is based on below link
- * https://nodejs.org/api/assert.html#assert_assert.
- *
- * Returns the `operator` or `undefined` value for an Assertion.
- *
- * @param {Object} object (constructed Assertion)
- * @param {Arguments} chai.Assertion.prototype.assert arguments
- * @namespace Utils
- * @name getGetOperator
- * @api public
- */
-
-module.exports = function getOperator(obj, args) {
-  var operator = flag(obj, 'operator');
-  var negate = flag(obj, 'negate');
-  var expected = args[3];
-  var msg = negate ? args[2] : args[1];
-
-  if (operator) {
-    return operator;
-  }
-
-  if (typeof msg === 'function') msg = msg();
-
-  msg = msg || '';
-  if (!msg) {
-    return undefined;
-  }
-
-  if (/\shave\s/.test(msg)) {
-    return undefined;
-  }
-
-  var isObject = isObjectType(expected);
-  if (/\snot\s/.test(msg)) {
-    return isObject ? 'notDeepStrictEqual' : 'notStrictEqual';
-  }
-
-  return isObject ? 'deepStrictEqual' : 'strictEqual';
-};
-
-},{"../config":4,"./flag":15,"./inspect":24}],20:[function(require,module,exports){
+},{"./flag":15,"./getActual":16,"./objDisplay":26}],19:[function(require,module,exports){
 /*!
  * Chai - getOwnEnumerableProperties utility
  * Copyright(c) 2011-2016 Jake Luer <jake@alogicalparadox.com>
@@ -8241,7 +8163,7 @@ module.exports = function getOwnEnumerableProperties(obj) {
   return Object.keys(obj).concat(getOwnEnumerablePropertySymbols(obj));
 };
 
-},{"./getOwnEnumerablePropertySymbols":21}],21:[function(require,module,exports){
+},{"./getOwnEnumerablePropertySymbols":20}],20:[function(require,module,exports){
 /*!
  * Chai - getOwnEnumerablePropertySymbols utility
  * Copyright(c) 2011-2016 Jake Luer <jake@alogicalparadox.com>
@@ -8270,7 +8192,7 @@ module.exports = function getOwnEnumerablePropertySymbols(obj) {
   });
 };
 
-},{}],22:[function(require,module,exports){
+},{}],21:[function(require,module,exports){
 /*!
  * Chai - getProperties utility
  * Copyright(c) 2012-2014 Jake Luer <jake@alogicalparadox.com>
@@ -8308,7 +8230,7 @@ module.exports = function getProperties(object) {
   return result;
 };
 
-},{}],23:[function(require,module,exports){
+},{}],22:[function(require,module,exports){
 /*!
  * chai
  * Copyright(c) 2011 Jake Luer <jake@alogicalparadox.com>
@@ -8482,12 +8404,7 @@ exports.isProxyEnabled = require('./isProxyEnabled');
 
 exports.isNaN = require('./isNaN');
 
-/*!
- * getOperator method
- */
-
-exports.getOperator = require('./getOperator');
-},{"./addChainableMethod":9,"./addLengthGuard":10,"./addMethod":11,"./addProperty":12,"./compareByInspect":13,"./expectTypes":14,"./flag":15,"./getActual":16,"./getMessage":18,"./getOperator":19,"./getOwnEnumerableProperties":20,"./getOwnEnumerablePropertySymbols":21,"./inspect":24,"./isNaN":25,"./isProxyEnabled":26,"./objDisplay":27,"./overwriteChainableMethod":28,"./overwriteMethod":29,"./overwriteProperty":30,"./proxify":31,"./test":32,"./transferFlags":33,"check-error":35,"deep-eql":36,"get-func-name":37,"pathval":38,"type-detect":39}],24:[function(require,module,exports){
+},{"./addChainableMethod":9,"./addLengthGuard":10,"./addMethod":11,"./addProperty":12,"./compareByInspect":13,"./expectTypes":14,"./flag":15,"./getActual":16,"./getMessage":18,"./getOwnEnumerableProperties":19,"./getOwnEnumerablePropertySymbols":20,"./inspect":23,"./isNaN":24,"./isProxyEnabled":25,"./objDisplay":26,"./overwriteChainableMethod":27,"./overwriteMethod":28,"./overwriteProperty":29,"./proxify":30,"./test":31,"./transferFlags":32,"check-error":34,"deep-eql":35,"get-func-name":36,"pathval":37,"type-detect":38}],23:[function(require,module,exports){
 // This is (almost) directly from Node.js utils
 // https://github.com/joyent/node/blob/f8c335d0caf47f16d31413f89aa28eda3878e3aa/lib/util.js
 
@@ -8865,7 +8782,7 @@ function objectToString(o) {
   return Object.prototype.toString.call(o);
 }
 
-},{"../config":4,"./getEnumerableProperties":17,"./getProperties":22,"get-func-name":37}],25:[function(require,module,exports){
+},{"../config":4,"./getEnumerableProperties":17,"./getProperties":21,"get-func-name":36}],24:[function(require,module,exports){
 /*!
  * Chai - isNaN utility
  * Copyright(c) 2012-2015 Sakthipriyan Vairamani <thechargingvolcano@gmail.com>
@@ -8893,7 +8810,7 @@ function isNaN(value) {
 // If ECMAScript 6's Number.isNaN is present, prefer that.
 module.exports = Number.isNaN || isNaN;
 
-},{}],26:[function(require,module,exports){
+},{}],25:[function(require,module,exports){
 var config = require('../config');
 
 /*!
@@ -8919,7 +8836,7 @@ module.exports = function isProxyEnabled() {
     typeof Reflect !== 'undefined';
 };
 
-},{"../config":4}],27:[function(require,module,exports){
+},{"../config":4}],26:[function(require,module,exports){
 /*!
  * Chai - flag utility
  * Copyright(c) 2012-2014 Jake Luer <jake@alogicalparadox.com>
@@ -8971,7 +8888,7 @@ module.exports = function objDisplay(obj) {
   }
 };
 
-},{"../config":4,"./inspect":24}],28:[function(require,module,exports){
+},{"../config":4,"./inspect":23}],27:[function(require,module,exports){
 /*!
  * Chai - overwriteChainableMethod utility
  * Copyright(c) 2012-2014 Jake Luer <jake@alogicalparadox.com>
@@ -9042,7 +8959,7 @@ module.exports = function overwriteChainableMethod(ctx, name, method, chainingBe
   };
 };
 
-},{"../../chai":2,"./transferFlags":33}],29:[function(require,module,exports){
+},{"../../chai":2,"./transferFlags":32}],28:[function(require,module,exports){
 /*!
  * Chai - overwriteMethod utility
  * Copyright(c) 2012-2014 Jake Luer <jake@alogicalparadox.com>
@@ -9136,7 +9053,7 @@ module.exports = function overwriteMethod(ctx, name, method) {
   ctx[name] = proxify(overwritingMethodWrapper, name);
 };
 
-},{"../../chai":2,"./addLengthGuard":10,"./flag":15,"./proxify":31,"./transferFlags":33}],30:[function(require,module,exports){
+},{"../../chai":2,"./addLengthGuard":10,"./flag":15,"./proxify":30,"./transferFlags":32}],29:[function(require,module,exports){
 /*!
  * Chai - overwriteProperty utility
  * Copyright(c) 2012-2014 Jake Luer <jake@alogicalparadox.com>
@@ -9230,7 +9147,7 @@ module.exports = function overwriteProperty(ctx, name, getter) {
   });
 };
 
-},{"../../chai":2,"./flag":15,"./isProxyEnabled":26,"./transferFlags":33}],31:[function(require,module,exports){
+},{"../../chai":2,"./flag":15,"./isProxyEnabled":25,"./transferFlags":32}],30:[function(require,module,exports){
 var config = require('../config');
 var flag = require('./flag');
 var getProperties = require('./getProperties');
@@ -9379,7 +9296,7 @@ function stringDistanceCapped(strA, strB, cap) {
   return memo[strA.length][strB.length];
 }
 
-},{"../config":4,"./flag":15,"./getProperties":22,"./isProxyEnabled":26}],32:[function(require,module,exports){
+},{"../config":4,"./flag":15,"./getProperties":21,"./isProxyEnabled":25}],31:[function(require,module,exports){
 /*!
  * Chai - test utility
  * Copyright(c) 2012-2014 Jake Luer <jake@alogicalparadox.com>
@@ -9409,7 +9326,7 @@ module.exports = function test(obj, args) {
   return negate ? !expr : expr;
 };
 
-},{"./flag":15}],33:[function(require,module,exports){
+},{"./flag":15}],32:[function(require,module,exports){
 /*!
  * Chai - transferFlags utility
  * Copyright(c) 2012-2014 Jake Luer <jake@alogicalparadox.com>
@@ -9456,7 +9373,7 @@ module.exports = function transferFlags(assertion, object, includeAll) {
   }
 };
 
-},{}],34:[function(require,module,exports){
+},{}],33:[function(require,module,exports){
 /*!
  * assertion-error
  * Copyright(c) 2013 Jake Luer <jake@qualiancy.com>
@@ -9574,7 +9491,7 @@ AssertionError.prototype.toJSON = function (stack) {
   return props;
 };
 
-},{}],35:[function(require,module,exports){
+},{}],34:[function(require,module,exports){
 'use strict';
 
 /* !
@@ -9748,7 +9665,7 @@ module.exports = {
   getConstructorName: getConstructorName,
 };
 
-},{}],36:[function(require,module,exports){
+},{}],35:[function(require,module,exports){
 'use strict';
 /* globals Symbol: false, Uint8Array: false, WeakMap: false */
 /*!
@@ -10205,7 +10122,7 @@ function isPrimitive(value) {
   return value === null || typeof value !== 'object';
 }
 
-},{"type-detect":39}],37:[function(require,module,exports){
+},{"type-detect":38}],36:[function(require,module,exports){
 'use strict';
 
 /* !
@@ -10251,7 +10168,7 @@ function getFuncName(aFunc) {
 
 module.exports = getFuncName;
 
-},{}],38:[function(require,module,exports){
+},{}],37:[function(require,module,exports){
 'use strict';
 
 /* !
@@ -10544,7 +10461,7 @@ module.exports = {
   setPathValue: setPathValue,
 };
 
-},{}],39:[function(require,module,exports){
+},{}],38:[function(require,module,exports){
 (function (global, factory) {
 	typeof exports === 'object' && typeof module !== 'undefined' ? module.exports = factory() :
 	typeof define === 'function' && define.amd ? define(factory) :

--- a/chai.js
+++ b/chai.js
@@ -95,7 +95,7 @@ exports.use(should);
 var assert = require('./chai/interface/assert');
 exports.use(assert);
 
-},{"./chai/assertion":3,"./chai/config":4,"./chai/core/assertions":5,"./chai/interface/assert":6,"./chai/interface/expect":7,"./chai/interface/should":8,"./chai/utils":22,"assertion-error":33}],3:[function(require,module,exports){
+},{"./chai/assertion":3,"./chai/config":4,"./chai/core/assertions":5,"./chai/interface/assert":6,"./chai/interface/expect":7,"./chai/interface/should":8,"./chai/utils":23,"assertion-error":34}],3:[function(require,module,exports){
 /*!
  * chai
  * http://chaijs.com
@@ -236,11 +236,20 @@ module.exports = function (_chai, util) {
     if (!ok) {
       msg = util.getMessage(this, arguments);
       var actual = util.getActual(this, arguments);
-      throw new AssertionError(msg, {
-          actual: actual
+      var assertionErrorObjectProperties = {
+        actual: actual
         , expected: expected
         , showDiff: showDiff
-      }, (config.includeStack) ? this.assert : flag(this, 'ssfi'));
+      };
+
+      var operator = util.getOperator(this, arguments);
+      if (operator) {
+        assertionErrorObjectProperties.operator = operator;
+      }
+
+      throw new AssertionError(msg,
+        assertionErrorObjectProperties,
+        (config.includeStack) ? this.assert : flag(this, 'ssfi'));
     }
   };
 
@@ -7703,7 +7712,7 @@ module.exports = function addChainableMethod(ctx, name, method, chainingBehavior
   });
 };
 
-},{"../../chai":2,"./addLengthGuard":10,"./flag":15,"./proxify":30,"./transferFlags":32}],10:[function(require,module,exports){
+},{"../../chai":2,"./addLengthGuard":10,"./flag":15,"./proxify":31,"./transferFlags":33}],10:[function(require,module,exports){
 var fnLengthDesc = Object.getOwnPropertyDescriptor(function () {}, 'length');
 
 /*!
@@ -7835,7 +7844,7 @@ module.exports = function addMethod(ctx, name, method) {
   ctx[name] = proxify(methodWrapper, name);
 };
 
-},{"../../chai":2,"./addLengthGuard":10,"./flag":15,"./proxify":30,"./transferFlags":32}],12:[function(require,module,exports){
+},{"../../chai":2,"./addLengthGuard":10,"./flag":15,"./proxify":31,"./transferFlags":33}],12:[function(require,module,exports){
 /*!
  * Chai - addProperty utility
  * Copyright(c) 2012-2014 Jake Luer <jake@alogicalparadox.com>
@@ -7909,7 +7918,7 @@ module.exports = function addProperty(ctx, name, getter) {
   });
 };
 
-},{"../../chai":2,"./flag":15,"./isProxyEnabled":25,"./transferFlags":32}],13:[function(require,module,exports){
+},{"../../chai":2,"./flag":15,"./isProxyEnabled":26,"./transferFlags":33}],13:[function(require,module,exports){
 /*!
  * Chai - compareByInspect utility
  * Copyright(c) 2011-2016 Jake Luer <jake@alogicalparadox.com>
@@ -7942,7 +7951,7 @@ module.exports = function compareByInspect(a, b) {
   return inspect(a) < inspect(b) ? -1 : 1;
 };
 
-},{"./inspect":23}],14:[function(require,module,exports){
+},{"./inspect":24}],14:[function(require,module,exports){
 /*!
  * Chai - expectTypes utility
  * Copyright(c) 2012-2014 Jake Luer <jake@alogicalparadox.com>
@@ -7995,7 +8004,7 @@ module.exports = function expectTypes(obj, types) {
   }
 };
 
-},{"./flag":15,"assertion-error":33,"type-detect":38}],15:[function(require,module,exports){
+},{"./flag":15,"assertion-error":34,"type-detect":39}],15:[function(require,module,exports){
 /*!
  * Chai - flag utility
  * Copyright(c) 2012-2014 Jake Luer <jake@alogicalparadox.com>
@@ -8132,7 +8141,76 @@ module.exports = function getMessage(obj, args) {
   return flagMsg ? flagMsg + ': ' + msg : msg;
 };
 
-},{"./flag":15,"./getActual":16,"./objDisplay":26}],19:[function(require,module,exports){
+},{"./flag":15,"./getActual":16,"./objDisplay":27}],19:[function(require,module,exports){
+/*!
+ * Module dependencies
+ */
+
+var inspect = require('./inspect');
+var config = require('../config');
+var flag = require('./flag');
+
+function isObjectType(obj) {
+  var str = inspect(obj),
+    type = Object.prototype.toString.call(obj);
+
+  if (config.truncateThreshold && str.length >= config.truncateThreshold) {
+    return (
+      type === '[object Function]' ||
+      type === '[object Array]' ||
+      type === '[object Object]'
+    );
+  }
+
+  return false;
+}
+
+/**
+ * ### .getGetOperator(message)
+ *
+ * Extract the operator from error message.
+ * Operator defined is based on below link
+ * https://nodejs.org/api/assert.html#assert_assert.
+ *
+ * Returns the `operator` or `undefined` value for an Assertion.
+ *
+ * @param {Object} object (constructed Assertion)
+ * @param {Arguments} chai.Assertion.prototype.assert arguments
+ * @namespace Utils
+ * @name getGetOperator
+ * @api public
+ */
+
+module.exports = function getOperator(obj, args) {
+  var operator = flag(obj, 'operator');
+  var negate = flag(obj, 'negate');
+  var expected = args[3];
+  var msg = negate ? args[2] : args[1];
+
+  if (operator) {
+    return operator;
+  }
+
+  if (typeof msg === 'function') msg = msg();
+
+  msg = msg || '';
+  if (!msg) {
+    return undefined;
+  }
+
+  if (/\shave\s/.test(msg)) {
+    return undefined;
+  }
+
+  var isObject = isObjectType(expected);
+  if (/\snot\s/.test(msg)) {
+    return isObject ? 'notDeepStrictEqual' : 'notStrictEqual';
+  }
+
+  return isObject ? 'deepStrictEqual' : 'strictEqual';
+};
+
+},{"../config":4,"./flag":15,"./inspect":24}],20:[function(require,module,exports){
 /*!
  * Chai - getOwnEnumerableProperties utility
  * Copyright(c) 2011-2016 Jake Luer <jake@alogicalparadox.com>
@@ -8163,7 +8241,7 @@ module.exports = function getOwnEnumerableProperties(obj) {
   return Object.keys(obj).concat(getOwnEnumerablePropertySymbols(obj));
 };
 
-},{"./getOwnEnumerablePropertySymbols":20}],20:[function(require,module,exports){
+},{"./getOwnEnumerablePropertySymbols":21}],21:[function(require,module,exports){
 /*!
  * Chai - getOwnEnumerablePropertySymbols utility
  * Copyright(c) 2011-2016 Jake Luer <jake@alogicalparadox.com>
@@ -8192,7 +8270,7 @@ module.exports = function getOwnEnumerablePropertySymbols(obj) {
   });
 };
 
-},{}],21:[function(require,module,exports){
+},{}],22:[function(require,module,exports){
 /*!
  * Chai - getProperties utility
  * Copyright(c) 2012-2014 Jake Luer <jake@alogicalparadox.com>
@@ -8230,7 +8308,7 @@ module.exports = function getProperties(object) {
   return result;
 };
 
-},{}],22:[function(require,module,exports){
+},{}],23:[function(require,module,exports){
 /*!
  * chai
  * Copyright(c) 2011 Jake Luer <jake@alogicalparadox.com>
@@ -8404,7 +8482,12 @@ exports.isProxyEnabled = require('./isProxyEnabled');
 
 exports.isNaN = require('./isNaN');
 
-},{"./addChainableMethod":9,"./addLengthGuard":10,"./addMethod":11,"./addProperty":12,"./compareByInspect":13,"./expectTypes":14,"./flag":15,"./getActual":16,"./getMessage":18,"./getOwnEnumerableProperties":19,"./getOwnEnumerablePropertySymbols":20,"./inspect":23,"./isNaN":24,"./isProxyEnabled":25,"./objDisplay":26,"./overwriteChainableMethod":27,"./overwriteMethod":28,"./overwriteProperty":29,"./proxify":30,"./test":31,"./transferFlags":32,"check-error":34,"deep-eql":35,"get-func-name":36,"pathval":37,"type-detect":38}],23:[function(require,module,exports){
+/*!
+ * getOperator method
+ */
+
+exports.getOperator = require('./getOperator');
+},{"./addChainableMethod":9,"./addLengthGuard":10,"./addMethod":11,"./addProperty":12,"./compareByInspect":13,"./expectTypes":14,"./flag":15,"./getActual":16,"./getMessage":18,"./getOperator":19,"./getOwnEnumerableProperties":20,"./getOwnEnumerablePropertySymbols":21,"./inspect":24,"./isNaN":25,"./isProxyEnabled":26,"./objDisplay":27,"./overwriteChainableMethod":28,"./overwriteMethod":29,"./overwriteProperty":30,"./proxify":31,"./test":32,"./transferFlags":33,"check-error":35,"deep-eql":36,"get-func-name":37,"pathval":38,"type-detect":39}],24:[function(require,module,exports){
 // This is (almost) directly from Node.js utils
 // https://github.com/joyent/node/blob/f8c335d0caf47f16d31413f89aa28eda3878e3aa/lib/util.js
 
@@ -8782,7 +8865,7 @@ function objectToString(o) {
   return Object.prototype.toString.call(o);
 }
 
-},{"../config":4,"./getEnumerableProperties":17,"./getProperties":21,"get-func-name":36}],24:[function(require,module,exports){
+},{"../config":4,"./getEnumerableProperties":17,"./getProperties":22,"get-func-name":37}],25:[function(require,module,exports){
 /*!
  * Chai - isNaN utility
  * Copyright(c) 2012-2015 Sakthipriyan Vairamani <thechargingvolcano@gmail.com>
@@ -8810,7 +8893,7 @@ function isNaN(value) {
 // If ECMAScript 6's Number.isNaN is present, prefer that.
 module.exports = Number.isNaN || isNaN;
 
-},{}],25:[function(require,module,exports){
+},{}],26:[function(require,module,exports){
 var config = require('../config');
 
 /*!
@@ -8836,7 +8919,7 @@ module.exports = function isProxyEnabled() {
     typeof Reflect !== 'undefined';
 };
 
-},{"../config":4}],26:[function(require,module,exports){
+},{"../config":4}],27:[function(require,module,exports){
 /*!
  * Chai - flag utility
  * Copyright(c) 2012-2014 Jake Luer <jake@alogicalparadox.com>
@@ -8888,7 +8971,7 @@ module.exports = function objDisplay(obj) {
   }
 };
 
-},{"../config":4,"./inspect":23}],27:[function(require,module,exports){
+},{"../config":4,"./inspect":24}],28:[function(require,module,exports){
 /*!
  * Chai - overwriteChainableMethod utility
  * Copyright(c) 2012-2014 Jake Luer <jake@alogicalparadox.com>
@@ -8959,7 +9042,7 @@ module.exports = function overwriteChainableMethod(ctx, name, method, chainingBe
   };
 };
 
-},{"../../chai":2,"./transferFlags":32}],28:[function(require,module,exports){
+},{"../../chai":2,"./transferFlags":33}],29:[function(require,module,exports){
 /*!
  * Chai - overwriteMethod utility
  * Copyright(c) 2012-2014 Jake Luer <jake@alogicalparadox.com>
@@ -9053,7 +9136,7 @@ module.exports = function overwriteMethod(ctx, name, method) {
   ctx[name] = proxify(overwritingMethodWrapper, name);
 };
 
-},{"../../chai":2,"./addLengthGuard":10,"./flag":15,"./proxify":30,"./transferFlags":32}],29:[function(require,module,exports){
+},{"../../chai":2,"./addLengthGuard":10,"./flag":15,"./proxify":31,"./transferFlags":33}],30:[function(require,module,exports){
 /*!
  * Chai - overwriteProperty utility
  * Copyright(c) 2012-2014 Jake Luer <jake@alogicalparadox.com>
@@ -9147,7 +9230,7 @@ module.exports = function overwriteProperty(ctx, name, getter) {
   });
 };
 
-},{"../../chai":2,"./flag":15,"./isProxyEnabled":25,"./transferFlags":32}],30:[function(require,module,exports){
+},{"../../chai":2,"./flag":15,"./isProxyEnabled":26,"./transferFlags":33}],31:[function(require,module,exports){
 var config = require('../config');
 var flag = require('./flag');
 var getProperties = require('./getProperties');
@@ -9296,7 +9379,7 @@ function stringDistanceCapped(strA, strB, cap) {
   return memo[strA.length][strB.length];
 }
 
-},{"../config":4,"./flag":15,"./getProperties":21,"./isProxyEnabled":25}],31:[function(require,module,exports){
+},{"../config":4,"./flag":15,"./getProperties":22,"./isProxyEnabled":26}],32:[function(require,module,exports){
 /*!
  * Chai - test utility
  * Copyright(c) 2012-2014 Jake Luer <jake@alogicalparadox.com>
@@ -9326,7 +9409,7 @@ module.exports = function test(obj, args) {
   return negate ? !expr : expr;
 };
 
-},{"./flag":15}],32:[function(require,module,exports){
+},{"./flag":15}],33:[function(require,module,exports){
 /*!
  * Chai - transferFlags utility
  * Copyright(c) 2012-2014 Jake Luer <jake@alogicalparadox.com>
@@ -9373,7 +9456,7 @@ module.exports = function transferFlags(assertion, object, includeAll) {
   }
 };
 
-},{}],33:[function(require,module,exports){
+},{}],34:[function(require,module,exports){
 /*!
  * assertion-error
  * Copyright(c) 2013 Jake Luer <jake@qualiancy.com>
@@ -9491,7 +9574,7 @@ AssertionError.prototype.toJSON = function (stack) {
   return props;
 };
 
-},{}],34:[function(require,module,exports){
+},{}],35:[function(require,module,exports){
 'use strict';
 
 /* !
@@ -9665,7 +9748,7 @@ module.exports = {
   getConstructorName: getConstructorName,
 };
 
-},{}],35:[function(require,module,exports){
+},{}],36:[function(require,module,exports){
 'use strict';
 /* globals Symbol: false, Uint8Array: false, WeakMap: false */
 /*!
@@ -10122,7 +10205,7 @@ function isPrimitive(value) {
   return value === null || typeof value !== 'object';
 }
 
-},{"type-detect":38}],36:[function(require,module,exports){
+},{"type-detect":39}],37:[function(require,module,exports){
 'use strict';
 
 /* !
@@ -10168,7 +10251,7 @@ function getFuncName(aFunc) {
 
 module.exports = getFuncName;
 
-},{}],37:[function(require,module,exports){
+},{}],38:[function(require,module,exports){
 'use strict';
 
 /* !
@@ -10461,7 +10544,7 @@ module.exports = {
   setPathValue: setPathValue,
 };
 
-},{}],38:[function(require,module,exports){
+},{}],39:[function(require,module,exports){
 (function (global, factory) {
 	typeof exports === 'object' && typeof module !== 'undefined' ? module.exports = factory() :
 	typeof define === 'function' && define.amd ? define(factory) :

--- a/lib/chai/assertion.js
+++ b/lib/chai/assertion.js
@@ -138,11 +138,20 @@ module.exports = function (_chai, util) {
     if (!ok) {
       msg = util.getMessage(this, arguments);
       var actual = util.getActual(this, arguments);
-      throw new AssertionError(msg, {
-          actual: actual
+      var assertionErrorObjectProperties = {
+        actual: actual
         , expected: expected
         , showDiff: showDiff
-      }, (config.includeStack) ? this.assert : flag(this, 'ssfi'));
+      };
+
+      var operator = util.getOperator(this, arguments);
+      if (operator) {
+        assertionErrorObjectProperties.operator = operator;
+      }
+
+      throw new AssertionError(msg,
+        assertionErrorObjectProperties,
+        (config.includeStack) ? this.assert : flag(this, 'ssfi'));
     }
   };
 

--- a/lib/chai/assertion.js
+++ b/lib/chai/assertion.js
@@ -139,7 +139,7 @@ module.exports = function (_chai, util) {
       msg = util.getMessage(this, arguments);
       var actual = util.getActual(this, arguments);
       var assertionErrorObjectProperties = {
-        actual: actual
+          actual: actual
         , expected: expected
         , showDiff: showDiff
       };
@@ -149,7 +149,8 @@ module.exports = function (_chai, util) {
         assertionErrorObjectProperties.operator = operator;
       }
 
-      throw new AssertionError(msg,
+      throw new AssertionError(
+        msg,
         assertionErrorObjectProperties,
         (config.includeStack) ? this.assert : flag(this, 'ssfi'));
     }

--- a/lib/chai/utils/getOperator.js
+++ b/lib/chai/utils/getOperator.js
@@ -1,0 +1,63 @@
+/*!
+ * Module dependencies
+ */
+
+var inspect = require('./inspect');
+var config = require('../config');
+var flag = require('./flag');
+
+function isObjectType(obj) {
+  var str = inspect(obj),
+    type = Object.prototype.toString.call(obj);
+
+  if (config.truncateThreshold && str.length >= config.truncateThreshold) {
+    return (
+      type === '[object Function]' ||
+      type === '[object Array]' ||
+      type === '[object Object]'
+    );
+  }
+
+  return false;
+}
+
+/**
+ * ### .getGetOperator(message)
+ *
+ * Extract the operator from error message.
+ * Operator defined is based on below link
+ * https://nodejs.org/api/assert.html#assert_assert.
+ *
+ * Returns the `operator` or `undefined` value for an Assertion.
+ *
+ * @param {Object} object (constructed Assertion)
+ * @param {Arguments} chai.Assertion.prototype.assert arguments
+ * @namespace Utils
+ * @name getGetOperator
+ * @api public
+ */
+
+module.exports = function getOperator(obj, args) {
+  var operator = flag(obj, 'operator');
+  var negate = flag(obj, 'negate');
+  var expected = args[3];
+  var msg = negate ? args[2] : args[1];
+
+  if (operator) {
+    return operator;
+  }
+
+  if (typeof msg === 'function') msg = msg();
+
+  msg = msg || '';
+  if (/\shave\s/.test(msg)) {
+    return undefined;
+  }
+
+  var isObject = isObjectType(expected);
+  if (/\snot\s/.test(msg)) {
+    return isObject ? 'notDeepStrictEqual' : 'notStrictEqual';
+  }
+
+  return isObject ? 'deepStrictEqual' : 'strictEqual';
+};

--- a/lib/chai/utils/getOperator.js
+++ b/lib/chai/utils/getOperator.js
@@ -50,6 +50,10 @@ module.exports = function getOperator(obj, args) {
   if (typeof msg === 'function') msg = msg();
 
   msg = msg || '';
+  if (!msg) {
+    return undefined;
+  }
+
   if (/\shave\s/.test(msg)) {
     return undefined;
   }

--- a/lib/chai/utils/getOperator.js
+++ b/lib/chai/utils/getOperator.js
@@ -1,24 +1,12 @@
-/*!
- * Module dependencies
- */
+var type = require('type-detect');
 
-var inspect = require('./inspect');
-var config = require('../config');
 var flag = require('./flag');
 
 function isObjectType(obj) {
-  var str = inspect(obj),
-    type = Object.prototype.toString.call(obj);
+  var objectType = type(obj);
+  var objectTypes = ['Array', 'Object', 'function'];
 
-  if (config.truncateThreshold && str.length >= config.truncateThreshold) {
-    return (
-      type === '[object Function]' ||
-      type === '[object Array]' ||
-      type === '[object Object]'
-    );
-  }
-
-  return false;
+  return objectTypes.indexOf(objectType) !== -1;
 }
 
 /**

--- a/lib/chai/utils/getOperator.js
+++ b/lib/chai/utils/getOperator.js
@@ -10,7 +10,7 @@ function isObjectType(obj) {
 }
 
 /**
- * ### .getGetOperator(message)
+ * ### .getOperator(message)
  *
  * Extract the operator from error message.
  * Operator defined is based on below link
@@ -21,7 +21,7 @@ function isObjectType(obj) {
  * @param {Object} object (constructed Assertion)
  * @param {Arguments} chai.Assertion.prototype.assert arguments
  * @namespace Utils
- * @name getGetOperator
+ * @name getOperator
  * @api public
  */
 

--- a/lib/chai/utils/index.js
+++ b/lib/chai/utils/index.js
@@ -170,3 +170,9 @@ exports.isProxyEnabled = require('./isProxyEnabled');
  */
 
 exports.isNaN = require('./isNaN');
+
+/*!
+ * getOperator method
+ */
+
+exports.getOperator = require('./getOperator');

--- a/test/globalErr.js
+++ b/test/globalErr.js
@@ -63,6 +63,62 @@ describe('globalErr', function () {
     });
   });
 
+  it('should pass operator if possible during plain object comparison', function () {
+    var val1 = {
+      propVal1: 'val1'
+    };
+
+    var val2 = {
+      propVal2: 'val2'
+    };
+
+    err(function () {
+      expect(val1).to.equal(val2);
+    }, {
+        message: "expected { propVal1: 'val1' } to equal { propVal2: 'val2' }"
+      , expected: val2
+      , actual: val1
+      , operator: 'deepStrictEqual'
+    });
+
+    err(function () {
+      expect(val1).to.not.equal(val1);
+    }, {
+      message: "expected { propVal1: 'val1' } to not equal { propVal1: 'val1' }"
+      , expected: val1
+      , actual: val1
+      , operator: 'notDeepStrictEqual'
+    });
+  });
+
+  it('should pass operator if possible during function comparison', function () {
+    function f1 () {
+      this.propF1 = 'propF1';
+    }
+
+    function f2 () {
+      this.propF2 = 'propF2';
+    }
+
+    err(function () {
+      expect(f1).to.equal(f2);
+    }, {
+        message: "expected [Function: f1] to equal [Function: f2]"
+      , expected: f2
+      , actual: f1
+      , operator: 'deepStrictEqual'
+    });
+
+    err(function () {
+      expect(f1).to.not.equal(f1);
+    }, {
+      message: "expected [Function: f1] to not equal [Function: f1]"
+      , expected: f1
+      , actual: f1
+      , operator: 'notDeepStrictEqual'
+    });
+  });
+
   it('should pass operator if possible during object comparison', function () {
     var val1 = [
         'string1'

--- a/test/globalErr.js
+++ b/test/globalErr.js
@@ -43,6 +43,59 @@ describe('globalErr', function () {
     });
   });
 
+  it('should pass operator if possible during none object comparison', function () {
+    err(function () {
+      expect('cat').to.equal('dog');
+    }, {
+        message: 'expected \'cat\' to equal \'dog\''
+      , expected: 'dog'
+      , actual: 'cat'
+      , operator: 'strictEqual'
+    });
+
+    err(function () {
+      expect('cat').to.not.equal('cat');
+    }, {
+      message: 'expected \'cat\' to not equal \'cat\''
+      , expected: 'cat'
+      , actual: 'cat'
+      , operator: 'notStrictEqual'
+    });
+  });
+
+  it('should pass operator if possible during object comparison', function () {
+    var val1 = [
+        'string1'
+      , 'string2'
+      , 'string3'
+      , 'string4'
+    ];
+
+    var val2 = [
+      'string5'
+    , 'string6'
+    , 'string7'
+    , 'string8'
+    ];
+    err(function () {
+      expect(val1).to.equal(val2);
+    }, {
+        message: 'expected [ Array(4) ] to equal [ Array(4) ]'
+      , expected: val2
+      , actual: val1
+      , operator: 'deepStrictEqual'
+    });
+
+    err(function () {
+      expect(val1).to.not.equal(val1);
+    }, {
+      message: 'expected [ Array(4) ] to not equal [ Array(4) ]'
+      , expected: val1
+      , actual: val1
+      , operator: 'notDeepStrictEqual'
+    });
+  });
+
   it('should throw if regex val does not match error message', function () {
     err(function () {
       err(function () { throw new Err('cat') }, /dog/);

--- a/test/utilities.js
+++ b/test/utilities.js
@@ -1324,4 +1324,105 @@ describe('utilities', function () {
       });
     }
   });
+
+  describe('getOperator', function() {
+    it('Must return operator if the "operator" flag is set', function() {
+      chai.use(function(_chai, _) {
+        expect(_.getOperator({}, [])).to.equal(undefined);
+        expect(_.getOperator({}, [null, null, null])).to.equal(undefined);
+
+        var obj = {};
+        _.flag(obj, 'operator', 'my-operator');
+        expect(_.getOperator(obj, [])).to.equal('my-operator');
+      });
+    });
+
+    it('Must return undefined if message is partial assertions', function() {
+      chai.use(function(_chai, _) {
+        expect(
+          _.getOperator({}, [null, 'to have the same ordered', null, 'test'])
+        ).to.equal(undefined);
+      });
+    });
+
+    it('Must return deepStrictEqual if "expected" is a object and assertion is for equal', function() {
+      chai.use(function(_chai, _) {
+        var expected = Object.create({
+          dummyProperty1: 'dummyProperty1',
+          dummyProperty2: 'dummyProperty2',
+          dummyProperty3: 'dummyProperty3'
+        });
+
+        var obj = {};
+        _.flag(obj, 'negate', false);
+
+        expect(
+          _.getOperator(obj, [
+            null,
+            'expect #{this} deep equal to #{exp}',
+            'expect #{this} not deep equal to #{exp}',
+            expected
+          ])
+        ).to.equal('deepStrictEqual');
+      });
+    });
+
+    it('Must return notDeepStrictEqual if "expected" is a string and assertion is for equal', function() {
+      chai.use(function(_chai, _) {
+        var expected = 'someString';
+
+        var obj = {};
+        _.flag(obj, 'negate', false);
+
+        expect(
+          _.getOperator(obj, [
+            null,
+            'expect #{this} equal to #{exp}',
+            'expect #{this} not equal to #{exp}',
+            expected
+          ])
+        ).to.equal('strictEqual');
+      });
+    });
+
+    it('Must return notDeepStrictEqual if "expected" is a object and assertion is for inequality', function() {
+      chai.use(function(_chai, _) {
+        var expected = Object.create({
+          dummyProperty1: 'dummyProperty1',
+          dummyProperty2: 'dummyProperty2',
+          dummyProperty3: 'dummyProperty3'
+        });
+
+        var obj = {};
+        _.flag(obj, 'negate', true);
+
+        expect(
+          _.getOperator(obj, [
+            null,
+            'expect #{this} deep equal to #{exp}',
+            'expect #{this} not deep equal to #{exp}',
+            expected
+          ])
+        ).to.equal('notDeepStrictEqual');
+      });
+    });
+
+    it('Must return notDeepStrictEqual if "expected" is a string and assertion is for inequality', function() {
+      chai.use(function(_chai, _) {
+        var expected = 'someString';
+
+        var obj = {};
+        _.flag(obj, 'negate', true);
+
+        expect(
+          _.getOperator(obj, [
+            null,
+            'expect #{this} equal to #{exp}',
+            'expect #{this} not equal to #{exp}',
+            expected
+          ])
+        ).to.equal('notStrictEqual');
+      });
+    });
+  });
 });

--- a/test/utilities.js
+++ b/test/utilities.js
@@ -1367,7 +1367,47 @@ describe('utilities', function () {
       });
     });
 
-    it('Must return notDeepStrictEqual if "expected" is a string and assertion is for equal', function() {
+    it('Must return deepStrictEqual if "expected" is a function and assertion is for equal', function() {
+      chai.use(function(_chai, _) {
+        function expected () {
+          this.prop = 'prop';
+        }
+
+        var obj = {};
+        _.flag(obj, 'negate', false);
+
+        expect(
+          _.getOperator(obj, [
+            null,
+            'expect #{this} deep equal to #{exp}',
+            'expect #{this} not deep equal to #{exp}',
+            expected
+          ])
+        ).to.equal('deepStrictEqual');
+      });
+    });
+
+    it('Must return deepStrictEqual if "expected" is an array and assertion is for equal', function() {
+      chai.use(function(_chai, _) {
+        var expected = [
+          'item 1'
+        ];
+
+        var obj = {};
+        _.flag(obj, 'negate', false);
+
+        expect(
+          _.getOperator(obj, [
+            null,
+            'expect #{this} deep equal to #{exp}',
+            'expect #{this} not deep equal to #{exp}',
+            expected
+          ])
+        ).to.equal('deepStrictEqual');
+      });
+    });
+
+    it('Must return strictEqual if "expected" is a string and assertion is for equal', function() {
       chai.use(function(_chai, _) {
         var expected = 'someString';
 
@@ -1407,7 +1447,47 @@ describe('utilities', function () {
       });
     });
 
-    it('Must return notDeepStrictEqual if "expected" is a string and assertion is for inequality', function() {
+    it('Must return notDeepStrictEqual if "expected" is a function and assertion is for inequality', function() {
+      chai.use(function(_chai, _) {
+        function expected () {
+          this.prop = 'prop';
+        }
+
+        var obj = {};
+        _.flag(obj, 'negate', true);
+
+        expect(
+          _.getOperator(obj, [
+            null,
+            'expect #{this} deep equal to #{exp}',
+            'expect #{this} not deep equal to #{exp}',
+            expected
+          ])
+        ).to.equal('notDeepStrictEqual');
+      });
+    });
+
+    it('Must return notDeepStrictEqual if "expected" is an array and assertion is for inequality', function() {
+      chai.use(function(_chai, _) {
+        var expected = [
+          'item 1'
+        ];
+
+        var obj = {};
+        _.flag(obj, 'negate', true);
+
+        expect(
+          _.getOperator(obj, [
+            null,
+            'expect #{this} deep equal to #{exp}',
+            'expect #{this} not deep equal to #{exp}',
+            expected
+          ])
+        ).to.equal('notDeepStrictEqual');
+      });
+    });
+
+    it('Must return notStrictEqual if "expected" is a string and assertion is for inequality', function() {
       chai.use(function(_chai, _) {
         var expected = 'someString';
 


### PR DESCRIPTION
This is an attempt to add `operator` property for the `AssertionError`.
(As per the issue https://github.com/chaijs/chai/issues/1252)
Operators are as follows.
- https://nodejs.org/api/assert.html#assert_assert_deepstrictequal_actual_expected_message
- https://nodejs.org/api/assert.html#assert_assert_notdeepstrictequal_actual_expected_message
- https://nodejs.org/api/assert.html#assert_assert_strictequal_actual_expected_message
- https://nodejs.org/api/assert.html#assert_assert_notstrictequal_actual_expected_message

Please give me feedback on this draft PR.
Thank you.