### PR TITLE
Drop test for IE10

### DIFF
--- a/sauce.browsers.js
+++ b/sauce.browsers.js
@@ -32,11 +32,15 @@ exports['SL_IE'] = {
   , browserName: 'internet explorer'
 };
 
+/*!
+ * TODO: fails because of Uint8Array support
+ *
 exports['SL_IE_Old'] = {
     base: 'SauceLabs'
   , browserName: 'internet explorer'
   , version: 10
 };
+*/
 
 exports['SL_Edge'] = {
     base: 'SauceLabs'


### PR DESCRIPTION
Test fails because of Uint8Array support