### PR TITLE
:bug: (exports DeprecationWarning) added ./* entry to exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
       "require": "./index.js",
       "import": "./index.mjs"
     },
-    "./": "./"
+    "./": "./",
+    "./*": "./*"
   },
   "scripts": {
     "test": "make test"


### PR DESCRIPTION
this works for node 13-16 removes warnings/errors
I think this resolves #1387

changing just to `./*.js` or `./*` breaks in node 13

