### PR TITLE
Fix JSDoc name in assert.hasAnyDeepKeys

### DIFF
--- a/lib/chai/interface/assert.js
+++ b/lib/chai/interface/assert.js
@@ -1826,7 +1826,7 @@ module.exports = function (chai, util) {
    *     assert.hasAnyDeepKeys(new Set([{one: 'one'}, {two: 'two'}]), [{one: 'one'}, {three: 'three'}]);
    *     assert.hasAnyDeepKeys(new Set([{one: 'one'}, {two: 'two'}]), [{one: 'one'}, {two: 'two'}]);
    *
-   * @name doesNotHaveAllKeys
+   * @name hasAnyDeepKeys
    * @param {Mixed} object
    * @param {Array|Object} keys
    * @param {String} message


### PR DESCRIPTION
It fixes the JSDoc name to `assert.hasAnyDeepKeys`. Also, when the chaijs.github.io is rebuilded, it will fixes the duplicated fragment in the Assert page at the [chaijs.github.io/chai.js#L5996](https://github.com/chaijs/chaijs.github.io/blob/master/chai.js#L5996)
![assertpageduplicated](https://i.ibb.co/7X8wSBy/2020-07-12-16-41-08.png)