### PR TITLE
Deep equality check in oneOf

### DIFF
--- a/lib/chai/core/assertions.js
+++ b/lib/chai/core/assertions.js
@@ -3150,7 +3150,8 @@ module.exports = function (chai, _) {
     var expected = flag(this, 'object')
       , flagMsg = flag(this, 'message')
       , ssfi = flag(this, 'ssfi')
-      , contains = flag(this, 'contains');
+      , contains = flag(this, 'contains')
+      , isDeep = flag(this, 'deep');
     new Assertion(list, flagMsg, ssfi, true).to.be.an('array');
 
     if (contains) {
@@ -3162,13 +3163,23 @@ module.exports = function (chai, _) {
         , expected
       );
     } else {
-      this.assert(
-        list.indexOf(expected) > -1
-        , 'expected #{this} to be one of #{exp}'
-        , 'expected #{this} to not be one of #{exp}'
-        , list
-        , expected
-      );
+      if (isDeep) {
+        this.assert(
+          list.some(possibility => _.eql(expected, possibility))
+          , 'expected #{this} to deeply equal one of #{exp}'
+          , 'expected #{this} to deeply equal one of #{exp}'
+          , list
+          , expected
+        );
+      } else {
+        this.assert(
+          list.indexOf(expected) > -1
+          , 'expected #{this} to be one of #{exp}'
+          , 'expected #{this} to not be one of #{exp}'
+          , list
+          , expected
+        );
+      }
     }
   }
 

--- a/test/expect.js
+++ b/test/expect.js
@@ -3308,6 +3308,7 @@ describe('expect', function () {
     expect([3, [4]]).to.not.be.oneOf([1, 2, [3, 4]]);
     var threeFour = [3, [4]];
     expect(threeFour).to.be.oneOf([1, 2, threeFour]);
+    expect([]).to.be.deep.oneOf([[], '']);
 
     expect([1, 2]).to.contain.oneOf([4,2,5]);
     expect([3, 4]).to.not.contain.oneOf([2,1,5]);


### PR DESCRIPTION
In issue #1241 it was noted that `.oneOf` gives an unexpected result when attempting deep comparisons, and it turns out that `.oneOf` does not check for the `deep` flag. Since this is already an existing option for `.equal`, it would make sense to extend this behavior to its counterpart in `.oneOf`. 

Fixes #1241.