### PR TITLE
chore(funding): display sponsor button for open collective

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+open_collective: chaijs


### PR DESCRIPTION
Add a sponsor button to the repository to increase the visibility of funding options for the project.

The sponsorship button will help increase the number of supporters in the open collective. Sponsorship is very important for all of you to continue doing this great job.

### Atention

follow the steps on the following page to activate the sponsor button at the top of the repository:

https://help.github.com/en/github/administering-a-repository/displaying-a-sponsor-button-in-your-repository#displaying-a-sponsor-button-in-your-repository

Example:
![image](https://user-images.githubusercontent.com/29241659/84343154-c4d86880-ab7d-11ea-8f3a-7dc36232ed77.png)
