### PR TITLE
chore: modified the error message

### DIFF
--- a/lib/chai/core/assertions.js
+++ b/lib/chai/core/assertions.js
@@ -533,8 +533,13 @@ module.exports = function (chai, _) {
         // objects with a custom `@@toStringTag`.
         if (val !== Object(val)) {
           throw new AssertionError(
-            flagMsg + 'object tested must be an array, a map, an object,'
-              + ' a set, a string, or a weakset, but ' + objType + ' given',
+            flagMsg + 'the given combination of arguments ('
+            + objType + ' and '
+            + _.type(val).toLowerCase() + ')'
+            + ' is invalid for this assertion. '
+            + 'You can use an array, a map, an object, a set, a string, '
+            + 'or a weakset instead of a '
+            + _.type(val).toLowerCase(),
             undefined,
             ssfi
           );
@@ -3120,12 +3125,12 @@ module.exports = function (chai, _) {
    *
    * It can also be chained with `.contain` or `.include`, which will work with
    * both arrays and strings:
-   * 
+   *
    *     expect('Today is sunny').to.contain.oneOf(['sunny', 'cloudy'])
    *     expect('Today is rainy').to.not.contain.oneOf(['sunny', 'cloudy'])
    *     expect([1,2,3]).to.contain.oneOf([3,4,5])
    *     expect([1,2,3]).to.not.contain.oneOf([4,5,6])
-   * 
+   *
    * `.oneOf` accepts an optional `msg` argument which is a custom error message
    * to show when the assertion fails. The message can also be given as the
    * second argument to `expect`.

--- a/test/assert.js
+++ b/test/assert.js
@@ -720,19 +720,31 @@ describe('assert', function () {
 
     err(function(){
       assert.include(true, true, 'blah');
-    }, "blah: object tested must be an array, a map, an object, a set, a string, or a weakset, but boolean given");
+    },
+      "blah: the given combination of arguments (boolean and boolean) is invalid for this assertion. " +
+      "You can use an array, a map, an object, a set, a string, or a weakset instead of a boolean"
+    );
 
     err(function () {
       assert.include(42, 'bar');
-    }, "object tested must be an array, a map, an object, a set, a string, or a weakset, but number given");
+    },
+      "the given combination of arguments (number and string) is invalid for this assertion. " +
+      "You can use an array, a map, an object, a set, a string, or a weakset instead of a string"
+    );
 
     err(function(){
       assert.include(null, 42);
-    }, "object tested must be an array, a map, an object, a set, a string, or a weakset, but null given");
+    },
+      "the given combination of arguments (null and number) is invalid for this assertion. " +
+      "You can use an array, a map, an object, a set, a string, or a weakset instead of a number"
+    );
 
     err(function () {
       assert.include(undefined, 'bar');
-    }, "object tested must be an array, a map, an object, a set, a string, or a weakset, but undefined given");
+    },
+      "the given combination of arguments (undefined and string) is invalid for this assertion. " +
+      "You can use an array, a map, an object, a set, a string, or a weakset instead of a string"
+    );
   });
 
   it('notInclude', function () {
@@ -798,19 +810,31 @@ describe('assert', function () {
 
     err(function(){
       assert.notInclude(true, true, 'blah');
-    }, "blah: object tested must be an array, a map, an object, a set, a string, or a weakset, but boolean given");
+    },
+      "blah: the given combination of arguments (boolean and boolean) is invalid for this assertion. " +
+      "You can use an array, a map, an object, a set, a string, or a weakset instead of a boolean"
+    );
 
     err(function () {
       assert.notInclude(42, 'bar');
-    }, "object tested must be an array, a map, an object, a set, a string, or a weakset, but number given");
+    },
+      "the given combination of arguments (number and string) is invalid for this assertion. " +
+      "You can use an array, a map, an object, a set, a string, or a weakset instead of a string"
+    );
 
     err(function(){
       assert.notInclude(null, 42);
-    }, "object tested must be an array, a map, an object, a set, a string, or a weakset, but null given");
+    },
+      "the given combination of arguments (null and number) is invalid for this assertion. " +
+      "You can use an array, a map, an object, a set, a string, or a weakset instead of a number"
+    );
 
     err(function () {
       assert.notInclude(undefined, 'bar');
-    }, "object tested must be an array, a map, an object, a set, a string, or a weakset, but undefined given");
+    },
+      "the given combination of arguments (undefined and string) is invalid for this assertion. " +
+      "You can use an array, a map, an object, a set, a string, or a weakset instead of a string"
+    );
 
     err(function () {
       assert.notInclude('foobar', 'bar');

--- a/test/expect.js
+++ b/test/expect.js
@@ -2286,39 +2286,66 @@ describe('expect', function () {
 
     err(function(){
       expect(true).to.include(true, 'blah');
-    }, "blah: object tested must be an array, a map, an object, a set, a string, or a weakset, but boolean given");
+    },
+      "blah: the given combination of arguments (boolean and boolean) is invalid for this assertion. " +
+      "You can use an array, a map, an object, a set, a string, or a weakset instead of a boolean"
+    );
 
     err(function(){
       expect(true, 'blah').to.include(true);
-    }, "blah: object tested must be an array, a map, an object, a set, a string, or a weakset, but boolean given");
+    },
+      "blah: the given combination of arguments (boolean and boolean) is invalid for this assertion. " +
+      "You can use an array, a map, an object, a set, a string, or a weakset instead of a boolean"
+    );
 
     err(function(){
       expect(42.0).to.include(42);
-    }, "object tested must be an array, a map, an object, a set, a string, or a weakset, but number given");
+    },
+      "the given combination of arguments (number and number) is invalid for this assertion. " +
+      "You can use an array, a map, an object, a set, a string, or a weakset instead of a number"
+    );
 
     err(function(){
       expect(null).to.include(42);
-    }, "object tested must be an array, a map, an object, a set, a string, or a weakset, but null given");
+    },
+      "the given combination of arguments (null and number) is invalid for this assertion. " +
+      "You can use an array, a map, an object, a set, a string, or a weakset instead of a number"
+    );
 
     err(function(){
       expect(undefined).to.include(42);
-    }, "object tested must be an array, a map, an object, a set, a string, or a weakset, but undefined given");
+    },
+      "the given combination of arguments (undefined and number) is invalid for this assertion. " +
+      "You can use an array, a map, an object, a set, a string, or a weakset instead of a number"
+    );
 
     err(function(){
       expect(true).to.not.include(true);
-    }, "object tested must be an array, a map, an object, a set, a string, or a weakset, but boolean given");
+    },
+      "the given combination of arguments (boolean and boolean) is invalid for this assertion. " +
+      "You can use an array, a map, an object, a set, a string, or a weakset instead of a boolean"
+    );
 
     err(function(){
       expect(42.0).to.not.include(42);
-    }, "object tested must be an array, a map, an object, a set, a string, or a weakset, but number given");
+    },
+      "the given combination of arguments (number and number) is invalid for this assertion. " +
+      "You can use an array, a map, an object, a set, a string, or a weakset instead of a number"
+    );
 
     err(function(){
       expect(null).to.not.include(42);
-    }, "object tested must be an array, a map, an object, a set, a string, or a weakset, but null given");
+    },
+      "the given combination of arguments (null and number) is invalid for this assertion. " +
+      "You can use an array, a map, an object, a set, a string, or a weakset instead of a number"
+    );
 
     err(function(){
       expect(undefined).to.not.include(42);
-    }, "object tested must be an array, a map, an object, a set, a string, or a weakset, but undefined given");
+    },
+      "the given combination of arguments (undefined and number) is invalid for this assertion. " +
+      "You can use an array, a map, an object, a set, a string, or a weakset instead of a number"
+    );
   });
 
   it('deep.include()', function () {

--- a/test/should.js
+++ b/test/should.js
@@ -1931,19 +1931,31 @@ describe('should', function() {
 
     err(function(){
       (true).should.include(true, 'blah');
-    }, "blah: object tested must be an array, a map, an object, a set, a string, or a weakset, but boolean given");
+    },
+      "blah: the given combination of arguments (boolean and boolean) is invalid for this assertion. " +
+      "You can use an array, a map, an object, a set, a string, or a weakset instead of a boolean"
+    );
 
     err(function(){
       (42).should.include(4);
-    }, "object tested must be an array, a map, an object, a set, a string, or a weakset, but number given");
+    },
+      "the given combination of arguments (number and number) is invalid for this assertion. " +
+      "You can use an array, a map, an object, a set, a string, or a weakset instead of a number"
+    );
 
     err(function(){
       (true).should.not.include(true);
-    }, "object tested must be an array, a map, an object, a set, a string, or a weakset, but boolean given");
+    },
+      "the given combination of arguments (boolean and boolean) is invalid for this assertion. " +
+      "You can use an array, a map, an object, a set, a string, or a weakset instead of a boolean"
+    );
 
     err(function(){
       (42).should.not.include(4);
-    }, "object tested must be an array, a map, an object, a set, a string, or a weakset, but number given");
+    },
+      "the given combination of arguments (number and number) is invalid for this assertion. " +
+      "You can use an array, a map, an object, a set, a string, or a weakset instead of a number"
+    );
   });
 
   it('deep.include()', function () {


### PR DESCRIPTION
This PR is to address the issue https://github.com/chaijs/chai/issues/1263.
The modified message is as mentioned in the closed PR:
https://github.com/chaijs/chai/pull/1267
```
AssertionError: the given combination of arguments (object and string) is invalid for this assertion. You can use an array, a map, an object, a set, a string, or a weakset instead of a string.
```
I didn't add or modify any tests yet, I'll update the tests once modifications are fine.

Thank you.