### PR TITLE
Add explicit export for `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
       "require": "./index.js",
       "import": "./index.mjs"
     },
-    "./": "./"
+    "./": "./",
+    "./package.json": "./package.json"
   },
   "scripts": {
     "prebuild": "npm run clean",


### PR DESCRIPTION
#### Purpose

Add an explicit export entry for `package.json` to fix the following error when running karma:

```
Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: Package subpath './package.json' is not defined by "exports" in node_modules/chai/package.json
```

 #### Background

https://github.com/nodejs/node/issues/33460

There is a lot of discussion around whether declaring `package.json` as "public API" via `exports` is a good or bad idea. My take is simply that we need to expose this as a workaround before node team decide what to do, otherwise it breaks many tools that relies on `package.json`.
