### PR TITLE
unbox BigInt primitives in shouldGetter

### DIFF
--- a/lib/chai/interface/should.js
+++ b/lib/chai/interface/should.js
@@ -13,7 +13,8 @@ module.exports = function (chai, util) {
       if (this instanceof String
           || this instanceof Number
           || this instanceof Boolean
-          || typeof Symbol === 'function' && this instanceof Symbol) {
+          || typeof Symbol === 'function' && this instanceof Symbol
+          || typeof BigInt === 'function' && this instanceof BigInt) {
         return new Assertion(this.valueOf(), null, shouldGetter);
       }
       return new Assertion(this, null, shouldGetter);

--- a/test/should.js
+++ b/test/should.js
@@ -397,6 +397,27 @@ describe('should', function() {
     }, "expected [] to be arguments but got Array");
   });
 
+  it('".should" getter should unbox primitive values', function(){
+    function assert(value) {
+      const AssertionObject = value.should;
+      const type = typeof value;
+      if (AssertionObject.__flags.object !== value) {
+        throw new Error("value `"+ value.toString() +"` ("+ type +") wasn't unboxed");
+      }
+    };
+
+    assert("a");
+    assert(0);
+    assert(true);
+    assert(false);
+    if (typeof Symbol === 'function') {
+      assert(Symbol("a"));
+    }
+    if (typeof BigInt === 'function') {
+      assert(BigInt(10));
+    }
+  });
+
   it('.equal()', function(){
     var foo;
     should.equal(undefined, foo);


### PR DESCRIPTION
Partially addresses https://github.com/chaijs/chai/issues/1321 so that global `should` getter unboxes primitive BigInt values.

Lemme know if I should write any tests.