### PR TITLE
Fix: update exports.version to current version

### DIFF
--- a/lib/chai.js
+++ b/lib/chai.js
@@ -10,7 +10,7 @@ var used = [];
  * Chai version
  */
 
-exports.version = '4.3.3';
+exports.version = '4.3.7';
 
 /*!
  * Assertion Error


### PR DESCRIPTION
This pull request changes [this line](https://github.com/chaijs/chai/blob/4.x.x/lib/chai.js#L13)
to 4.3.7

See issue: #1525
