### PR TITLE
Release chai@4.3.0

### DIFF
--- a/lib/chai.js
+++ b/lib/chai.js
@@ -10,7 +10,7 @@ var used = [];
  * Chai version
  */
 
-exports.version = '4.2.0';
+exports.version = '4.3.0';
 
 /*!
  * Assertion Error

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "Veselin Todorov <hi@vesln.com>",
     "John Firebaugh <john.firebaugh@gmail.com>"
   ],
-  "version": "4.2.0",
+  "version": "4.3.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/chaijs/chai"


### PR DESCRIPTION
# Summary

Hello everyone 😊 

This is a release for `4.3.0`. It doesn't contain that many changes but I think it's important to release this one ASAP so that we can get [this feature out](https://github.com/chaijs/chai/pull/1257).

https://github.com/chaijs/chai/pull/1257 is important for `jest` to be able to show better diffs for people using `chai` as their assertion library.

As per instructions in `CONTRIBUTING.md` a draft release is available at https://github.com/chaijs/chai/releases/tag/untagged-86c01ce248840cb410d6 and will be published once we get this version out. It's been a while since I've last released a `chai` version so please let me know if I missed anything.

The next step is to get this in and publish the release so that the package can be published to NPM, correct?

I've seen [this post](https://github.com/chaijs/chai/pull/1201#issuecomment-424693019) though and it seems like we might have to manually publish.

PS: Travis seems to be failing because SauceLabs is under maintenance for free users.