### PR TITLE
Export chai as ES module

### DIFF
--- a/lib/chai.mjs
+++ b/lib/chai.mjs
@@ -1,0 +1,30 @@
+import chai from './chai.js';
+
+// Destructure everything we want to export from chai.
+const {
+	version,
+	AssertionError,
+	use,
+	util,
+	config,
+	Assertion,
+	expect,
+	should,
+	Should,
+	assert,
+} = chai;
+
+// Re-export.
+export {
+	chai as default,
+	version,
+	AssertionError,
+	use,
+	util,
+	config,
+	Assertion,
+	expect,
+	should,
+	Should,
+	assert,
+};

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "main": "./index",
   "exports": {
     "import": "./lib/chai.mjs",
-    "default": "./index.js",
+    "default": "./index.js"
   },
   "scripts": {
     "test": "make test"

--- a/package.json
+++ b/package.json
@@ -27,8 +27,8 @@
   },
   "main": "./index",
   "exports": {
-    "require": "./index.js",
-    "import": "./lib/chai.mjs"
+    "import": "./lib/chai.mjs",
+    "default": "./index.js",
   },
   "scripts": {
     "test": "make test"

--- a/package.json
+++ b/package.json
@@ -26,6 +26,10 @@
     "url": "https://github.com/chaijs/chai/issues"
   },
   "main": "./index",
+  "exports": {
+    "require": "./index.js",
+    "import": "./lib/chai.mjs"
+  },
   "scripts": {
     "test": "make test"
   },


### PR DESCRIPTION
Since Node 13.2 `--experimental-modules` was unflagged. Since then mocha [has enabled support](https://github.com/mochajs/mocha/pull/4038) for tests written as an ES module in [v7.0.0-esm1](https://github.com/mochajs/mocha/releases/tag/v7.0.0-esm1).

This means that from now on it is possible to write your tests as 
```js
import chai from 'chai';

describe('foo', function() {
  it('bar', function() {
    chai.expect(true).to.be.true;
  });
});
```

Unfortunately it is not possible to write
```js
import { expect } from 'chai';
```
because Node doesn't support named exports from CommonJS modules.

This PR changes this by exporting chai as an ES module and by making use of conditional exports, which was unflagged - but is still experimental - in Node 13.7.

I am aware that conditional exports is still experimental, and hence you'll still get a warning, both for
```js
import { expect } from 'chai';
const { expect } = require('chai');
```
I therefore propose to release the conditional exports as an experimental version - similar to mocha `v7.0.0-esm1` - but to *include* the `chai.mjs` file in a semver minor so that people can do
```js
import { expect } from 'chai/lib/chai.mjs';
```
if they want.