### PR TITLE
Use object.constructor.name for objDisplay.

### DIFF
--- a/lib/chai/utils/objDisplay.js
+++ b/lib/chai/utils/objDisplay.js
@@ -40,7 +40,7 @@ module.exports = function objDisplay(obj) {
         , kstr = keys.length > 2
           ? keys.splice(0, 2).join(', ') + ', ...'
           : keys.join(', ');
-      return '{ Object (' + kstr + ') }';
+        return '{ ' + (obj.constructor.name || 'Object') + ' (' + kstr + ') }';
     } else {
       return str;
     }

--- a/test/globalErr.js
+++ b/test/globalErr.js
@@ -161,7 +161,7 @@ describe('globalErr', function () {
   it('should throw if object val\'s props are not included in error object', function () {
     err(function () {
       err(function () { throw new Err('cat') }, {text: 'cat'});
-    }, /expected { Object \(message, showDiff(, \.\.\.)*\) } to have property \'text\'/);
+    }, /expected { AssertionError \(message, showDiff(, \.\.\.)*\) } to have property \'text\'/);
 
     err(function () {
       err(function () { throw new Err('cat') }, {message: 'dog'});


### PR DESCRIPTION
To make failure messages more descriptive, like:
```log
 AssertionError: expected { MyComponent (foo, bar) } ...
```
instead of 
```log
 AssertionError: expected { Object (foo, bar) } ...
```

I was not sure where to add a specific test for this change. `objDisplay` does not have a dedicated test file. Could you give me any hint?