### PR TITLE
fix: accept empty keys when actual object is empty

### DIFF
--- a/lib/chai/core/assertions.js
+++ b/lib/chai/core/assertions.js
@@ -2386,7 +2386,7 @@ module.exports = function (chai, _) {
       });
     }
 
-    if (!keys.length) {
+    if (!keys.length && actual.length) {
       throw new AssertionError(flagMsg + 'keys required', undefined, ssfi);
     }
 

--- a/test/assert.js
+++ b/test/assert.js
@@ -994,6 +994,9 @@ describe('assert', function () {
     assert.hasAllKeys({ foo: 1, bar: 2 }, [ 'foo', 'bar' ]);
     assert.hasAllKeys({ foo: 1 }, { foo: 30 });
     assert.hasAllKeys({ foo: 1, bar: 2 }, { 'foo': 6, 'bar': 7 });
+    assert.hasAllKeys({});
+    assert.hasAllKeys({}, []);
+    assert.hasAllKeys({}, {});
 
     assert.containsAllKeys({ foo: 1, bar: 2, baz: 3 }, [ 'foo', 'bar' ]);
     assert.containsAllKeys({ foo: 1, bar: 2, baz: 3 }, [ 'bar', 'foo' ]);
@@ -1004,6 +1007,9 @@ describe('assert', function () {
     assert.containsAllKeys({ foo: 1, bar: 2 }, { 'bar': 7 });
     assert.containsAllKeys({ foo: 1, bar: 2 }, { 'foo': 6 });
     assert.containsAllKeys({ foo: 1, bar: 2 }, { 'bar': 7, 'foo': 6 });
+    assert.containsAllKeys({});
+    assert.containsAllKeys({}, []);
+    assert.containsAllKeys({}, {});
 
     assert.doesNotHaveAllKeys({ foo: 1, bar: 2 }, [ 'baz' ]);
     assert.doesNotHaveAllKeys({ foo: 1, bar: 2 }, [ 'foo' ]);
@@ -1027,6 +1033,10 @@ describe('assert', function () {
     assert.doesNotHaveAnyKeys({ foo: 1, bar: 2 }, [ 'baz' ]);
     assert.doesNotHaveAnyKeys({ foo: 1, bar: 2 }, { baz: 1, biz: 2, fake: 3 });
     assert.doesNotHaveAnyKeys({ foo: 1, bar: 2 }, { baz: 1 });
+
+    assert.doesNotHaveAnyKeys({});
+    assert.doesNotHaveAnyKeys({}, []);
+    assert.doesNotHaveAnyKeys({}, {});
 
     var enumProp1 = 'enumProp1'
       , enumProp2 = 'enumProp2'

--- a/test/expect.js
+++ b/test/expect.js
@@ -2566,6 +2566,17 @@ describe('expect', function () {
     expect({ foo: 1, bar: 2 }).not.have.all.keys({ 'baz': 8, 'foo': 7 });
     expect({ foo: 1, bar: 2 }).not.contain.all.keys({ 'baz': 8, 'foo': 7 });
 
+    expect({}).to.have.all.keys();
+    expect({}).to.have.all.keys({});
+    expect({}).to.have.all.keys([]);
+    expect({}).contain.keys();
+    expect({}).contain.keys({});
+    expect({}).contain.keys([]);
+
+    expect({}).to.not.have.any.keys();
+    expect({}).not.have.any.keys({});
+    expect({}).not.any.keys([]);
+
     var enumProp1 = 'enumProp1'
       , enumProp2 = 'enumProp2'
       , nonEnumProp = 'nonEnumProp'

--- a/test/should.js
+++ b/test/should.js
@@ -2165,6 +2165,17 @@ describe('should', function() {
     ({ 1: 1, 2: 2 }).should.have.any.keys(1, 3);
     ({ 1: 1, 2: 2 }).should.contain.keys(1);
 
+    ({}).should.have.all.keys();
+    ({}).should.have.all.keys([]);
+    ({}).should.have.all.keys({});
+    ({}).should.contain.keys();
+    ({}).should.contain.keys([]);
+    ({}).should.contain.keys({});
+
+    ({}).should.not.have.any.keys();
+    ({}).should.not.have.any.keys([]);
+    ({}).should.not.have.any.keys({});
+
     var enumProp1 = 'enumProp1'
       , enumProp2 = 'enumProp2'
       , nonEnumProp = 'nonEnumProp'


### PR DESCRIPTION
When comparing object keys, the user may happen upon comparing two empty
objects. Before this commit, this would be an error:

    // before
    expect({}).to.have.all.keys({});
    AssertionError: keys required

This commit makes it legal for `keys` to accept no keys when the actual object
is itself empty.

I happened upon this when generating values in property-based testing. Some
tests had object comparisons as the above, but failed for the empty input,
forcing a dance like this:

```js
if (Object.keys(right).length === 0) {
    expect(left).to.be.an('object').that.is.empty;
} else {
    expect(left).to.have.all.keys(right);
}
```

There is a negative side to this PR to consider: `keys` will change its
behaviour depending on the object being inspected. That may be fine or it may be
not, depending on the project's goals.

Another thing to consider is how now there are "two" ways to check if an object
is empty:

1. `expect({}).to.be.empty`
2. `expect({}).to.have.all.keys({})`

That, I feel, is less of a problem, as there seem to be multiple ways of
achieving the same result elsewhere in the library.

Thanks for your time.
