### PR TITLE
chore: add "type":"module" to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "url": "https://github.com/chaijs/chai/issues"
   },
   "main": "./index",
+  "type":"module",
   "exports": {
     ".": {
       "require": "./index.js",


### PR DESCRIPTION
Adds "type":"module" to package.json, so chai can be used in browsers as an es module. 

related to: https://github.com/open-wc/open-wc/pull/2267