### PR TITLE
docs: specify return type of objDisplay

### DIFF
--- a/lib/chai/utils/objDisplay.js
+++ b/lib/chai/utils/objDisplay.js
@@ -19,6 +19,7 @@ var config = require('../config');
  * messages or should be truncated.
  *
  * @param {Mixed} javascript object to inspect
+ * @returns {string} stringified object
  * @name objDisplay
  * @namespace Utils
  * @api public


### PR DESCRIPTION
previously it was incorrectly labeled as `objDisplay(obj: object): void` in `@types/chai`.