### PR TITLE
4.x.x: Fix link to commit logs on GitHub

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,7 +1,7 @@
 ### Note
 
 As of 3.0.0, the History.md file has been deprecated. [Please refer to the full
-commit logs available on GitHub](https://github.com/chaijs/chai/commits/master).
+commit logs available on GitHub](https://github.com/chaijs/chai/commits/4.x.x).
 
 ---
 

--- a/History.md
+++ b/History.md
@@ -1,7 +1,7 @@
 ### Note
 
 As of 3.0.0, the History.md file has been deprecated. [Please refer to the full
-commit logs available on GitHub](https://github.com/chaijs/chai/commits/4.x.x).
+commit logs available on GitHub](https://github.com/chaijs/chai/commits).
 
 ---
 


### PR DESCRIPTION
As there is no `master` branch, the link returned a 404.