### PR TITLE
Fix 1564

### DIFF
--- a/lib/chai/core/assertions.js
+++ b/lib/chai/core/assertions.js
@@ -673,7 +673,19 @@ Assertion.addProperty('true', function () {
 });
 
 /**
- * TODO
+ * ### .callable
+ *
+ * Asserts that the target a callable function.
+ *
+ *     expect(console.log).to.be.callable;
+ *
+ * A custom error message can be given as the second argument to `expect`.
+ *
+ *     expect('not a function', 'nooo why fail??').to.be.callable;
+ *
+ * @name callable
+ * @namespace BDD
+ * @api public
  */
 Assertion.addProperty('callable', function () {
   const val = flag(this, 'object')

--- a/lib/chai/core/assertions.js
+++ b/lib/chai/core/assertions.js
@@ -673,6 +673,54 @@ Assertion.addProperty('true', function () {
 });
 
 /**
+ * TODO
+ */
+Assertion.addProperty('callable', function () {
+  const val = flag(this, 'object')
+  const ssfi = flag(this, 'ssfi')
+  const msg = flag(this, 'message') || ''
+
+  if (!['Function', 'AsyncFunction', 'GeneratorFunction', 'AsyncGeneratorFunction'].includes(_.type(val))) {
+    throw new AssertionError(
+      msg + 'expected ' + _.inspect(val) + ' to be callable',
+      undefined,
+      ssfi
+    );
+  }
+});
+
+Assertion.addProperty('asyncFunction', function () {
+  const val = flag(this, 'object')
+  const ssfi = flag(this, 'ssfi')
+  const msg = flag(this, 'message') || ''
+
+  if (!['AsyncFunction', 'AsyncGeneratorFunction'].includes(_.type(val))) {
+    throw new AssertionError(
+      msg + 'expected ' + _.inspect(val) + ' to be a AsyncFunction',
+      undefined,
+      ssfi
+    );
+  }
+});
+
+/**
+ * TODO
+ */
+Assertion.addProperty('generatorFunction', function() {
+  const val = flag(this, 'object')
+  const ssfi = flag(this, 'ssfi')
+  const msg = flag(this, 'message') || ''
+
+  if (!['GeneratorFunction', 'AsyncGeneratorFunction'].includes(_.type(val))) {
+    throw new AssertionError(
+      msg + 'expected ' + inspect(val) + ' to be a GeneratorFunction',
+      undefined,
+      ssfi
+    );
+  }
+});
+
+/**
  * ### .false
  *
  * Asserts that the target is strictly (`===`) equal to `false`.

--- a/lib/chai/core/assertions.js
+++ b/lib/chai/core/assertions.js
@@ -709,14 +709,25 @@ Assertion.addProperty('callable', function () {
   }
 });
 
+/**
+ * @todo
+ */
 Assertion.addProperty('asyncFunction', function () {
   const val = flag(this, 'object')
   const ssfi = flag(this, 'ssfi')
-  const msg = `${flag(this, 'message')}: ` || ''
+  const message = flag(this, 'message')
+  const msg = message ? `${message}: ` : ''
+  const negate = flag(this, 'negate');
 
-  if (!['AsyncFunction', 'AsyncGeneratorFunction'].includes(_.type(val))) {
+  const assertionMessage = negate ?
+    `${msg}expected ${_.inspect(val)} not to be a AsyncFunction` : 
+    `${msg}expected ${_.inspect(val)} to be a AsyncFunction`;
+
+  const isAsyncCallable = ['AsyncFunction', 'AsyncGeneratorFunction'].includes(_.type(val));
+
+  if ((isAsyncCallable && negate) || (!isAsyncCallable && !negate)) {
     throw new AssertionError(
-      msg + 'expected ' + _.inspect(val) + ' to be a AsyncFunction',
+      assertionMessage,
       undefined,
       ssfi
     );
@@ -724,16 +735,24 @@ Assertion.addProperty('asyncFunction', function () {
 });
 
 /**
- * TODO
+ * @todo
  */
 Assertion.addProperty('generatorFunction', function() {
   const val = flag(this, 'object')
   const ssfi = flag(this, 'ssfi')
-  const msg = `${flag(this, 'message')}: ` || ''
+  const message = flag(this, 'message')
+  const msg = message ? `${message}: ` : ''
+  const negate = flag(this, 'negate');
 
-  if (!['GeneratorFunction', 'AsyncGeneratorFunction'].includes(_.type(val))) {
+  const assertionMessage = negate ?
+    `${msg}expected ${_.inspect(val)} not to be a GeneratorFunction` : 
+    `${msg}expected ${_.inspect(val)} to be a GeneratorFunction`;
+
+  const isGeneratorCallable = ['GeneratorFunction', 'AsyncGeneratorFunction'].includes(_.type(val));
+
+  if ((isGeneratorCallable && negate) || (!isGeneratorCallable && !negate)) {
     throw new AssertionError(
-      msg + 'expected ' + _.inspect(val) + ' to be a GeneratorFunction',
+      assertionMessage,
       undefined,
       ssfi
     );
@@ -741,16 +760,24 @@ Assertion.addProperty('generatorFunction', function() {
 });
 
 /**
- * TODO
+ * @todo
  */
 Assertion.addProperty('asyncGeneratorFunction', function() {
   const val = flag(this, 'object')
   const ssfi = flag(this, 'ssfi')
-  const msg = `${flag(this, 'message')}: ` || ''
+  const message = flag(this, 'message')
+  const msg = message ? `${message}: ` : ''
+  const negate = flag(this, 'negate');
 
-  if (_.type(val) !== 'AsyncGeneratorFunction') {
+  const assertionMessage = negate ?
+    `${msg}expected ${_.inspect(val)} not to be a AsyncGeneratorFunction` : 
+    `${msg}expected ${_.inspect(val)} to be a AsyncGeneratorFunction`;
+
+  const isAsyncGeneratorCallable = _.type(val) === 'AsyncGeneratorFunction';
+
+  if ((isAsyncGeneratorCallable && negate) || (!isAsyncGeneratorCallable && !negate)) {
     throw new AssertionError(
-      msg + 'expected ' + _.inspect(val) + ' to be a AsyncGeneratorFunction',
+      assertionMessage,
       undefined,
       ssfi
     );

--- a/lib/chai/core/assertions.js
+++ b/lib/chai/core/assertions.js
@@ -721,6 +721,23 @@ Assertion.addProperty('generatorFunction', function() {
 });
 
 /**
+ * TODO
+ */
+Assertion.addProperty('asyncGeneratorFunction', function() {
+  const val = flag(this, 'object')
+  const ssfi = flag(this, 'ssfi')
+  const msg = `${flag(this, 'message')}: ` || ''
+
+  if (_.type(val) !== 'AsyncGeneratorFunction') {
+    throw new AssertionError(
+      msg + 'expected ' + _.inspect(val) + ' to be a AsyncGeneratorFunction',
+      undefined,
+      ssfi
+    );
+  }
+});
+
+/**
  * ### .false
  *
  * Asserts that the target is strictly (`===`) equal to `false`.

--- a/lib/chai/core/assertions.js
+++ b/lib/chai/core/assertions.js
@@ -239,6 +239,13 @@ Assertion.addProperty('all', function () {
   flag(this, 'any', false);
 });
 
+const functionTypes = {
+  'function': ['function', 'asyncfunction', 'generatorfunction', 'asyncgeneratorfunction'],
+  'asyncfunction': ['asyncfunction', 'asyncgeneratorfunction'],
+  'generatorfunction': ['generatorfunction', 'asyncgeneratorfunction'],
+  'asyncgeneratorfunction': ['asyncgeneratorfunction']
+}
+
 /**
  * ### .a(type[, msg])
  *
@@ -298,14 +305,6 @@ Assertion.addProperty('all', function () {
  * @namespace BDD
  * @api public
  */
-
-const functionTypes = {
-  'function': ['function', 'asyncfunction', 'generatorfunction', 'asyncgeneratorfunction'],
-  'asyncfunction': ['asyncfunction', 'asyncgeneratorfunction'],
-  'generatorfunction': ['generatorfunction', 'asyncgeneratorfunction'],
-  'asyncgeneratorfunction': ['asyncgeneratorfunction']
-}
-
 function an (type, msg) {
   if (msg) flag(this, 'message', msg);
   type = type.toLowerCase();

--- a/lib/chai/core/assertions.js
+++ b/lib/chai/core/assertions.js
@@ -678,7 +678,7 @@ Assertion.addProperty('true', function () {
 Assertion.addProperty('callable', function () {
   const val = flag(this, 'object')
   const ssfi = flag(this, 'ssfi')
-  const msg = flag(this, 'message') || ''
+  const msg = `${flag(this, 'message')}: ` || ''
 
   if (!['Function', 'AsyncFunction', 'GeneratorFunction', 'AsyncGeneratorFunction'].includes(_.type(val))) {
     throw new AssertionError(
@@ -692,7 +692,7 @@ Assertion.addProperty('callable', function () {
 Assertion.addProperty('asyncFunction', function () {
   const val = flag(this, 'object')
   const ssfi = flag(this, 'ssfi')
-  const msg = flag(this, 'message') || ''
+  const msg = `${flag(this, 'message')}: ` || ''
 
   if (!['AsyncFunction', 'AsyncGeneratorFunction'].includes(_.type(val))) {
     throw new AssertionError(
@@ -709,7 +709,7 @@ Assertion.addProperty('asyncFunction', function () {
 Assertion.addProperty('generatorFunction', function() {
   const val = flag(this, 'object')
   const ssfi = flag(this, 'ssfi')
-  const msg = flag(this, 'message') || ''
+  const msg = `${flag(this, 'message')}: ` || ''
 
   if (!['GeneratorFunction', 'AsyncGeneratorFunction'].includes(_.type(val))) {
     throw new AssertionError(

--- a/lib/chai/core/assertions.js
+++ b/lib/chai/core/assertions.js
@@ -713,7 +713,7 @@ Assertion.addProperty('generatorFunction', function() {
 
   if (!['GeneratorFunction', 'AsyncGeneratorFunction'].includes(_.type(val))) {
     throw new AssertionError(
-      msg + 'expected ' + inspect(val) + ' to be a GeneratorFunction',
+      msg + 'expected ' + _.inspect(val) + ' to be a GeneratorFunction',
       undefined,
       ssfi
     );

--- a/lib/chai/core/assertions.js
+++ b/lib/chai/core/assertions.js
@@ -686,9 +686,9 @@ Assertion.addProperty('callable', function () {
     `${msg}expected ${_.inspect(val)} not to be a callable function` : 
     `${msg}expected ${_.inspect(val)} to be a callable function`;
 
-  const isCallable = !['Function', 'AsyncFunction', 'GeneratorFunction', 'AsyncGeneratorFunction'].includes(_.type(val));
+  const isCallable = ['Function', 'AsyncFunction', 'GeneratorFunction', 'AsyncGeneratorFunction'].includes(_.type(val));
 
-  if ((!isCallable && negate) || (isCallable && !negate)) {
+  if ((isCallable && negate) || (!isCallable && !negate)) {
     throw new AssertionError(
       assertionMessage,
       undefined,

--- a/lib/chai/core/assertions.js
+++ b/lib/chai/core/assertions.js
@@ -299,17 +299,34 @@ Assertion.addProperty('all', function () {
  * @api public
  */
 
+const functionTypes = {
+  'function': ['function', 'asyncfunction', 'generatorfunction', 'asyncgeneratorfunction'],
+  'asyncfunction': ['asyncfunction', 'asyncgeneratorfunction'],
+  'generatorfunction': ['generatorfunction', 'asyncgeneratorfunction'],
+  'asyncgeneratorfunction': ['asyncgeneratorfunction']
+}
+
 function an (type, msg) {
   if (msg) flag(this, 'message', msg);
   type = type.toLowerCase();
   var obj = flag(this, 'object')
     , article = ~[ 'a', 'e', 'i', 'o', 'u' ].indexOf(type.charAt(0)) ? 'an ' : 'a ';
 
-  this.assert(
-      type === _.type(obj).toLowerCase()
-    , 'expected #{this} to be ' + article + type
-    , 'expected #{this} not to be ' + article + type
-  );
+  const detectedType = _.type(obj).toLowerCase();
+
+  if (functionTypes['function'].includes(type)) {
+    this.assert(
+        functionTypes[type].includes(detectedType)
+      , 'expected #{this} to be ' + article + type
+      , 'expected #{this} not to be ' + article + type
+    );
+  } else {
+    this.assert(
+      type === detectedType
+      , 'expected #{this} to be ' + article + type
+      , 'expected #{this} not to be ' + article + type
+    );
+  }
 }
 
 Assertion.addChainableMethod('an', an);
@@ -701,81 +718,6 @@ Assertion.addProperty('callable', function () {
   const isCallable = ['Function', 'AsyncFunction', 'GeneratorFunction', 'AsyncGeneratorFunction'].includes(_.type(val));
 
   if ((isCallable && negate) || (!isCallable && !negate)) {
-    throw new AssertionError(
-      assertionMessage,
-      undefined,
-      ssfi
-    );
-  }
-});
-
-/**
- * @todo
- */
-Assertion.addProperty('asyncFunction', function () {
-  const val = flag(this, 'object')
-  const ssfi = flag(this, 'ssfi')
-  const message = flag(this, 'message')
-  const msg = message ? `${message}: ` : ''
-  const negate = flag(this, 'negate');
-
-  const assertionMessage = negate ?
-    `${msg}expected ${_.inspect(val)} not to be a AsyncFunction` : 
-    `${msg}expected ${_.inspect(val)} to be a AsyncFunction`;
-
-  const isAsyncCallable = ['AsyncFunction', 'AsyncGeneratorFunction'].includes(_.type(val));
-
-  if ((isAsyncCallable && negate) || (!isAsyncCallable && !negate)) {
-    throw new AssertionError(
-      assertionMessage,
-      undefined,
-      ssfi
-    );
-  }
-});
-
-/**
- * @todo
- */
-Assertion.addProperty('generatorFunction', function() {
-  const val = flag(this, 'object')
-  const ssfi = flag(this, 'ssfi')
-  const message = flag(this, 'message')
-  const msg = message ? `${message}: ` : ''
-  const negate = flag(this, 'negate');
-
-  const assertionMessage = negate ?
-    `${msg}expected ${_.inspect(val)} not to be a GeneratorFunction` : 
-    `${msg}expected ${_.inspect(val)} to be a GeneratorFunction`;
-
-  const isGeneratorCallable = ['GeneratorFunction', 'AsyncGeneratorFunction'].includes(_.type(val));
-
-  if ((isGeneratorCallable && negate) || (!isGeneratorCallable && !negate)) {
-    throw new AssertionError(
-      assertionMessage,
-      undefined,
-      ssfi
-    );
-  }
-});
-
-/**
- * @todo
- */
-Assertion.addProperty('asyncGeneratorFunction', function() {
-  const val = flag(this, 'object')
-  const ssfi = flag(this, 'ssfi')
-  const message = flag(this, 'message')
-  const msg = message ? `${message}: ` : ''
-  const negate = flag(this, 'negate');
-
-  const assertionMessage = negate ?
-    `${msg}expected ${_.inspect(val)} not to be a AsyncGeneratorFunction` : 
-    `${msg}expected ${_.inspect(val)} to be a AsyncGeneratorFunction`;
-
-  const isAsyncGeneratorCallable = _.type(val) === 'AsyncGeneratorFunction';
-
-  if ((isAsyncGeneratorCallable && negate) || (!isAsyncGeneratorCallable && !negate)) {
     throw new AssertionError(
       assertionMessage,
       undefined,

--- a/lib/chai/core/assertions.js
+++ b/lib/chai/core/assertions.js
@@ -678,11 +678,19 @@ Assertion.addProperty('true', function () {
 Assertion.addProperty('callable', function () {
   const val = flag(this, 'object')
   const ssfi = flag(this, 'ssfi')
-  const msg = `${flag(this, 'message')}: ` || ''
+  const message = flag(this, 'message')
+  const msg = message ? `${message}: ` : ''
+  const negate = flag(this, 'negate');
 
-  if (!['Function', 'AsyncFunction', 'GeneratorFunction', 'AsyncGeneratorFunction'].includes(_.type(val))) {
+  const assertionMessage = negate ?
+    `${msg}expected ${_.inspect(val)} not to be a callable function` : 
+    `${msg}expected ${_.inspect(val)} to be a callable function`;
+
+  const isCallable = !['Function', 'AsyncFunction', 'GeneratorFunction', 'AsyncGeneratorFunction'].includes(_.type(val));
+
+  if ((!isCallable && negate) || (isCallable && !negate)) {
     throw new AssertionError(
-      msg + 'expected ' + _.inspect(val) + ' to be callable',
+      assertionMessage,
       undefined,
       ssfi
     );

--- a/lib/chai/interface/assert.js
+++ b/lib/chai/interface/assert.js
@@ -590,38 +590,6 @@ assert.isNotCallable = function (val, msg) {
 };
 
 /**
- * ### .isAsyncFunction(value, [message])
- *
- * Asserts that `value` is an async function.
- *
- *     async function serveTea() { return 'cup of tea'; };
- *     assert.isAsyncFunction(serveTea, 'great, we can have tea now');
- *
- * @name isAsyncFunction
- * @param {Mixed} value
- * @param {String} message
- * @namespace Assert
- * @api public
- */
-assert.isAsyncFunction = function (val, msg) {
-  new Assertion(val, msg, assert.isAsyncFunction, true).is.a('asyncFunction');
-};
-
-/**
- * TODO
- */
-assert.isGeneratorFunction = function(val, msg) {
-  new Assertion(val, msg, assert.isGeneratorFunction, true).is.a('generatorFunction');
-}
-
-/**
- * TODO
- */
-assert.isAsyncGeneratorFunction = function(val, msg) {
-  new Assertion(val, msg, assert.isAsyncGeneratorFunction, true).is.a('asyncGeneratorFunction');
-}
-
-/**
  * ### .isObject(value, [message])
  *
  * Asserts that `value` is an object of type 'Object' (as revealed by `Object.prototype.toString`).

--- a/lib/chai/interface/assert.js
+++ b/lib/chai/interface/assert.js
@@ -601,7 +601,7 @@ assert.isCallable = function (val, msg) {
 /**
  * ### .isAsyncFunction(value, [message])
  *
- * Asserts that `value` is a async function.
+ * Asserts that `value` is an async function.
  *
  *     async function serveTea() { return 'cup of tea'; };
  *     assert.isAsyncFunction(serveTea, 'great, we can have tea now');

--- a/lib/chai/interface/assert.js
+++ b/lib/chai/interface/assert.js
@@ -8,6 +8,7 @@ import * as chai from '../../../index.js';
 import {Assertion} from '../assertion.js';
 import {flag, inspect} from '../utils/index.js';
 import {AssertionError} from 'assertion-error';
+import {type} from '../utils/type-detect.js';
 
 /**
  * ### assert(expression, message)
@@ -589,6 +590,56 @@ assert.isFunction = function (val, msg) {
 assert.isNotFunction = function (val, msg) {
   new Assertion(val, msg, assert.isNotFunction, true).to.not.be.a('function');
 };
+
+/**
+ * TODO
+ */
+assert.isCallable = function (val, msg) {
+  if (!['Function', 'AsyncFunction', 'GeneratorFunction', 'AsyncGeneratorFunction'].includes(type(val))) {
+    throw new AssertionError(
+      msg + ': expected ' + inspect(val) + ' to be callable',
+      undefined,
+      assert.isCallable
+    );
+  }
+}
+
+/**
+ * ### .isAsyncFunction(value, [message])
+ *
+ * Asserts that `value` is a async function.
+ *
+ *     async function serveTea() { return 'cup of tea'; };
+ *     assert.isAsyncFunction(serveTea, 'great, we can have tea now');
+ *
+ * @name isAsyncFunction
+ * @param {Mixed} value
+ * @param {String} message
+ * @namespace Assert
+ * @api public
+ */
+assert.isAsyncFunction = function (val, msg) {
+  if (!['AsyncFunction', 'AsyncGeneratorFunction'].includes(type(val))) {
+    throw new AssertionError(
+      msg + ': expected ' + inspect(val) + ' to be a AsyncFunction',
+      undefined,
+      assert.isAsyncFunction
+    );
+  }
+};
+
+/**
+ * TODO
+ */
+assert.isGeneratorFunction = function(val, msg) {
+  if (!['GeneratorFunction', 'AsyncGeneratorFunction'].includes(type(val))) {
+    throw new AssertionError(
+      msg + ': expected ' + inspect(val) + ' to be a GeneratorFunction',
+      undefined,
+      assert.isGeneratorFunction
+    );
+  }
+}
 
 /**
  * ### .isObject(value, [message])

--- a/lib/chai/interface/assert.js
+++ b/lib/chai/interface/assert.js
@@ -624,6 +624,13 @@ assert.isGeneratorFunction = function(val, msg) {
 }
 
 /**
+ * TODO
+ */
+assert.isAsyncGeneratorFunction = function(val, msg) {
+  new Assertion(val, msg, assert.isAsyncGeneratorFunction, true).is.asyncGeneratorFunction;
+}
+
+/**
  * ### .isObject(value, [message])
  *
  * Asserts that `value` is an object of type 'Object' (as revealed by `Object.prototype.toString`).

--- a/lib/chai/interface/assert.js
+++ b/lib/chai/interface/assert.js
@@ -604,21 +604,21 @@ assert.isNotCallable = function (val, msg) {
  * @api public
  */
 assert.isAsyncFunction = function (val, msg) {
-  new Assertion(val, msg, assert.isAsyncFunction, true).is.asyncFunction;
+  new Assertion(val, msg, assert.isAsyncFunction, true).is.a('asyncFunction');
 };
 
 /**
  * TODO
  */
 assert.isGeneratorFunction = function(val, msg) {
-  new Assertion(val, msg, assert.isGeneratorFunction, true).is.generatorFunction;
+  new Assertion(val, msg, assert.isGeneratorFunction, true).is.a('generatorFunction');
 }
 
 /**
  * TODO
  */
 assert.isAsyncGeneratorFunction = function(val, msg) {
-  new Assertion(val, msg, assert.isAsyncGeneratorFunction, true).is.asyncGeneratorFunction;
+  new Assertion(val, msg, assert.isAsyncGeneratorFunction, true).is.a('asyncGeneratorFunction');
 }
 
 /**

--- a/lib/chai/interface/assert.js
+++ b/lib/chai/interface/assert.js
@@ -554,49 +554,40 @@ assert.isDefined = function (val, msg) {
 };
 
 /**
- * ### .isFunction(value, [message])
+ * ### .isCallable(value, [message])
  *
- * Asserts that `value` is a function.
+ * Asserts that `value` is a callable function.
  *
  *     function serveTea() { return 'cup of tea'; };
- *     assert.isFunction(serveTea, 'great, we can have tea now');
+ *     assert.isCallable(serveTea, 'great, we can have tea now');
  *
- * @name isFunction
+ * @name isCallable
  * @param {Mixed} value
  * @param {String} message
  * @namespace Assert
  * @api public
- */
-
-assert.isFunction = function (val, msg) {
-  new Assertion(val, msg, assert.isFunction, true).to.be.a('function');
-};
-
-/**
- * ### .isNotFunction(value, [message])
- *
- * Asserts that `value` is _not_ a function.
- *
- *     var serveTea = [ 'heat', 'pour', 'sip' ];
- *     assert.isNotFunction(serveTea, 'great, we have listed the steps');
- *
- * @name isNotFunction
- * @param {Mixed} value
- * @param {String} message
- * @namespace Assert
- * @api public
- */
-
-assert.isNotFunction = function (val, msg) {
-  new Assertion(val, msg, assert.isNotFunction, true).to.not.be.a('function');
-};
-
-/**
- * TODO
  */
 assert.isCallable = function (val, msg) {
   new Assertion(val, msg, assert.isCallable, true).is.callable;
 }
+
+/**
+ * ### .isNotCallable(value, [message])
+ *
+ * Asserts that `value` is _not_ a callable function.
+ *
+ *     var serveTea = [ 'heat', 'pour', 'sip' ];
+ *     assert.isNotCallable(serveTea, 'great, we have listed the steps');
+ *
+ * @name isNotCallable
+ * @param {Mixed} value
+ * @param {String} message
+ * @namespace Assert
+ * @api public
+ */
+assert.isNotCallable = function (val, msg) {
+  new Assertion(val, msg, assert.isNotCallable, true).is.not.callable;
+};
 
 /**
  * ### .isAsyncFunction(value, [message])
@@ -3144,4 +3135,6 @@ assert.isNotEmpty = function(val, msg) {
 ('isFrozen', 'frozen')
 ('isNotFrozen', 'notFrozen')
 ('isEmpty', 'empty')
-('isNotEmpty', 'notEmpty');
+('isNotEmpty', 'notEmpty')
+('isCallable', 'isFunction')
+('isNotCallable', 'isNotFunction')

--- a/lib/chai/interface/assert.js
+++ b/lib/chai/interface/assert.js
@@ -595,13 +595,7 @@ assert.isNotFunction = function (val, msg) {
  * TODO
  */
 assert.isCallable = function (val, msg) {
-  if (!['Function', 'AsyncFunction', 'GeneratorFunction', 'AsyncGeneratorFunction'].includes(type(val))) {
-    throw new AssertionError(
-      msg + ': expected ' + inspect(val) + ' to be callable',
-      undefined,
-      assert.isCallable
-    );
-  }
+  new Assertion(val, msg, assert.isCallable, true).is.callable;
 }
 
 /**
@@ -619,26 +613,14 @@ assert.isCallable = function (val, msg) {
  * @api public
  */
 assert.isAsyncFunction = function (val, msg) {
-  if (!['AsyncFunction', 'AsyncGeneratorFunction'].includes(type(val))) {
-    throw new AssertionError(
-      msg + ': expected ' + inspect(val) + ' to be a AsyncFunction',
-      undefined,
-      assert.isAsyncFunction
-    );
-  }
+  new Assertion(val, msg, assert.isAsyncFunction, true).is.asyncFunction;
 };
 
 /**
  * TODO
  */
 assert.isGeneratorFunction = function(val, msg) {
-  if (!['GeneratorFunction', 'AsyncGeneratorFunction'].includes(type(val))) {
-    throw new AssertionError(
-      msg + ': expected ' + inspect(val) + ' to be a GeneratorFunction',
-      undefined,
-      assert.isGeneratorFunction
-    );
-  }
+  new Assertion(val, msg, assert.isGeneratorFunction, true).is.generatorFunction;
 }
 
 /**

--- a/test/assert.js
+++ b/test/assert.js
@@ -557,7 +557,7 @@ describe('assert', function () {
 
     err(function () {
       assert.isAsyncFunction(function() {}, 'blah');
-    }, "blah: expected [Function] to be a AsyncFunction");
+    }, "blah: expected [Function] to be an asyncfunction");
   });
 
   it('isGeneratorFunction', function() {
@@ -569,7 +569,7 @@ describe('assert', function () {
 
     err(function () {
       assert.isGeneratorFunction(function() {}, 'blah');
-    }, "blah: expected [Function] to be a GeneratorFunction");
+    }, "blah: expected [Function] to be a generatorfunction");
   })
   
   it('isAsyncGeneratorFunction', function() {
@@ -578,15 +578,15 @@ describe('assert', function () {
 
     err(function () {
       assert.isAsyncGeneratorFunction(function() {}, 'blah');
-    }, "blah: expected [Function] to be a AsyncGeneratorFunction");
+    }, "blah: expected [Function] to be an asyncgeneratorfunction");
     
     err(function () {
       assert.isAsyncGeneratorFunction(async function() {}, 'blah');
-    }, "blah: expected [AsyncFunction] to be a AsyncGeneratorFunction");
+    }, "blah: expected [AsyncFunction] to be an asyncgeneratorfunction");
     
     err(function () {
       assert.isAsyncGeneratorFunction(function*() {}, 'blah');
-    }, "blah: expected [GeneratorFunction] to be a AsyncGeneratorFunction");
+    }, "blah: expected [GeneratorFunction] to be an asyncgeneratorfunction");
   })
 
   it('isNotFunction', function () {

--- a/test/assert.js
+++ b/test/assert.js
@@ -545,15 +545,6 @@ describe('assert', function () {
     }, "blah: expected undefined to not equal undefined");
   });
 
-  it('isFunction', function() {
-    var func = function() {};
-    assert.isFunction(func);
-
-    err(function () {
-      assert.isFunction({}, 'blah');
-    }, "blah: expected {} to be a callable function");
-  });
-
   it('isCallable', function() {
     var func = function() {};
     assert.isCallable(func);
@@ -580,6 +571,15 @@ describe('assert', function () {
     err(function () {
       assert.isNotCallable(function() {}, 'blah');
     }, "blah: expected [Function] not to be a callable function");
+  });
+
+  it('isFunction', function() {
+    var func = function() {};
+    assert.isFunction(func);
+
+    err(function () {
+      assert.isFunction({}, 'blah');
+    }, "blah: expected {} to be a callable function");
   });
 
   it('isNotFunction', function () {

--- a/test/assert.js
+++ b/test/assert.js
@@ -582,11 +582,11 @@ describe('assert', function () {
     
     err(function () {
       assert.isAsyncGeneratorFunction(async function() {}, 'blah');
-    }, "blah: expected [Function] to be a AsyncGeneratorFunction");
+    }, "blah: expected [AsyncFunction] to be a AsyncGeneratorFunction");
     
     err(function () {
       assert.isAsyncGeneratorFunction(function*() {}, 'blah');
-    }, "blah: expected [Function] to be a AsyncGeneratorFunction");
+    }, "blah: expected [GeneratorFunction] to be a AsyncGeneratorFunction");
   })
 
   it('isNotFunction', function () {

--- a/test/assert.js
+++ b/test/assert.js
@@ -530,6 +530,48 @@ describe('assert', function () {
     }, "blah: expected {} to be a function");
   });
 
+  it('isCallable', function() {
+    var func = function() {};
+    assert.isCallable(func);
+
+    var func = async function() {};
+    assert.isCallable(func);
+
+    var func = function* () {}
+    assert.isCallable(func);
+
+    var func = async function* () {}
+    assert.isCallable(func);
+
+    err(function () {
+      assert.isCallable({}, 'blah');
+    }, "blah: expected {} to be callable");
+  });
+
+  it('isAsyncFunction', function() {
+    var func = async function() {};
+    assert.isAsyncFunction(func);
+
+    var func = async function*() {};
+    assert.isAsyncFunction(func);
+
+    err(function () {
+      assert.isAsyncFunction(function() {}, 'blah');
+    }, "blah: expected [Function] to be a AsyncFunction");
+  });
+
+  it('isGeneratorFunction', function() {
+    var func = function* () {}
+    assert.isGeneratorFunction(func) 
+
+    var func = async function* () {}
+    assert.isGeneratorFunction(func) 
+
+    err(function () {
+      assert.isGeneratorFunction(function() {}, 'blah');
+    }, "blah: expected [Function] to be a GeneratorFunction");
+  })
+
   it('isNotFunction', function () {
     assert.isNotFunction(5);
 

--- a/test/assert.js
+++ b/test/assert.js
@@ -548,47 +548,6 @@ describe('assert', function () {
     }, "blah: expected {} to be a callable function");
   });
 
-  it('isAsyncFunction', function() {
-    var func = async function() {};
-    assert.isAsyncFunction(func);
-
-    var func = async function*() {};
-    assert.isAsyncFunction(func);
-
-    err(function () {
-      assert.isAsyncFunction(function() {}, 'blah');
-    }, "blah: expected [Function] to be an asyncfunction");
-  });
-
-  it('isGeneratorFunction', function() {
-    var func = function* () {}
-    assert.isGeneratorFunction(func) 
-
-    var func = async function* () {}
-    assert.isGeneratorFunction(func) 
-
-    err(function () {
-      assert.isGeneratorFunction(function() {}, 'blah');
-    }, "blah: expected [Function] to be a generatorfunction");
-  })
-  
-  it('isAsyncGeneratorFunction', function() {
-    var func = async function* () {}
-    assert.isAsyncGeneratorFunction(func) 
-
-    err(function () {
-      assert.isAsyncGeneratorFunction(function() {}, 'blah');
-    }, "blah: expected [Function] to be an asyncgeneratorfunction");
-    
-    err(function () {
-      assert.isAsyncGeneratorFunction(async function() {}, 'blah');
-    }, "blah: expected [AsyncFunction] to be an asyncgeneratorfunction");
-    
-    err(function () {
-      assert.isAsyncGeneratorFunction(function*() {}, 'blah');
-    }, "blah: expected [GeneratorFunction] to be an asyncgeneratorfunction");
-  })
-
   it('isNotFunction', function () {
     assert.isNotFunction(5);
 

--- a/test/assert.js
+++ b/test/assert.js
@@ -571,6 +571,23 @@ describe('assert', function () {
       assert.isGeneratorFunction(function() {}, 'blah');
     }, "blah: expected [Function] to be a GeneratorFunction");
   })
+  
+  it('isAsyncGeneratorFunction', function() {
+    var func = async function* () {}
+    assert.isAsyncGeneratorFunction(func) 
+
+    err(function () {
+      assert.isAsyncGeneratorFunction(function() {}, 'blah');
+    }, "blah: expected [Function] to be a AsyncGeneratorFunction");
+    
+    err(function () {
+      assert.isAsyncGeneratorFunction(async function() {}, 'blah');
+    }, "blah: expected [Function] to be a AsyncGeneratorFunction");
+    
+    err(function () {
+      assert.isAsyncGeneratorFunction(function*() {}, 'blah');
+    }, "blah: expected [Function] to be a AsyncGeneratorFunction");
+  })
 
   it('isNotFunction', function () {
     assert.isNotFunction(5);

--- a/test/assert.js
+++ b/test/assert.js
@@ -527,7 +527,7 @@ describe('assert', function () {
 
     err(function () {
       assert.isFunction({}, 'blah');
-    }, "blah: expected {} to be a function");
+    }, "blah: expected {} to be a callable function");
   });
 
   it('isCallable', function() {
@@ -545,7 +545,7 @@ describe('assert', function () {
 
     err(function () {
       assert.isCallable({}, 'blah');
-    }, "blah: expected {} to be callable");
+    }, "blah: expected {} to be a callable function");
   });
 
   it('isAsyncFunction', function() {
@@ -594,7 +594,7 @@ describe('assert', function () {
 
     err(function () {
       assert.isNotFunction(function () {}, 'blah');
-    }, "blah: expected [Function] not to be a function");
+    }, "blah: expected [Function] not to be a callable function");
   });
 
   it('isArray', function() {

--- a/test/assert.js
+++ b/test/assert.js
@@ -139,6 +139,20 @@ describe('assert', function () {
     assert.typeOf('test', 'string');
     assert.typeOf(true, 'boolean');
     assert.typeOf(5, 'number');
+    
+    assert.typeOf(() => {}, 'function');
+    assert.typeOf(function() {}, 'function');
+    assert.typeOf(async function() {}, 'asyncfunction');
+    assert.typeOf(function*() {}, 'generatorfunction');
+    assert.typeOf(async function*() {}, 'asyncgeneratorfunction');
+    
+    err(function () {
+      assert.typeOf(5, 'function', 'blah');
+    }, "blah: expected 5 to be a function");
+    
+    err(function () {
+      assert.typeOf(function() {}, 'asyncfunction', 'blah');
+    }, "blah: expected [Function] to be an asyncfunction");
 
     if (typeof Symbol === 'function') {
       assert.typeOf(Symbol(), 'symbol');
@@ -151,10 +165,20 @@ describe('assert', function () {
 
   it('notTypeOf', function () {
     assert.notTypeOf('test', 'number');
+    
+    assert.notTypeOf(() => {}, 'string');
+    assert.notTypeOf(function() {}, 'string');
+    assert.notTypeOf(async function() {}, 'string');
+    assert.notTypeOf(function*() {}, 'string');
+    assert.notTypeOf(async function*() {}, 'string');
 
     err(function () {
       assert.notTypeOf(5, 'number', 'blah');
     }, "blah: expected 5 not to be a number");
+    
+    err(function () {
+      assert.notTypeOf(() => {}, 'function', 'blah');
+    }, "blah: expected [Function] not to be a function");
   });
 
   it('instanceOf', function() {
@@ -546,6 +570,16 @@ describe('assert', function () {
     err(function () {
       assert.isCallable({}, 'blah');
     }, "blah: expected {} to be a callable function");
+  });
+  
+  it('isNotCallable', function() {
+    assert.isNotCallable(false);
+    assert.isNotCallable(10);
+    assert.isNotCallable('string');
+
+    err(function () {
+      assert.isNotCallable(function() {}, 'blah');
+    }, "blah: expected [Function] not to be a callable function");
   });
 
   it('isNotFunction', function () {

--- a/test/expect.js
+++ b/test/expect.js
@@ -385,6 +385,23 @@ describe('expect', function () {
     }, "blah: expected 5 not to be a number");
   });
 
+  it('callable', function() {
+    expect(function() {}).to.be.callable;
+    expect(async function() {}).to.be.callable;
+    expect(function*() {}).to.be.callable;
+    expect(async function*() {}).to.be.callable;
+  })
+
+  it('asyncFunction', function() {
+    expect(async function() {}).to.be.asyncFunction;
+    expect(async function*() {}).to.be.asyncFunction;
+  })
+  
+  it('generatorFunction', function() {
+    expect(function*() {}).to.be.generatorFunction;
+    expect(async function*() {}).to.be.generatorFunction;
+  })
+
   it('instanceof', function(){
     function Foo(){}
     expect(new Foo()).to.be.an.instanceof(Foo);
@@ -407,8 +424,8 @@ describe('expect', function () {
     err(function(){
       expect(new Foo(), 'blah').to.an.instanceof(1);
     }, "blah: The instanceof assertion needs a constructor but Number was given.");
-
     err(function(){
+
       expect(new Foo()).to.an.instanceof('batman');
     }, "The instanceof assertion needs a constructor but String was given.");
 

--- a/test/expect.js
+++ b/test/expect.js
@@ -402,6 +402,10 @@ describe('expect', function () {
     expect(async function*() {}).to.be.generatorFunction;
   })
 
+  it('asyncGeneratorFunction', function() {
+    expect(async function*() {}).to.be.asyncGeneratorFunction;
+  })
+
   it('instanceof', function(){
     function Foo(){}
     expect(new Foo()).to.be.an.instanceof(Foo);

--- a/test/expect.js
+++ b/test/expect.js
@@ -391,6 +391,29 @@ describe('expect', function () {
     expect(function*() {}).to.be.callable;
     expect(async function*() {}).to.be.callable;
     
+    expect('foobar').to.not.be.callable;
+    
+    err(function(){
+      expect('foobar', 'blah').to.be.callable;
+    }, "blah: expected 'foobar' to be a callable function");
+    
+    err(function(){
+      expect(function() {}, 'blah').to.not.be.callable;
+    }, "blah: expected [Function] not to be a callable function");
+  });
+    
+  it('function', function() {
+    expect(function() {}).to.be.a('function');
+    expect(async function() {}).to.be.a('function');
+    expect(function*() {}).to.be.a('function');
+    expect(async function*() {}).to.be.a('function');
+    
+    expect('foobar').to.not.be.a('function');
+    
+    err(function(){
+      expect('foobar').to.be.a('function', 'blah');
+    }, "blah: expected 'foobar' to be a function");
+
     err(function(){
       expect(function() {}).to.not.be.a('function', 'blah');
     }, "blah: expected [Function] not to be a function");
@@ -403,6 +426,10 @@ describe('expect', function () {
   it('asyncFunction', function() {
     expect(async function() {}).to.be.a('AsyncFunction');
     expect(async function*() {}).to.be.a('AsyncFunction');
+
+    err(function(){
+      expect('foobar').to.be.a('asyncfunction', 'blah');
+    }, "blah: expected 'foobar' to be an asyncfunction");
 
     err(function(){
       expect(async function() {}).to.not.be.a('asyncfunction', 'blah');
@@ -418,6 +445,10 @@ describe('expect', function () {
     expect(async function*() {}).to.be.a('generatorFunction');
     
     err(function(){
+      expect('foobar').to.be.a('generatorfunction', 'blah');
+    }, "blah: expected 'foobar' to be a generatorfunction");
+    
+    err(function(){
       expect(function*() {}).to.not.be.a('generatorfunction', 'blah');
     }, "blah: expected [GeneratorFunction] not to be a generatorfunction");
     
@@ -428,6 +459,10 @@ describe('expect', function () {
 
   it('asyncGeneratorFunction', function() {
     expect(async function*() {}).to.be.a('asyncGeneratorFunction');
+    
+    err(function(){
+      expect(async function() {}, 'blah').to.be.a('asyncgeneratorfunction');
+    }, "blah: expected [AsyncFunction] to be an asyncgeneratorfunction");
     
     err(function(){
       expect(async function*() {}, 'blah').to.not.be.a('asyncgeneratorfunction');
@@ -456,8 +491,8 @@ describe('expect', function () {
     err(function(){
       expect(new Foo(), 'blah').to.an.instanceof(1);
     }, "blah: The instanceof assertion needs a constructor but Number was given.");
-    err(function(){
 
+    err(function(){
       expect(new Foo()).to.an.instanceof('batman');
     }, "The instanceof assertion needs a constructor but String was given.");
 

--- a/test/expect.js
+++ b/test/expect.js
@@ -401,8 +401,8 @@ describe('expect', function () {
   })
 
   it('asyncFunction', function() {
-    expect(async function() {}).to.be.asyncFunction;
-    expect(async function*() {}).to.be.asyncFunction;
+    expect(async function() {}).to.be.a('asyncFunction');
+    expect(async function*() {}).to.be.a('asyncFunction');
 
     err(function(){
       expect(async function() {}).to.not.be.a('asyncfunction', 'blah');
@@ -414,8 +414,8 @@ describe('expect', function () {
   })
   
   it('generatorFunction', function() {
-    expect(function*() {}).to.be.generatorFunction;
-    expect(async function*() {}).to.be.generatorFunction;
+    expect(function*() {}).to.be.a('generatorFunction');
+    expect(async function*() {}).to.be.a('generatorFunction');
     
     err(function(){
       expect(function*() {}).to.not.be.a('generatorfunction', 'blah');
@@ -427,7 +427,7 @@ describe('expect', function () {
   })
 
   it('asyncGeneratorFunction', function() {
-    expect(async function*() {}).to.be.asyncGeneratorFunction;
+    expect(async function*() {}).to.be.a('asyncGeneratorFunction');
     
     err(function(){
       expect(async function*() {}, 'blah').to.not.be.a('asyncgeneratorfunction');

--- a/test/expect.js
+++ b/test/expect.js
@@ -390,20 +390,48 @@ describe('expect', function () {
     expect(async function() {}).to.be.callable;
     expect(function*() {}).to.be.callable;
     expect(async function*() {}).to.be.callable;
+    
+    err(function(){
+      expect(function() {}).to.not.be.a('function', 'blah');
+    }, "blah: expected [Function] not to be a function");
+    
+    err(function(){
+      expect(function() {}, 'blah').to.not.be.a('function');
+    }, "blah: expected [Function] not to be a function");
   })
 
   it('asyncFunction', function() {
     expect(async function() {}).to.be.asyncFunction;
     expect(async function*() {}).to.be.asyncFunction;
+
+    err(function(){
+      expect(async function() {}).to.not.be.a('asyncfunction', 'blah');
+    }, "blah: expected [AsyncFunction] not to be an asyncfunction");
+    
+    err(function(){
+      expect(async function() {}, 'blah').to.not.be.a('asyncfunction');
+    }, "blah: expected [AsyncFunction] not to be an asyncfunction");
   })
   
   it('generatorFunction', function() {
     expect(function*() {}).to.be.generatorFunction;
     expect(async function*() {}).to.be.generatorFunction;
+    
+    err(function(){
+      expect(function*() {}).to.not.be.a('generatorfunction', 'blah');
+    }, "blah: expected [GeneratorFunction] not to be a generatorfunction");
+    
+    err(function(){
+      expect(function*() {}, 'blah').to.not.be.a('generatorfunction');
+    }, "blah: expected [GeneratorFunction] not to be a generatorfunction");
   })
 
   it('asyncGeneratorFunction', function() {
     expect(async function*() {}).to.be.asyncGeneratorFunction;
+    
+    err(function(){
+      expect(async function*() {}, 'blah').to.not.be.a('asyncgeneratorfunction');
+    }, "blah: expected [AsyncGeneratorFunction] not to be an asyncgeneratorfunction");
   })
 
   it('instanceof', function(){

--- a/test/expect.js
+++ b/test/expect.js
@@ -401,8 +401,8 @@ describe('expect', function () {
   })
 
   it('asyncFunction', function() {
-    expect(async function() {}).to.be.a('asyncFunction');
-    expect(async function*() {}).to.be.a('asyncFunction');
+    expect(async function() {}).to.be.a('AsyncFunction');
+    expect(async function*() {}).to.be.a('AsyncFunction');
 
     err(function(){
       expect(async function() {}).to.not.be.a('asyncfunction', 'blah');

--- a/test/should.js
+++ b/test/should.js
@@ -461,6 +461,18 @@ describe("should", function () {
     }, "expected '' to be false");
   });
 
+  it("callable", function () {
+    (function () {}).should.be.callable;
+    (async function () {}).should.be.callable;
+    (function* () {}).should.be.callable;
+    (async function* () {}).should.be.callable;
+    true.should.not.be.callable;
+
+    err(function () {
+      "".should.be.callable;
+    }, "expected '' to be a callable function");
+  });
+
   it("null", function () {
     (0).should.not.be.null;
 

--- a/test/should.js
+++ b/test/should.js
@@ -1,71 +1,49 @@
-import * as chai from "../index.js";
-import { globalErr as err } from "./bootstrap/index.js";
+import * as chai from '../index.js';
+import {globalErr as err} from './bootstrap/index.js';
 
-describe("should", function () {
+describe('should', function() {
   var should = chai.Should();
 
-  it("assertion", function () {
-    "test".should.be.a("string");
-    should.equal("foo", "foo");
-    should.not.equal("foo", "bar");
+  it('assertion', function(){
+    'test'.should.be.a('string');
+    should.equal('foo', 'foo');
+    should.not.equal('foo', 'bar');
   });
 
-  describe("safeguards", function () {
+  describe('safeguards', function () {
     before(function () {
-      chai.util.addProperty(
-        chai.Assertion.prototype,
-        "tmpProperty",
-        function () {
-          new chai.Assertion(42).equal(42);
-        },
-      );
-      chai.util.overwriteProperty(
-        chai.Assertion.prototype,
-        "tmpProperty",
-        function (_super) {
-          return function () {
-            _super.call(this);
-          };
-        },
-      );
-
-      chai.util.addMethod(chai.Assertion.prototype, "tmpMethod", function () {
+      chai.util.addProperty(chai.Assertion.prototype, 'tmpProperty', function () {
         new chai.Assertion(42).equal(42);
       });
-      chai.util.overwriteMethod(
-        chai.Assertion.prototype,
-        "tmpMethod",
-        function (_super) {
-          return function () {
-            _super.call(this);
-          };
-        },
-      );
+      chai.util.overwriteProperty(chai.Assertion.prototype, 'tmpProperty', function (_super) {
+        return function () {
+          _super.call(this);
+        };
+      });
 
-      chai.util.addChainableMethod(
-        chai.Assertion.prototype,
-        "tmpChainableMethod",
-        function () {
-          new chai.Assertion(42).equal(42);
-        },
-        function () {
-          new chai.Assertion(42).equal(42);
-        },
-      );
-      chai.util.overwriteChainableMethod(
-        chai.Assertion.prototype,
-        "tmpChainableMethod",
-        function (_super) {
-          return function () {
-            _super.call(this);
-          };
-        },
-        function (_super) {
-          return function () {
-            _super.call(this);
-          };
-        },
-      );
+      chai.util.addMethod(chai.Assertion.prototype, 'tmpMethod', function () {
+        new chai.Assertion(42).equal(42);
+      });
+      chai.util.overwriteMethod(chai.Assertion.prototype, 'tmpMethod', function (_super) {
+        return function () {
+          _super.call(this);
+        };
+      });
+
+      chai.util.addChainableMethod(chai.Assertion.prototype, 'tmpChainableMethod', function () {
+        new chai.Assertion(42).equal(42);
+      }, function () {
+        new chai.Assertion(42).equal(42);
+      });
+      chai.util.overwriteChainableMethod(chai.Assertion.prototype, 'tmpChainableMethod', function (_super) {
+        return function () {
+          _super.call(this);
+        };
+      }, function (_super) {
+        return function () {
+          _super.call(this);
+        };
+      });
     });
 
     after(function () {
@@ -74,459 +52,344 @@ describe("should", function () {
       delete chai.Assertion.prototype.tmpChainableMethod;
     });
 
-    describe("proxify", function () {
-      it("throws when invalid property follows should", function () {
-        err(
-          function () {
-            (42).should.pizza;
-          },
-          "Invalid Chai property: pizza",
-          true,
-        );
+    describe('proxify', function () {
+      it('throws when invalid property follows should', function () {
+        err(function () {
+          (42).should.pizza;
+        }, 'Invalid Chai property: pizza', true);
       });
 
-      it("throws when invalid property follows language chain", function () {
-        err(
-          function () {
-            (42).should.to.pizza;
-          },
-          "Invalid Chai property: pizza",
-          true,
-        );
+      it('throws when invalid property follows language chain', function () {
+        err(function () {
+          (42).should.to.pizza;
+        }, 'Invalid Chai property: pizza', true);
       });
 
-      it("throws when invalid property follows property assertion", function () {
-        err(
-          function () {
-            (42).should.ok.pizza;
-          },
-          "Invalid Chai property: pizza",
-          true,
-        );
+      it('throws when invalid property follows property assertion', function () {
+        err(function () {
+          (42).should.ok.pizza;
+        }, 'Invalid Chai property: pizza', true);
       });
 
-      it("throws when invalid property follows overwritten property assertion", function () {
-        err(
-          function () {
-            (42).should.tmpProperty.pizza;
-          },
-          "Invalid Chai property: pizza",
-          true,
-        );
+      it('throws when invalid property follows overwritten property assertion', function () {
+        err(function () {
+          (42).should.tmpProperty.pizza;
+        }, 'Invalid Chai property: pizza', true);
       });
 
-      it("throws when invalid property follows uncalled method assertion", function () {
-        err(
-          function () {
-            (42).should.equal.pizza;
-          },
-          'Invalid Chai property: equal.pizza. See docs for proper usage of "equal".',
-          true,
-        );
+      it('throws when invalid property follows uncalled method assertion', function () {
+        err(function () {
+          (42).should.equal.pizza;
+        }, 'Invalid Chai property: equal.pizza. See docs for proper usage of "equal".', true);
       });
 
-      it("throws when invalid property follows called method assertion", function () {
-        err(
-          function () {
-            (42).should.equal(42).pizza;
-          },
-          "Invalid Chai property: pizza",
-          true,
-        );
+      it('throws when invalid property follows called method assertion', function () {
+        err(function () {
+          (42).should.equal(42).pizza;
+        }, 'Invalid Chai property: pizza', true);
       });
 
-      it("throws when invalid property follows uncalled overwritten method assertion", function () {
-        err(
-          function () {
-            (42).should.tmpMethod.pizza;
-          },
-          'Invalid Chai property: tmpMethod.pizza. See docs for proper usage of "tmpMethod".',
-          true,
-        );
+      it('throws when invalid property follows uncalled overwritten method assertion', function () {
+        err(function () {
+          (42).should.tmpMethod.pizza;
+        }, 'Invalid Chai property: tmpMethod.pizza. See docs for proper usage of "tmpMethod".', true);
       });
 
-      it("throws when invalid property follows called overwritten method assertion", function () {
-        err(
-          function () {
-            (42).should.tmpMethod().pizza;
-          },
-          "Invalid Chai property: pizza",
-          true,
-        );
+      it('throws when invalid property follows called overwritten method assertion', function () {
+        err(function () {
+          (42).should.tmpMethod().pizza;
+        }, 'Invalid Chai property: pizza', true);
       });
 
-      it("throws when invalid property follows uncalled chainable method assertion", function () {
-        err(
-          function () {
-            (42).should.a.pizza;
-          },
-          "Invalid Chai property: pizza",
-          true,
-        );
+      it('throws when invalid property follows uncalled chainable method assertion', function () {
+        err(function () {
+          (42).should.a.pizza;
+        }, 'Invalid Chai property: pizza', true);
       });
 
-      it("throws when invalid property follows called chainable method assertion", function () {
-        err(
-          function () {
-            (42).should.a("number").pizza;
-          },
-          "Invalid Chai property: pizza",
-          true,
-        );
+      it('throws when invalid property follows called chainable method assertion', function () {
+        err(function () {
+          (42).should.a('number').pizza;
+        }, 'Invalid Chai property: pizza', true);
       });
 
-      it("throws when invalid property follows uncalled overwritten chainable method assertion", function () {
-        err(
-          function () {
-            (42).should.tmpChainableMethod.pizza;
-          },
-          "Invalid Chai property: pizza",
-          true,
-        );
+      it('throws when invalid property follows uncalled overwritten chainable method assertion', function () {
+        err(function () {
+          (42).should.tmpChainableMethod.pizza;
+        }, 'Invalid Chai property: pizza', true);
       });
 
-      it("throws when invalid property follows called overwritten chainable method assertion", function () {
-        err(
-          function () {
-            (42).should.tmpChainableMethod().pizza;
-          },
-          "Invalid Chai property: pizza",
-          true,
-        );
+      it('throws when invalid property follows called overwritten chainable method assertion', function () {
+        err(function () {
+          (42).should.tmpChainableMethod().pizza;
+        }, 'Invalid Chai property: pizza', true);
       });
 
-      it("doesn't throw if invalid property is excluded via config", function () {
+      it('doesn\'t throw if invalid property is excluded via config', function () {
         (function () {
           (42).should.then;
         }).should.not.throw();
       });
     });
 
-    describe("length guard", function () {
-      var fnLengthDesc = Object.getOwnPropertyDescriptor(
-        function () {},
-        "length",
-      );
+    describe('length guard', function () {
+      var fnLengthDesc = Object.getOwnPropertyDescriptor(function () {}, 'length');
       if (!fnLengthDesc.configurable) return;
 
-      it("doesn't throw when `.length` follows `.should`", function () {
+      it('doesn\'t throw when `.length` follows `.should`', function () {
         (function () {
-          "foo".should.length;
+          ('foo').should.length;
         }).should.not.throw();
       });
 
-      it("doesn't throw when `.length` follows language chain", function () {
+      it('doesn\'t throw when `.length` follows language chain', function () {
         (function () {
-          "foo".should.to.length;
+          ('foo').should.to.length;
         }).should.not.throw();
       });
 
-      it("doesn't throw when `.length` follows property assertion", function () {
+      it('doesn\'t throw when `.length` follows property assertion', function () {
         (function () {
-          "foo".should.ok.length;
+          ('foo').should.ok.length;
         }).should.not.throw();
       });
 
-      it("doesn't throw when `.length` follows overwritten property assertion", function () {
+      it('doesn\'t throw when `.length` follows overwritten property assertion', function () {
         (function () {
-          "foo".should.tmpProperty.length;
+          ('foo').should.tmpProperty.length;
         }).should.not.throw();
       });
 
-      it("throws when `.length` follows uncalled method assertion", function () {
-        err(
-          function () {
-            "foo".should.equal.length;
-          },
-          'Invalid Chai property: equal.length. See docs for proper usage of "equal".',
-          true,
-        );
+      it('throws when `.length` follows uncalled method assertion', function () {
+        err(function () {
+          ('foo').should.equal.length;
+        }, 'Invalid Chai property: equal.length. See docs for proper usage of "equal".', true);
       });
 
-      it("doesn't throw when `.length` follows called method assertion", function () {
+      it('doesn\'t throw when `.length` follows called method assertion', function () {
         (function () {
-          "foo".should.equal("foo").length;
+          ('foo').should.equal('foo').length;
         }).should.not.throw();
       });
 
-      it("throws when `.length` follows uncalled overwritten method assertion", function () {
-        err(
-          function () {
-            "foo".should.tmpMethod.length;
-          },
-          'Invalid Chai property: tmpMethod.length. See docs for proper usage of "tmpMethod".',
-          true,
-        );
+      it('throws when `.length` follows uncalled overwritten method assertion', function () {
+        err(function () {
+          ('foo').should.tmpMethod.length;
+        }, 'Invalid Chai property: tmpMethod.length. See docs for proper usage of "tmpMethod".', true);
       });
 
-      it("doesn't throw when `.length` follows called overwritten method assertion", function () {
+      it('doesn\'t throw when `.length` follows called overwritten method assertion', function () {
         (function () {
-          "foo".should.tmpMethod().length;
+          ('foo').should.tmpMethod().length;
         }).should.not.throw();
       });
 
-      it("throws when `.length` follows uncalled chainable method assertion", function () {
-        err(
-          function () {
-            "foo".should.a.length;
-          },
-          'Invalid Chai property: a.length. Due to a compatibility issue, "length" cannot directly follow "a". Use "a.lengthOf" instead.',
-          true,
-        );
+      it('throws when `.length` follows uncalled chainable method assertion', function () {
+        err(function () {
+          ('foo').should.a.length;
+        }, 'Invalid Chai property: a.length. Due to a compatibility issue, "length" cannot directly follow "a". Use "a.lengthOf" instead.', true);
       });
 
-      it("doesn't throw when `.length` follows called chainable method assertion", function () {
+      it('doesn\'t throw when `.length` follows called chainable method assertion', function () {
         (function () {
-          "foo".should.a("string").length;
+          ('foo').should.a('string').length;
         }).should.not.throw();
       });
 
-      it("throws when `.length` follows uncalled overwritten chainable method assertion", function () {
-        err(
-          function () {
-            "foo".should.tmpChainableMethod.length;
-          },
-          'Invalid Chai property: tmpChainableMethod.length. Due to a compatibility issue, "length" cannot directly follow "tmpChainableMethod". Use "tmpChainableMethod.lengthOf" instead.',
-          true,
-        );
+      it('throws when `.length` follows uncalled overwritten chainable method assertion', function () {
+        err(function () {
+          ('foo').should.tmpChainableMethod.length;
+        }, 'Invalid Chai property: tmpChainableMethod.length. Due to a compatibility issue, "length" cannot directly follow "tmpChainableMethod". Use "tmpChainableMethod.lengthOf" instead.', true);
       });
 
-      it("doesn't throw when `.length` follows called overwritten chainable method assertion", function () {
+      it('doesn\'t throw when `.length` follows called overwritten chainable method assertion', function () {
         (function () {
-          "foo".should.tmpChainableMethod().length;
+          ('foo').should.tmpChainableMethod().length;
         }).should.not.throw();
       });
     });
   });
 
-  it("no-op chains", function () {
+  it('no-op chains', function() {
     function test(chain) {
       // tests that chain exists
-      (1).should[chain].should.not.undefined;
+      ((1).should[chain]).should.not.undefined;
 
       // tests methods
       (1).should[chain].equal(1);
 
       // tests properties that assert
-      false.should[chain].false;
+      (false).should[chain].false;
 
       // tests not
-      false.should[chain].not.true;
+      (false).should[chain].not.true;
 
       // tests chainable methods
       [1, 2, 3].should[chain].contains(1);
     }
 
-    [
-      "to",
-      "be",
-      "been",
-      "is",
-      "and",
-      "has",
-      "have",
-      "with",
-      "that",
-      "which",
-      "at",
-      "of",
-      "same",
-      "but",
-      "does",
-      "still",
-    ].forEach(test);
+    [ 'to', 'be', 'been', 'is'
+    , 'and', 'has', 'have', 'with'
+    , 'that', 'which', 'at', 'of'
+    , 'same', 'but', 'does', 'still' ].forEach(test);
   });
 
-  describe("fail", function () {
-    it("should accept a message as the 3rd argument", function () {
-      err(function () {
-        should.fail(0, 1, "this has failed");
+  describe("fail", function() {
+    it('should accept a message as the 3rd argument', function () {
+      err(function() {
+        should.fail(0, 1, 'this has failed');
       }, /this has failed/);
     });
 
-    it("should accept a message as the only argument", function () {
-      err(function () {
-        should.fail("this has failed");
+    it('should accept a message as the only argument', function () {
+      err(function() {
+        should.fail('this has failed');
       }, /this has failed/);
     });
 
-    it("should produce a default message when called without any arguments", function () {
-      err(function () {
+    it('should produce a default message when called without any arguments', function () {
+      err(function() {
         should.fail();
       }, /should\.fail()/);
     });
   });
 
-  it("root exist", function () {
-    var foo = "foo",
-      bar = undefined;
+  it('root exist', function () {
+    var foo = 'foo'
+      , bar = undefined;
     should.exist(foo);
     should.not.exist(bar);
     should.exist(0);
     should.exist(false);
-    should.exist("");
+    should.exist('');
 
     err(function () {
-      should.exist(bar, "blah");
+      should.exist(bar, 'blah');
     }, "blah: expected undefined to exist");
 
     err(function () {
-      should.not.exist(foo, "blah");
+      should.not.exist(foo, 'blah');
     }, "blah: expected 'foo' to not exist");
   });
 
-  it("root equal", function () {
-    var value1 = "value",
-      value2 = "value",
-      foo = "foo";
+  it('root equal', function () {
+    var value1 = 'value'
+      , value2 = 'value'
+      , foo = 'foo';
     should.equal(value1, value2);
     should.not.equal(value1, foo);
 
     err(function () {
-      should.equal(value1, foo, "blah");
+      should.equal(value1, foo, 'blah');
     }, "blah: expected 'value' to equal 'foo'");
 
     err(function () {
-      should.not.equal(value1, value2, "blah");
-    }, "blah: expected 'value' to not equal 'value'");
+      should.not.equal(value1, value2, 'blah');
+    }, "blah: expected 'value' to not equal 'value'")
   });
 
-  it("root Throw", function () {
-    should.Throw(
-      function () {
-        throw new Error("error!");
-      },
-      Error,
-      "error!",
-    );
-    should.not.Throw(function () {});
+  it('root Throw', function () {
+    should.Throw(function() { throw new Error('error!') }, Error, 'error!');
+    should.not.Throw(function () { });
 
     err(function () {
-      should.Throw(
-        function () {
-          throw new Error("error!");
-        },
-        Error,
-        "needed user!",
-        "blah",
-      );
+      should.Throw(function () { throw new Error('error!') }, Error, 'needed user!', 'blah');
     }, "blah: expected [Function] to throw error including 'needed user!' but got 'error!'");
 
     err(function () {
-      should.not.Throw(
-        function () {
-          throw new Error("error!");
-        },
-        Error,
-        "error!",
-        "blah",
-      );
+      should.not.Throw(function () { throw new Error('error!') }, Error, 'error!', 'blah');
     }, "blah: expected [Function] to not throw 'Error' but 'Error: error!' was thrown");
   });
 
-  it("true", function () {
-    true.should.be.true;
+  it('true', function(){
+    (true).should.be.true;
     false.should.not.be.true;
-    (1).should.not.be.true;
-    false;
+    (1).should.not.be.true;false
     false.should.have.been.false;
 
-    err(function () {
-      "test".should.be.true;
-    }, "expected 'test' to be true");
+    err(function(){
+      'test'.should.be.true;
+    }, "expected 'test' to be true")
   });
 
-  it("ok", function () {
+  it('ok', function(){
     true.should.be.ok;
     false.should.not.be.ok;
     (1).should.be.ok;
     (0).should.not.be.ok;
 
-    err(function () {
-      "".should.be.ok;
+    err(function(){
+      ''.should.be.ok;
     }, "expected '' to be truthy");
 
-    err(function () {
-      "test".should.not.be.ok;
+    err(function(){
+      'test'.should.not.be.ok;
     }, "expected 'test' to be falsy");
   });
 
-  it("false", function () {
+  it('false', function(){
     false.should.be.false;
     true.should.not.be.false;
     (0).should.not.be.false;
 
-    err(function () {
-      "".should.be.false;
-    }, "expected '' to be false");
+    err(function(){
+      ''.should.be.false;
+    }, "expected '' to be false")
   });
 
-  it("callable", function () {
-    (function () {}).should.be.callable;
-    (async function () {}).should.be.callable;
-    (function* () {}).should.be.callable;
-    (async function* () {}).should.be.callable;
-    true.should.not.be.callable;
-
-    err(function () {
-      "".should.be.callable;
-    }, "expected '' to be a callable function");
-  });
-
-  it("null", function () {
+  it('null', function(){
     (0).should.not.be.null;
 
-    err(function () {
-      "".should.be.null;
-    }, "expected '' to be null");
+    err(function(){
+      ''.should.be.null;
+    }, "expected '' to be null")
   });
 
-  it("NaN", function () {
+  it('NaN', function(){
     NaN.should.be.NaN;
 
     Infinity.should.not.be.NaN;
-    "foo".should.not.be.NaN;
+    'foo'.should.not.be.NaN;
     ({}).should.not.be.NaN;
     should.not.equal(undefined, NaN);
     (4).should.not.be.NaN;
 
-    err(function () {
+    err(function(){
       NaN.should.not.be.NaN;
     }, "expected NaN not to be NaN");
 
-    err(function () {
+    err(function(){
       Infinity.should.be.NaN;
     }, "expected Infinity to be NaN");
 
-    err(function () {
-      "foo".should.be.NaN;
+    err(function(){
+      'foo'.should.be.NaN;
     }, "expected 'foo' to be NaN");
 
-    err(function () {
+    err(function(){
       ({}).should.be.NaN;
     }, "expected {} to be NaN");
 
-    err(function () {
+    err(function(){
       should.equal(undefined, NaN);
     }, "expected undefined to equal NaN");
 
-    err(function () {
+    err(function(){
       (4).should.be.NaN;
     }, "expected 4 to be NaN");
+
   });
 
-  it("undefined", function () {
+  it('undefined', function(){
     (0).should.not.be.undefined;
 
-    err(function () {
-      "".should.be.undefined;
-    }, "expected '' to be undefined");
+    err(function(){
+      ''.should.be.undefined;
+    }, "expected '' to be undefined")
   });
 
-  it("arguments", function () {
-    var args = (function () {
-      return arguments;
-    })(1, 2, 3);
+  it('arguments', function(){
+    var args = (function(){ return arguments; })(1,2,3);
     args.should.be.arguments;
     [].should.not.be.arguments;
 
@@ -535,16 +398,14 @@ describe("should", function () {
     }, "expected [] to be arguments but got Array");
   });
 
-  it('".should" getter should unbox primitive values', function () {
+  it('".should" getter should unbox primitive values', function(){
     function assert(value) {
       const AssertionObject = value.should;
       const type = typeof value;
       if (AssertionObject.__flags.object !== value) {
-        throw new Error(
-          "value `" + value.toString() + "` (" + type + ") wasn't unboxed",
-        );
+        throw new Error("value `"+ value.toString() +"` ("+ type +") wasn't unboxed");
       }
-    }
+    };
 
     assert("a");
     assert(0);
@@ -554,39 +415,37 @@ describe("should", function () {
     assert(BigInt(10));
   });
 
-  it(".equal()", function () {
+  it('.equal()', function(){
     var foo;
     should.equal(undefined, foo);
   });
 
-  it("typeof", function () {
-    "test".should.be.a("string");
+  it('typeof', function(){
+    'test'.should.be.a('string');
 
-    err(function () {
-      "test".should.not.be.a("string");
+    err(function(){
+      'test'.should.not.be.a('string');
     }, "expected 'test' not to be a string");
 
-    (5).should.be.a("number");
-    new Number(1).should.be.a("number");
-    Number(1).should.be.a("number");
-    true.should.be.a("boolean");
-    new Array().should.be.a("array");
-    new Object().should.be.a("object");
-    ({}).should.be.a("object");
-    [].should.be.a("array");
-    (function () {}).should.be.a("function");
-    (async function* () {}).should.be.a("function");
-    (async function () {}).should.be.a("asyncfunction");
-    Symbol().should.be.a("symbol");
-    (5).should.be.a("number");
+    (5).should.be.a('number');
+    (new Number(1)).should.be.a('number');
+    Number(1).should.be.a('number');
+    (true).should.be.a('boolean');
+    (new Array()).should.be.a('array');
+    (new Object()).should.be.a('object');
+    ({}).should.be.a('object');
+    ([]).should.be.a('array');
+    (function() {}).should.be.a('function');
+    Symbol().should.be.a('symbol');
+    (5).should.be.a('number');
 
-    err(function () {
-      (5).should.not.be.a("number", "blah");
+    err(function(){
+      (5).should.not.be.a('number', 'blah');
     }, "blah: expected 5 not to be a number");
   });
 
-  it("instanceof", function () {
-    function Foo() {}
+  it('instanceof', function(){
+    function Foo(){}
     new Foo().should.be.an.instanceof(Foo);
 
     // Normally, `instanceof` requires that the constructor be a function or an
@@ -594,54 +453,48 @@ describe("should", function () {
     // as IE11, `instanceof` also accepts DOM-related interfaces such as
     // `HTMLElement`, despite being non-callable objects in those browsers.
     // See: https://github.com/chaijs/chai/issues/1000.
-    if (
-      typeof document !== "undefined" &&
-      typeof document.createElement !== "undefined" &&
-      typeof HTMLElement !== "undefined"
-    ) {
-      document.createElement("div").should.be.an.instanceof(HTMLElement);
+    if (typeof document !== 'undefined' &&
+        typeof document.createElement !== 'undefined' &&
+        typeof HTMLElement !== 'undefined') {
+      document.createElement('div').should.be.an.instanceof(HTMLElement);
     }
 
-    err(function () {
-      new Foo().should.be.an.instanceof(1, "blah");
+    err(function(){
+      new Foo().should.be.an.instanceof(1, 'blah');
     }, "blah: The instanceof assertion needs a constructor but Number was given.");
 
-    err(function () {
-      new Foo().should.be.an.instanceof("batman");
+    err(function(){
+      new Foo().should.be.an.instanceof('batman');
     }, "The instanceof assertion needs a constructor but String was given.");
 
-    err(function () {
+    err(function(){
       new Foo().should.be.an.instanceof({});
     }, "The instanceof assertion needs a constructor but Object was given.");
 
-    err(function () {
+    err(function(){
       new Foo().should.be.an.instanceof(true);
     }, "The instanceof assertion needs a constructor but Boolean was given.");
 
-    err(function () {
+    err(function(){
       new Foo().should.be.an.instanceof(null);
     }, "The instanceof assertion needs a constructor but null was given.");
 
-    err(function () {
+    err(function(){
       new Foo().should.be.an.instanceof(undefined);
     }, "The instanceof assertion needs a constructor but undefined was given.");
 
-    err(
-      function () {
-        function Thing() {}
-        var t = new Thing();
-        Thing.prototype = 1337;
-        t.should.be.an.instanceof(Thing);
-      },
-      "The instanceof assertion needs a constructor but Function was given.",
-      true,
-    );
+    err(function(){
+      function Thing(){};
+      var t = new Thing();
+      Thing.prototype = 1337;
+      t.should.be.an.instanceof(Thing);
+    }, 'The instanceof assertion needs a constructor but Function was given.', true);
 
-    err(function () {
+    err(function(){
       new Foo().should.be.an.instanceof(Symbol());
     }, "The instanceof assertion needs a constructor but Symbol was given.");
 
-    err(function () {
+    err(function() {
       var FakeConstructor = {};
       var fakeInstanceB = 4;
       FakeConstructor[Symbol.hasInstance] = function (val) {
@@ -649,9 +502,9 @@ describe("should", function () {
       };
 
       fakeInstanceB.should.be.an.instanceof(FakeConstructor);
-    }, "expected 4 to be an instance of an unnamed constructor");
+    }, 'expected 4 to be an instance of an unnamed constructor');
 
-    err(function () {
+    err(function() {
       var FakeConstructor = {};
       var fakeInstanceB = 4;
       FakeConstructor[Symbol.hasInstance] = function (val) {
@@ -659,90 +512,90 @@ describe("should", function () {
       };
 
       fakeInstanceB.should.not.be.an.instanceof(FakeConstructor);
-    }, "expected 4 to not be an instance of an unnamed constructor");
+    }, 'expected 4 to not be an instance of an unnamed constructor');
 
-    err(function () {
-      (3).should.an.instanceof(Foo, "blah");
+    err(function(){
+      (3).should.an.instanceof(Foo, 'blah');
     }, "blah: expected 3 to be an instance of Foo");
   });
 
-  it("within(start, finish)", function () {
+  it('within(start, finish)', function(){
     (5).should.be.within(5, 10);
-    (5).should.be.within(3, 6);
-    (5).should.be.within(3, 5);
-    (5).should.not.be.within(1, 3);
+    (5).should.be.within(3,6);
+    (5).should.be.within(3,5);
+    (5).should.not.be.within(1,3);
 
-    err(function () {
-      (5).should.not.be.within(4, 6, "blah");
+    err(function(){
+      (5).should.not.be.within(4,6, 'blah');
     }, "blah: expected 5 to not be within 4..6");
 
-    err(function () {
-      (10).should.be.within(50, 100, "blah");
+    err(function(){
+      (10).should.be.within(50,100, 'blah');
     }, "blah: expected 10 to be within 50..100");
 
-    err(function () {
-      ({ foo: 1 }).should.have.length.within(50, 100, "blah");
+    err(function(){
+      ({ foo: 1 }).should.have.length.within(50,100, 'blah');
+    }, "blah: expected { foo: 1 } to have property 'length'");
+
+    err(function(){
+      ({ foo: 1 }).should.have.lengthOf.within(50,100, 'blah');
     }, "blah: expected { foo: 1 } to have property 'length'");
 
     err(function () {
-      ({ foo: 1 }).should.have.lengthOf.within(50, 100, "blah");
-    }, "blah: expected { foo: 1 } to have property 'length'");
-
-    err(function () {
-      "string".should.be.within(0, 1, "blah");
+      ('string').should.be.within(0, 1, 'blah');
     }, "blah: expected 'string' to be a number or a date");
 
     err(function () {
-      (1).should.be.within(null, 1, "blah");
+      (1).should.be.within(null, 1, 'blah');
     }, "blah: the arguments to within must be numbers");
 
     err(function () {
-      (1).should.be.within(0, null, "blah");
+      (1).should.be.within(0, null, 'blah');
     }, "blah: the arguments to within must be numbers");
 
     err(function () {
-      "string".should.not.be.within(0, 1, "blah");
+      ('string').should.not.be.within(0, 1, 'blah');
     }, "blah: expected 'string' to be a number or a date");
 
     err(function () {
-      (1).should.not.be.within(null, 1, "blah");
+      (1).should.not.be.within(null, 1, 'blah');
     }, "blah: the arguments to within must be numbers");
 
     err(function () {
-      (1).should.not.be.within(0, null, "blah");
+      (1).should.not.be.within(0, null, 'blah');
     }, "blah: the arguments to within must be numbers");
 
     err(function () {
-      (1).should.have.length.within(5, 7, "blah");
+      (1).should.have.length.within(5,7, 'blah');
     }, "blah: expected 1 to have property 'length'");
 
     err(function () {
-      (1).should.have.lengthOf.within(5, 7, "blah");
+      (1).should.have.lengthOf.within(5,7, 'blah');
     }, "blah: expected 1 to have property 'length'");
 
-    new Map().should.have.length.within(0, 0);
-    new Map().should.have.lengthOf.within(0, 0);
+    (new Map).should.have.length.within(0, 0);
+    (new Map).should.have.lengthOf.within(0, 0);
 
-    var map = new Map();
-    map.set("a", 1);
-    map.set("b", 2);
-    map.set("c", 3);
+    var map = new Map;
+    map.set('a', 1);
+    map.set('b', 2);
+    map.set('c', 3);
 
     map.should.have.length.within(2, 4);
     map.should.have.lengthOf.within(2, 4);
 
     err(function () {
-      map.should.have.length.within(5, 7, "blah");
+      map.should.have.length.within(5, 7, 'blah');
     }, "blah: expected Map{ 'a' => 1, 'b' => 2, 'c' => 3 } to have a size within 5..7");
 
     err(function () {
-      map.should.have.lengthOf.within(5, 7, "blah");
+      map.should.have.lengthOf.within(5, 7, 'blah');
     }, "blah: expected Map{ 'a' => 1, 'b' => 2, 'c' => 3 } to have a size within 5..7");
 
-    new Set().should.have.length.within(0, 0);
-    new Set().should.have.lengthOf.within(0, 0);
+    (new Set).should.have.length.within(0, 0);
+    (new Set).should.have.lengthOf.within(0, 0);
 
-    var set = new Set();
+    var set = new Set;
     set.add(1);
     set.add(2);
     set.add(3);
@@ -751,15 +604,15 @@ describe("should", function () {
     set.should.have.lengthOf.within(2, 4);
 
     err(function () {
-      set.should.have.length.within(5, 7, "blah");
+      set.should.have.length.within(5, 7, 'blah');
     }, "blah: expected Set{ 1, 2, 3 } to have a size within 5..7");
 
     err(function () {
-      set.should.have.lengthOf.within(5, 7, "blah");
+      set.should.have.lengthOf.within(5, 7, 'blah');
     }, "blah: expected Set{ 1, 2, 3 } to have a size within 5..7");
   });
 
-  it("within(start, finish) (dates)", function () {
+  it('within(start, finish) (dates)', function(){
     var now = new Date();
     var oneSecondBefore = new Date(now.getTime() - 1000);
     var oneSecondAfter = new Date(now.getTime() + 1000);
@@ -772,142 +625,120 @@ describe("should", function () {
     now.should.be.within(now, now);
     oneSecondAfter.should.not.be.within(oneSecondAfter, oneSecondBefore);
 
-    err(
-      function () {
-        now.should.not.be.within(now, oneSecondAfter, "blah");
-      },
-      "blah: expected " +
-        nowISO +
-        " to not be within " +
-        nowISO +
-        ".." +
-        afterISO,
-    );
+    err(function(){
+      now.should.not.be.within(now, oneSecondAfter, 'blah');
+    }, "blah: expected " + nowISO + " to not be within " + nowISO + ".." + afterISO);
 
-    err(
-      function () {
-        oneSecondBefore.should.be.within(now, oneSecondAfter, "blah");
-      },
-      "blah: expected " +
-        beforeISO +
-        " to be within " +
-        nowISO +
-        ".." +
-        afterISO,
-    );
+    err(function(){
+      oneSecondBefore.should.be.within(now, oneSecondAfter, 'blah');
+    }, "blah: expected " + beforeISO + " to be within " + nowISO + ".." + afterISO);
 
-    err(function () {
-      [].should.have.length.within(now, 100, "blah");
+    err(function(){
+      ([]).should.have.length.within(now, 100, 'blah');
     }, "blah: the arguments to within must be numbers");
 
-    err(
-      function () {
-        now.should.have.lengthOf.within(50, now, "blah");
-      },
-      "blah: expected " + nowISO + " to have property 'length'",
-    );
-
-    err(
-      function () {
-        now.should.have.length.within(5, 7);
-      },
-      "expected " + nowISO + " to have property 'length'",
-    );
+    err(function(){
+      now.should.have.lengthOf.within(50, now, 'blah');
+    }, "blah: expected " + nowISO + " to have property 'length'");
 
     err(function () {
-      (0).should.be.within(0, now, "blah");
+      now.should.have.length.within(5, 7);
+    }, "expected " + nowISO + " to have property 'length'");
+
+    err(function () {
+      (0).should.be.within(0, now, 'blah');
     }, "blah: the arguments to within must be numbers");
 
     err(function () {
-      (1).should.be.within(now, 1, "blah");
+      (1).should.be.within(now, 1, 'blah');
     }, "blah: the arguments to within must be numbers");
 
     err(function () {
-      now.should.be.within(1, now, "blah");
+      now.should.be.within(1, now, 'blah');
     }, "blah: the arguments to within must be dates");
 
     err(function () {
-      now.should.not.be.within(now, 1, "blah");
+      now.should.not.be.within(now, 1, 'blah');
     }, "blah: the arguments to within must be dates");
 
     err(function () {
-      now.should.not.be.within(null, now, "blah");
+      now.should.not.be.within(null, now, 'blah');
     }, "blah: the arguments to within must be dates");
 
     err(function () {
-      now.should.not.be.within(now, null, "blah");
+      now.should.not.be.within(now, null, 'blah');
     }, "blah: the arguments to within must be dates");
   });
 
-  it("above(n)", function () {
+  it('above(n)', function(){
     (5).should.be.above(2);
     (5).should.be.greaterThan(2);
     (5).should.not.be.above(5);
     (5).should.not.be.above(6);
 
-    err(function () {
-      (5).should.be.above(6, "blah");
+    err(function(){
+      (5).should.be.above(6, 'blah');
     }, "blah: expected 5 to be above 6");
 
-    err(function () {
-      (10).should.not.be.above(6, "blah");
+    err(function(){
+      (10).should.not.be.above(6, 'blah');
     }, "blah: expected 10 to be at most 6");
 
-    err(function () {
-      ({ foo: 1 }).should.have.length.above(3, "blah");
+    err(function(){
+      ({foo: 1}).should.have.length.above(3, 'blah');
+    }, "blah: expected { foo: 1 } to have property 'length'");
+
+    err(function(){
+      ({foo: 1}).should.have.lengthOf.above(3, 'blah');
     }, "blah: expected { foo: 1 } to have property 'length'");
 
     err(function () {
-      ({ foo: 1 }).should.have.lengthOf.above(3, "blah");
-    }, "blah: expected { foo: 1 } to have property 'length'");
-
-    err(function () {
-      "string".should.be.above(0, "blah");
+      ('string').should.be.above(0, 'blah');
     }, "blah: expected 'string' to be a number or a date");
 
     err(function () {
-      (1).should.be.above(null, "blah");
+      (1).should.be.above(null, 'blah');
     }, "blah: the argument to above must be a number");
 
     err(function () {
-      "string".should.not.be.above(0, "blah");
+      ('string').should.not.be.above(0, 'blah');
     }, "blah: expected 'string' to be a number or a date");
 
     err(function () {
-      (1).should.not.be.above(null, "blah");
+      (1).should.not.be.above(null, 'blah');
     }, "blah: the argument to above must be a number");
 
     err(function () {
-      (1).should.have.length.above(0, "blah");
+      (1).should.have.length.above(0, 'blah');
     }, "blah: expected 1 to have property 'length'");
 
     err(function () {
-      (1).should.have.lengthOf.above(0, "blah");
+      (1).should.have.lengthOf.above(0, 'blah');
     }, "blah: expected 1 to have property 'length'");
 
-    new Map().should.have.length.above(-1);
-    new Map().should.have.lengthOf.above(-1);
+    (new Map).should.have.length.above(-1);
+    (new Map).should.have.lengthOf.above(-1);
 
-    var map = new Map();
-    map.set("a", 1);
-    map.set("b", 2);
-    map.set("c", 3);
+    var map = new Map;
+    map.set('a', 1);
+    map.set('b', 2);
+    map.set('c', 3);
 
     map.should.have.length.above(2);
     map.should.have.lengthOf.above(2);
 
     err(function () {
-      map.should.have.length.above(5, "blah");
+      map.should.have.length.above(5, 'blah');
     }, "blah: expected Map{ 'a' => 1, 'b' => 2, 'c' => 3 } to have a size above 5 but got 3");
 
     err(function () {
-      map.should.have.lengthOf.above(5, "blah");
+      map.should.have.lengthOf.above(5, 'blah');
     }, "blah: expected Map{ 'a' => 1, 'b' => 2, 'c' => 3 } to have a size above 5 but got 3");
 
-    new Set().should.have.length.above(-1);
-    new Set().should.have.lengthOf.above(-1);
+    (new Set).should.have.length.above(-1);
+    (new Set).should.have.lengthOf.above(-1);
 
-    var set = new Set();
+    var set = new Set;
     set.add(1);
     set.add(2);
     set.add(3);
@@ -916,15 +747,15 @@ describe("should", function () {
     set.should.have.lengthOf.above(2);
 
     err(function () {
-      set.should.have.length.above(5, "blah");
+      set.should.have.length.above(5, 'blah');
     }, "blah: expected Set{ 1, 2, 3 } to have a size above 5 but got 3");
 
     err(function () {
-      set.should.have.lengthOf.above(5, "blah");
+      set.should.have.lengthOf.above(5, 'blah');
     }, "blah: expected Set{ 1, 2, 3 } to have a size above 5 but got 3");
   });
 
-  it("above(n) (dates)", function () {
+  it('above(n) (dates)', function(){
     var now = new Date();
     var oneSecondAgo = new Date(now.getTime() - 1000);
     var oneSecondAfter = new Date(now.getTime() + 1000);
@@ -934,113 +765,98 @@ describe("should", function () {
     now.should.not.be.above(oneSecondAfter);
     oneSecondAgo.should.not.be.above(oneSecondAfter);
 
-    err(
-      function () {
-        now.should.be.above(oneSecondAfter, "blah");
-      },
-      "blah: expected " +
-        now.toISOString() +
-        " to be above " +
-        oneSecondAfter.toISOString(),
-    );
+    err(function(){
+      now.should.be.above(oneSecondAfter, 'blah');
+    }, "blah: expected " +  now.toISOString() + " to be above " + oneSecondAfter.toISOString());
 
-    err(
-      function () {
-        now.should.not.be.above(oneSecondAgo, "blah");
-      },
-      "blah: expected " +
-        now.toISOString() +
-        " to be at most " +
-        oneSecondAgo.toISOString(),
-    );
+    err(function(){
+      now.should.not.be.above(oneSecondAgo, 'blah');
+    }, "blah: expected " + now.toISOString() + " to be at most " + oneSecondAgo.toISOString());
 
-    err(
-      function () {
-        now.should.have.length.above(3, "blah");
-      },
-      "blah: expected " + now.toISOString() + " to have property 'length'",
-    );
+    err(function(){
+      now.should.have.length.above(3, 'blah');
+    }, "blah: expected " + now.toISOString() + " to have property 'length'");
 
-    err(function () {
-      "string".should.have.length.above(now, "blah");
+    err(function(){
+      ('string').should.have.length.above(now, 'blah');
     }, "blah: the argument to above must be a number");
 
     err(function () {
-      now.should.be.above(1, "blah");
+      now.should.be.above(1, 'blah');
     }, "blah: the argument to above must be a date");
 
     err(function () {
-      now.should.be.above(null, "blah");
+      now.should.be.above(null, 'blah');
     }, "blah: the argument to above must be a date");
 
     err(function () {
-      (1).should.not.be.above(now, "blah");
+      (1).should.not.be.above(now, 'blah');
     }, "blah: the argument to above must be a number");
 
     err(function () {
-      [].should.have.length.above(now, "blah");
+      ([]).should.have.length.above(now, 'blah');
     }, "blah: the argument to above must be a number");
   });
 
-  it("least(n)", function () {
+  it('least(n)', function(){
     (5).should.be.at.least(5);
     (5).should.not.be.at.least(6);
 
-    err(function () {
-      (5).should.be.at.least(6, "blah");
+    err(function(){
+      (5).should.be.at.least(6, 'blah');
     }, "blah: expected 5 to be at least 6");
 
-    err(function () {
-      (10).should.not.be.at.least(6, "blah");
+    err(function(){
+      (10).should.not.be.at.least(6, 'blah');
     }, "blah: expected 10 to be below 6");
 
-    err(function () {
-      ({ foo: 1 }).should.have.length.of.at.least(3, "blah");
+    err(function(){
+      ({foo: 1}).should.have.length.of.at.least(3, 'blah');
+    }, "blah: expected { foo: 1 } to have property 'length'");
+
+    err(function(){
+      ({foo: 1}).should.have.lengthOf.at.least(3, 'blah');
     }, "blah: expected { foo: 1 } to have property 'length'");
 
     err(function () {
-      ({ foo: 1 }).should.have.lengthOf.at.least(3, "blah");
-    }, "blah: expected { foo: 1 } to have property 'length'");
-
-    err(function () {
-      "string".should.be.at.least(0, "blah");
+      ('string').should.be.at.least(0, 'blah');
     }, "blah: expected 'string' to be a number or a date");
 
     err(function () {
-      (1).should.be.at.least(null, "blah");
+      (1).should.be.at.least(null, 'blah');
     }, "blah: the argument to least must be a number");
 
     err(function () {
-      "string".should.not.be.at.least(0, "blah");
+      ('string').should.not.be.at.least(0, 'blah');
     }, "blah: expected 'string' to be a number or a date");
 
     err(function () {
-      (1).should.not.be.at.least(null, "blah");
+      (1).should.not.be.at.least(null, 'blah');
     }, "blah: the argument to least must be a number");
 
-    new Map().should.have.length.of.at.least(0);
-    new Map().should.have.lengthOf.at.least(0);
+    (new Map).should.have.length.of.at.least(0);
+    (new Map).should.have.lengthOf.at.least(0);
 
-    var map = new Map();
-    map.set("a", 1);
-    map.set("b", 2);
-    map.set("c", 3);
+    var map = new Map;
+    map.set('a', 1);
+    map.set('b', 2);
+    map.set('c', 3);
 
     map.should.have.length.of.at.least(3);
     map.should.have.lengthOf.at.least(3);
 
     err(function () {
-      map.should.have.length.of.at.least(4, "blah");
+      map.should.have.length.of.at.least(4, 'blah');
     }, "blah: expected Map{ 'a' => 1, 'b' => 2, 'c' => 3 } to have a size at least 4 but got 3");
 
     err(function () {
-      map.should.have.lengthOf.at.least(4, "blah");
+      map.should.have.lengthOf.at.least(4, 'blah');
     }, "blah: expected Map{ 'a' => 1, 'b' => 2, 'c' => 3 } to have a size at least 4 but got 3");
 
-    new Set().should.have.length.of.at.least(0);
-    new Set().should.have.lengthOf.at.least(0);
+    (new Set).should.have.length.of.at.least(0);
+    (new Set).should.have.lengthOf.at.least(0);
 
-    var set = new Set();
+    var set = new Set;
     set.add(1);
     set.add(2);
     set.add(3);
@@ -1049,83 +865,83 @@ describe("should", function () {
     set.should.have.lengthOf.at.least(3);
 
     err(function () {
-      set.should.have.length.of.at.least(4, "blah");
+      set.should.have.length.of.at.least(4, 'blah');
     }, "blah: expected Set{ 1, 2, 3 } to have a size at least 4 but got 3");
 
     err(function () {
-      set.should.have.lengthOf.at.least(4, "blah");
+      set.should.have.lengthOf.at.least(4, 'blah');
     }, "blah: expected Set{ 1, 2, 3 } to have a size at least 4 but got 3");
   });
 
-  it("below(n)", function () {
+  it('below(n)', function(){
     (2).should.be.below(5);
     (2).should.be.lessThan(5);
     (2).should.not.be.below(2);
     (2).should.not.be.below(1);
 
-    err(function () {
-      (6).should.be.below(5, "blah");
+    err(function(){
+      (6).should.be.below(5, 'blah');
     }, "blah: expected 6 to be below 5");
 
-    err(function () {
-      (6).should.not.be.below(10, "blah");
+    err(function(){
+      (6).should.not.be.below(10, 'blah');
     }, "blah: expected 6 to be at least 10");
 
-    err(function () {
-      ({ foo: 1 }).should.have.length.below(3, "blah");
+    err(function(){
+      ({foo: 1}).should.have.length.below(3, 'blah');
+    }, "blah: expected { foo: 1 } to have property 'length'");
+
+    err(function(){
+      ({foo: 1}).should.have.lengthOf.below(3, 'blah');
     }, "blah: expected { foo: 1 } to have property 'length'");
 
     err(function () {
-      ({ foo: 1 }).should.have.lengthOf.below(3, "blah");
-    }, "blah: expected { foo: 1 } to have property 'length'");
+      ('string').should.be.below(0, 'blah');
+    },  "blah: expected 'string' to be a number or a date");
 
     err(function () {
-      "string".should.be.below(0, "blah");
-    }, "blah: expected 'string' to be a number or a date");
-
-    err(function () {
-      (1).should.be.below(null, "blah");
+      (1).should.be.below(null, 'blah');
     }, "blah: the argument to below must be a number");
 
     err(function () {
-      "string".should.not.be.below(0, "blah");
+      ('string').should.not.be.below(0, 'blah');
     }, "blah: expected 'string' to be a number or a date");
 
     err(function () {
-      (1).should.not.be.below(null, "blah");
+      (1).should.not.be.below(null, 'blah');
     }, "blah: the argument to below must be a number");
 
     err(function () {
-      (1).should.have.length.below(0, "blah");
+      (1).should.have.length.below(0, 'blah');
     }, "blah: expected 1 to have property 'length'");
 
     err(function () {
-      (1).should.have.lengthOf.below(0, "blah");
+      (1).should.have.lengthOf.below(0, 'blah');
     }, "blah: expected 1 to have property 'length'");
 
-    new Map().should.have.length.below(1);
-    new Map().should.have.lengthOf.below(1);
+    (new Map).should.have.length.below(1);
+    (new Map).should.have.lengthOf.below(1);
 
-    var map = new Map();
-    map.set("a", 1);
-    map.set("b", 2);
-    map.set("c", 3);
+    var map = new Map;
+    map.set('a', 1);
+    map.set('b', 2);
+    map.set('c', 3);
 
     map.should.have.length.below(4);
     map.should.have.lengthOf.below(4);
 
     err(function () {
-      map.should.have.length.below(2, "blah");
+      map.should.have.length.below(2, 'blah');
     }, "blah: expected Map{ 'a' => 1, 'b' => 2, 'c' => 3 } to have a size below 2 but got 3");
 
     err(function () {
-      map.should.have.lengthOf.below(2, "blah");
+      map.should.have.lengthOf.below(2, 'blah');
     }, "blah: expected Map{ 'a' => 1, 'b' => 2, 'c' => 3 } to have a size below 2 but got 3");
 
-    new Set().should.have.length.below(1);
-    new Set().should.have.lengthOf.below(1);
+    (new Set).should.have.length.below(1);
+    (new Set).should.have.lengthOf.below(1);
 
-    var set = new Set();
+    var set = new Set;
     set.add(1);
     set.add(2);
     set.add(3);
@@ -1134,15 +950,15 @@ describe("should", function () {
     set.should.have.lengthOf.below(4);
 
     err(function () {
-      set.should.have.length.below(2, "blah");
+      set.should.have.length.below(2, 'blah');
     }, "blah: expected Set{ 1, 2, 3 } to have a size below 2 but got 3");
 
     err(function () {
-      set.should.have.lengthOf.below(2, "blah");
+      set.should.have.lengthOf.below(2, 'blah');
     }, "blah: expected Set{ 1, 2, 3 } to have a size below 2 but got 3");
   });
 
-  it("below(n) (dates)", function () {
+  it('below(n) (dates)', function(){
     var now = new Date();
     var oneSecondAgo = new Date(now.getTime() - 1000);
     var oneSecondAfter = new Date(now.getTime() + 1000);
@@ -1152,121 +968,106 @@ describe("should", function () {
     now.should.not.be.below(oneSecondAgo);
     oneSecondAfter.should.not.be.below(oneSecondAgo);
 
-    err(
-      function () {
-        now.should.be.below(now, "blah");
-      },
-      "blah: expected " +
-        now.toISOString() +
-        " to be below " +
-        now.toISOString(),
-    );
+    err(function(){
+      now.should.be.below(now, 'blah');
+    }, "blah: expected " + now.toISOString() + " to be below " + now.toISOString());
 
-    err(
-      function () {
-        now.should.not.be.below(oneSecondAfter, "blah");
-      },
-      "blah: expected " +
-        now.toISOString() +
-        " to be at least " +
-        oneSecondAfter.toISOString(),
-    );
+    err(function(){
+      now.should.not.be.below(oneSecondAfter, 'blah');
+    }, "blah: expected " + now.toISOString() + " to be at least " + oneSecondAfter.toISOString());
 
-    err(
-      function () {
-        now.should.have.length.below(3, "blah");
-      },
-      "blah: expected " + now.toISOString() + " to have property 'length'",
-    );
+    err(function(){
+      now.should.have.length.below(3, 'blah');
+    }, "blah: expected " + now.toISOString() + " to have property 'length'");
 
     err(function () {
-      now.should.be.below(null, "blah");
+      now.should.be.below(null, 'blah');
     }, "blah: the argument to below must be a date");
 
     err(function () {
-      (1).should.not.be.below(now, "blah");
+      (1).should.not.be.below(now, 'blah');
     }, "blah: the argument to below must be a number");
 
     err(function () {
-      now.should.not.be.below(1, "blah");
+      now.should.not.be.below(1, 'blah');
     }, "blah: the argument to below must be a date");
 
     err(function () {
-      now.should.not.be.below(null, "blah");
+      now.should.not.be.below(null, 'blah');
     }, "blah: the argument to below must be a date");
 
     err(function () {
-      "string".should.have.length.below(now, "blah");
+      ('string').should.have.length.below(now, 'blah');
     }, "blah: the argument to below must be a number");
   });
 
-  it("most(n)", function () {
+  it('most(n)', function(){
     (2).should.be.at.most(2);
     (2).should.not.be.at.most(1);
 
-    err(function () {
-      (6).should.be.at.most(5, "blah");
+    err(function(){
+      (6).should.be.at.most(5, 'blah');
     }, "blah: expected 6 to be at most 5");
 
-    err(function () {
-      (6).should.not.be.at.most(10, "blah");
+    err(function(){
+      (6).should.not.be.at.most(10, 'blah');
     }, "blah: expected 6 to be above 10");
 
-    err(function () {
-      ({ foo: 1 }).should.have.length.of.at.most(3, "blah");
+    err(function(){
+      ({foo: 1}).should.have.length.of.at.most(3, 'blah');
+    }, "blah: expected { foo: 1 } to have property 'length'");
+
+    err(function(){
+      ({foo: 1}).should.have.lengthOf.at.most(3, 'blah');
     }, "blah: expected { foo: 1 } to have property 'length'");
 
     err(function () {
-      ({ foo: 1 }).should.have.lengthOf.at.most(3, "blah");
-    }, "blah: expected { foo: 1 } to have property 'length'");
-
-    err(function () {
-      "string".should.be.at.most(0, "blah");
+      ('string').should.be.at.most(0, 'blah');
     }, "blah: expected 'string' to be a number or a date");
 
     err(function () {
-      (1).should.be.at.most(null, "blah");
+      (1).should.be.at.most(null, 'blah');
     }, "blah: the argument to most must be a number");
 
     err(function () {
-      "string".should.not.be.at.most(0, "blah");
+      ('string').should.not.be.at.most(0, 'blah');
     }, "blah: expected 'string' to be a number or a date");
 
     err(function () {
-      (1).should.not.be.at.most(null, "blah");
+      (1).should.not.be.at.most(null, 'blah');
     }, "blah: the argument to most must be a number");
 
     err(function () {
-      (1).should.have.length.of.at.most(0, "blah");
+      (1).should.have.length.of.at.most(0, 'blah');
     }, "blah: expected 1 to have property 'length'");
 
     err(function () {
-      (1).should.have.lengthOf.at.most(0, "blah");
+      (1).should.have.lengthOf.at.most(0, 'blah');
     }, "blah: expected 1 to have property 'length'");
 
-    new Map().should.have.length.of.at.most(0);
-    new Map().should.have.lengthOf.at.most(0);
+    (new Map).should.have.length.of.at.most(0);
+    (new Map).should.have.lengthOf.at.most(0);
 
-    var map = new Map();
-    map.set("a", 1);
-    map.set("b", 2);
-    map.set("c", 3);
+    var map = new Map;
+    map.set('a', 1);
+    map.set('b', 2);
+    map.set('c', 3);
 
     map.should.have.length.of.at.most(3);
     map.should.have.lengthOf.at.most(3);
 
     err(function () {
-      map.should.have.length.of.at.most(2, "blah");
+      map.should.have.length.of.at.most(2, 'blah');
     }, "blah: expected Map{ 'a' => 1, 'b' => 2, 'c' => 3 } to have a size at most 2 but got 3");
 
     err(function () {
-      map.should.have.lengthOf.at.most(2, "blah");
+      map.should.have.lengthOf.at.most(2, 'blah');
     }, "blah: expected Map{ 'a' => 1, 'b' => 2, 'c' => 3 } to have a size at most 2 but got 3");
 
-    new Set().should.have.length.of.at.most(0);
-    new Set().should.have.lengthOf.at.most(0);
+    (new Set).should.have.length.of.at.most(0);
+    (new Set).should.have.lengthOf.at.most(0);
 
-    var set = new Set();
+    var set = new Set;
     set.add(1);
     set.add(2);
     set.add(3);
@@ -1275,15 +1076,15 @@ describe("should", function () {
     set.should.have.lengthOf.at.most(3);
 
     err(function () {
-      set.should.have.length.of.at.most(2, "blah");
+      set.should.have.length.of.at.most(2, 'blah');
     }, "blah: expected Set{ 1, 2, 3 } to have a size at most 2 but got 3");
 
     err(function () {
-      set.should.have.lengthOf.at.most(2, "blah");
+      set.should.have.lengthOf.at.most(2, 'blah');
     }, "blah: expected Set{ 1, 2, 3 } to have a size at most 2 but got 3");
   });
 
-  it("most(n) (dates)", function () {
+  it('most(n) (dates)', function(){
     var now = new Date();
     var oneSecondBefore = new Date(now.getTime() - 1000);
     var oneSecondAfter = new Date(now.getTime() + 1000);
@@ -1295,52 +1096,40 @@ describe("should", function () {
     now.should.be.at.most(oneSecondAfter);
     now.should.not.be.at.most(oneSecondBefore);
 
-    err(
-      function () {
-        now.should.be.at.most(oneSecondBefore, "blah");
-      },
-      "blah: expected " + nowISO + " to be at most " + beforeISO,
-    );
+    err(function(){
+      now.should.be.at.most(oneSecondBefore, 'blah');
+    }, "blah: expected " + nowISO + " to be at most " + beforeISO);
 
-    err(
-      function () {
-        now.should.not.be.at.most(oneSecondAfter, "blah");
-      },
-      "blah: expected " + nowISO + " to be above " + afterISO,
-    );
+    err(function(){
+      now.should.not.be.at.most(oneSecondAfter, 'blah');
+    }, "blah: expected " + nowISO + " to be above " + afterISO);
 
-    err(function () {
-      [].should.have.length.of.at.most(now, "blah");
+    err(function(){
+      ([]).should.have.length.of.at.most(now, 'blah');
+    }, "blah: the argument to most must be a number");
+
+    err(function(){
+      ('').should.not.have.lengthOf.at.most(now, 'blah');
     }, "blah: the argument to most must be a number");
 
     err(function () {
-      "".should.not.have.lengthOf.at.most(now, "blah");
-    }, "blah: the argument to most must be a number");
-
-    err(
-      function () {
-        now.should.have.length.of.at.most(0, "blah");
-      },
-      "blah: expected " + nowISO + " to have property 'length'",
-    );
-
-    err(
-      function () {
-        now.should.not.have.lengthOf.at.most(0, "blah");
-      },
-      "blah: expected " + nowISO + " to have property 'length'",
-    );
+      now.should.have.length.of.at.most(0, 'blah');
+    }, "blah: expected " + nowISO + " to have property 'length'");
 
     err(function () {
-      now.should.be.at.most(0, "blah");
+      now.should.not.have.lengthOf.at.most(0, 'blah');
+    }, "blah: expected " + nowISO + " to have property 'length'");
+
+    err(function () {
+      now.should.be.at.most(0, 'blah');
     }, "blah: the argument to most must be a date");
 
     err(function () {
-      now.should.be.at.most(null, "blah");
+      now.should.be.at.most(null, 'blah');
     }, "blah: the argument to most must be a date");
 
     err(function () {
-      (1).should.not.be.at.most(now, "blah");
+      (1).should.not.be.at.most(now, 'blah');
     }, "blah: the argument to most must be a number");
 
     err(function () {
@@ -1348,66 +1137,66 @@ describe("should", function () {
     }, "the argument to most must be a date");
   });
 
-  it("match(regexp)", function () {
-    "foobar".should.match(/^foo/);
-    "foobar".should.not.match(/^bar/);
+  it('match(regexp)', function(){
+    'foobar'.should.match(/^foo/)
+    'foobar'.should.not.match(/^bar/)
 
-    err(function () {
-      "foobar".should.match(/^bar/i, "blah");
+    err(function(){
+      'foobar'.should.match(/^bar/i, 'blah')
     }, "blah: expected 'foobar' to match /^bar/i");
 
-    err(function () {
-      "foobar".should.not.match(/^foo/i, "blah");
+    err(function(){
+      'foobar'.should.not.match(/^foo/i, 'blah')
     }, "blah: expected 'foobar' not to match /^foo/i");
   });
 
-  it("lengthOf(n)", function () {
-    "test".should.have.length(4);
-    "test".should.have.lengthOf(4);
-    "test".should.not.have.length(3);
-    "test".should.not.have.lengthOf(3);
-    [1, 2, 3].should.have.length(3);
-    [1, 2, 3].should.have.lengthOf(3);
+  it('lengthOf(n)', function(){
+    'test'.should.have.length(4);
+    'test'.should.have.lengthOf(4);
+    'test'.should.not.have.length(3);
+    'test'.should.not.have.lengthOf(3);
+    [1,2,3].should.have.length(3);
+    [1,2,3].should.have.lengthOf(3);
 
-    err(function () {
-      (4).should.have.length(3, "blah");
-    }, "blah: expected 4 to have property 'length'");
+    err(function(){
+      (4).should.have.length(3, 'blah');
+    }, 'blah: expected 4 to have property \'length\'');
 
-    err(function () {
-      (4).should.have.lengthOf(3, "blah");
-    }, "blah: expected 4 to have property 'length'");
+    err(function(){
+      (4).should.have.lengthOf(3, 'blah');
+    }, 'blah: expected 4 to have property \'length\'');
 
-    err(function () {
-      "asd".should.not.have.length(3, "blah");
+    err(function(){
+      'asd'.should.not.have.length(3, 'blah');
     }, "blah: expected 'asd' to not have a length of 3");
 
-    err(function () {
-      "asd".should.not.have.lengthOf(3, "blah");
+    err(function(){
+      'asd'.should.not.have.lengthOf(3, 'blah');
     }, "blah: expected 'asd' to not have a length of 3");
 
-    new Map().should.have.length(0);
-    new Map().should.have.lengthOf(0);
+    (new Map).should.have.length(0);
+    (new Map).should.have.lengthOf(0);
 
-    var map = new Map();
-    map.set("a", 1);
-    map.set("b", 2);
-    map.set("c", 3);
+    var map = new Map;
+    map.set('a', 1);
+    map.set('b', 2);
+    map.set('c', 3);
 
     map.should.have.length(3);
     map.should.have.lengthOf(3);
 
-    err(function () {
-      map.should.not.have.length(3, "blah");
+    err(function(){
+      map.should.not.have.length(3, 'blah');
     }, "blah: expected Map{ 'a' => 1, 'b' => 2, 'c' => 3 } to not have a size of 3");
 
-    err(function () {
-      map.should.not.have.lengthOf(3, "blah");
+    err(function(){
+      map.should.not.have.lengthOf(3, 'blah');
     }, "blah: expected Map{ 'a' => 1, 'b' => 2, 'c' => 3 } to not have a size of 3");
 
-    new Set().should.have.length(0);
-    new Set().should.have.lengthOf(0);
+    (new Set).should.have.length(0);
+    (new Set).should.have.lengthOf(0);
 
-    var set = new Set();
+    var set = new Set;
     set.add(1);
     set.add(2);
     set.add(3);
@@ -1415,24 +1204,24 @@ describe("should", function () {
     set.should.have.length(3);
     set.should.have.lengthOf(3);
 
-    err(function () {
-      set.should.not.have.length(3, "blah");
+    err(function(){
+      set.should.not.have.length(3, 'blah');
     }, "blah: expected Set{ 1, 2, 3 } to not have a size of 3");
 
-    err(function () {
-      set.should.not.have.lengthOf(3, "blah");
+    err(function(){
+      set.should.not.have.lengthOf(3, 'blah');;
     }, "blah: expected Set{ 1, 2, 3 } to not have a size of 3");
   });
 
-  it("eql(val)", function () {
-    var a = new Date(1, 2, 3),
-      b = new Date(4, 5, 6);
+  it('eql(val)', function(){
+    var a = new Date(1, 2, 3)
+      , b = new Date(4, 5, 6);
 
     a.should.eql(a);
     a.should.not.eql(b);
     a.should.not.eql({});
-    "test".should.eql("test");
-    ({ foo: "bar" }).should.eql({ foo: "bar" });
+    'test'.should.eql('test');
+    ({ foo: 'bar' }).should.eql({ foo: 'bar' });
     /a/.should.eql(/a/);
     /a/.should.not.eql(/b/);
     /a/.should.not.eql({});
@@ -1443,637 +1232,616 @@ describe("should", function () {
     /a/m.should.eql(/a/m);
     /a/m.should.not.eql(/b/m);
     (1).should.eql(1);
-    "4".should.not.eql(4);
+    '4'.should.not.eql(4);
 
     var sym = Symbol();
     sym.should.eql(sym);
 
-    err(function () {
-      (4).should.eql(3, "blah");
-    }, "blah: expected 4 to deeply equal 3");
+    err(function(){
+      (4).should.eql(3, 'blah');
+    }, 'blah: expected 4 to deeply equal 3');
   });
 
-  it("equal(val)", function () {
-    "test".should.equal("test");
+  it('equal(val)', function(){
+    'test'.should.equal('test');
     (1).should.equal(1);
 
     var sym = Symbol();
     sym.should.equal(sym);
 
-    err(function () {
-      (4).should.equal(3, "blah");
-    }, "blah: expected 4 to equal 3");
+    err(function(){
+      (4).should.equal(3, 'blah');
+    }, 'blah: expected 4 to equal 3');
 
-    err(function () {
-      "4".should.equal(4, "blah");
+    err(function(){
+      '4'.should.equal(4, 'blah');
     }, "blah: expected '4' to equal 4");
   });
 
-  it("deep.equal(val)", function () {
-    ({ foo: "bar" }).should.deep.equal({ foo: "bar" });
-    ({ foo: "bar" }).should.not.deep.equal({ foo: "baz" });
+  it('deep.equal(val)', function(){
+    ({ foo: 'bar' }).should.deep.equal({ foo: 'bar' });
+    ({ foo: 'bar' }).should.not.deep.equal({ foo: 'baz' });
 
-    err(function () {
-      ({ foo: "bar" }).should.deep.equal({ foo: "baz" }, "blah");
+    err(function(){
+      ({foo: 'bar'}).should.deep.equal({foo: 'baz'}, 'blah');
     }, "blah: expected { foo: 'bar' } to deeply equal { foo: 'baz' }");
 
-    err(function () {
-      ({ foo: "bar" }).should.not.deep.equal({ foo: "bar" }, "blah");
+    err(function(){
+      ({foo: 'bar'}).should.not.deep.equal({foo: 'bar'}, 'blah');
     }, "blah: expected { foo: 'bar' } to not deeply equal { foo: 'bar' }");
   });
 
-  it("empty", function () {
-    function FakeArgs() {}
+  it('empty', function(){
+    function FakeArgs() {};
     FakeArgs.prototype.length = 0;
 
-    "".should.be.empty;
-    "foo".should.not.be.empty;
-    [].should.be.empty;
-    ["foo"].should.not.be.empty;
-    new FakeArgs().should.be.empty;
-    ({ arguments: 0 }).should.not.be.empty;
+    ''.should.be.empty;
+    'foo'.should.not.be.empty;
+    ([]).should.be.empty;
+    (['foo']).should.not.be.empty;
+    (new FakeArgs).should.be.empty;
+    ({arguments: 0}).should.not.be.empty;
     ({}).should.be.empty;
-    ({ foo: "bar" }).should.not.be.empty;
+    ({foo: 'bar'}).should.not.be.empty;
 
-    err(function () {
-      new WeakMap().should.not.be.empty;
+    err(function(){
+      (new WeakMap).should.not.be.empty;
     }, ".empty was passed a weak collection");
 
-    err(function () {
-      new WeakSet().should.not.be.empty;
+    err(function(){
+      (new WeakSet).should.not.be.empty;
     }, ".empty was passed a weak collection");
 
-    new Map().should.be.empty;
+    (new Map).should.be.empty;
 
     // Not using Map constructor args because not supported in IE 11.
-    var map = new Map();
-    map.set("a", 1);
+    var map = new Map;
+    map.set('a', 1);
     map.should.not.be.empty;
 
-    err(function () {
-      new Map().should.not.be.empty;
+    err(function(){
+      (new Map).should.not.be.empty;
     }, "expected Map{} not to be empty");
 
-    map = new Map();
-    map.key = "val";
+    map = new Map;
+    map.key = 'val';
     map.should.be.empty;
 
-    err(function () {
+    err(function(){
       map.should.not.be.empty;
     }, "expected Map{} not to be empty");
 
-    new Set().should.be.empty;
+    (new Set).should.be.empty;
 
     // Not using Set constructor args because not supported in IE 11.
-    var set = new Set();
+    var set = new Set;
     set.add(1);
     set.should.not.be.empty;
 
-    err(function () {
-      new Set().should.not.be.empty;
+    err(function(){
+      (new Set).should.not.be.empty;
     }, "expected Set{} not to be empty");
 
-    set = new Set();
-    set.key = "val";
+    set = new Set;
+    set.key = 'val';
     set.should.be.empty;
 
-    err(function () {
+    err(function(){
       set.should.not.be.empty;
     }, "expected Set{} not to be empty");
 
-    err(function () {
-      "".should.not.be.empty;
-    }, "expected '' not to be empty");
+    err(function(){
+      ''.should.not.be.empty;
+    }, "expected \'\' not to be empty");
 
-    err(function () {
-      "foo".should.be.empty;
-    }, "expected 'foo' to be empty");
+    err(function(){
+      'foo'.should.be.empty;
+    }, "expected \'foo\' to be empty");
 
-    err(function () {
-      [].should.not.be.empty;
+    err(function(){
+      ([]).should.not.be.empty;
     }, "expected [] not to be empty");
 
-    err(function () {
-      ["foo"].should.be.empty;
-    }, "expected [ 'foo' ] to be empty");
+    err(function(){
+      (['foo']).should.be.empty;
+    }, "expected [ \'foo\' ] to be empty");
 
-    err(function () {
-      new FakeArgs().should.not.be.empty;
+    err(function(){
+      (new FakeArgs).should.not.be.empty;
     }, "expected FakeArgs{} not to be empty");
 
-    err(function () {
-      ({ arguments: 0 }).should.be.empty;
+    err(function(){
+      ({arguments: 0}).should.be.empty;
     }, "expected { arguments: +0 } to be empty");
 
-    err(function () {
+    err(function(){
       ({}).should.not.be.empty;
     }, "expected {} not to be empty");
 
-    err(function () {
-      ({ foo: "bar" }).should.be.empty;
-    }, "expected { foo: 'bar' } to be empty");
+    err(function(){
+      ({foo: 'bar'}).should.be.empty;
+    }, "expected { foo: \'bar\' } to be empty");
 
-    err(function () {
+    err(function(){
       (0).should.be.empty;
     }, ".empty was passed non-string primitive +0");
 
-    err(function () {
+    err(function(){
       (1).should.be.empty;
     }, ".empty was passed non-string primitive 1");
 
-    err(function () {
+    err(function(){
       true.should.be.empty;
     }, ".empty was passed non-string primitive true");
 
-    err(function () {
+    err(function(){
       false.should.be.empty;
     }, ".empty was passed non-string primitive false");
 
-    if (typeof Symbol !== "undefined") {
-      err(function () {
+    if (typeof Symbol !== 'undefined') {
+      err(function(){
         Symbol().should.be.empty;
       }, ".empty was passed non-string primitive Symbol()");
 
-      err(function () {
+      err(function(){
         Symbol.iterator.should.be.empty;
       }, ".empty was passed non-string primitive Symbol(Symbol.iterator)");
     }
 
-    err(function () {
-      (function () {}).should.be.empty;
+    err(function(){
+      (function() {}).should.be.empty;
     }, ".empty was passed a function");
 
-    if (FakeArgs.name === "FakeArgs") {
-      err(function () {
+    if (FakeArgs.name === 'FakeArgs') {
+      err(function(){
         FakeArgs.should.be.empty;
       }, ".empty was passed a function FakeArgs");
     }
   });
 
-  it("finite(value)", function () {
+  it('finite(value)', function() {
     (4).should.be.finite;
     (-10).should.be.finite;
 
-    err(function () {
-      NaN.should.be.finite;
+    err(function(){
+      (NaN).should.be.finite;
     }, "expected NaN to be a finite number");
 
-    err(function () {
-      Infinity.should.be.finite;
+    err(function(){
+      (Infinity).should.be.finite;
     }, "expected Infinity to be a finite number");
 
-    err(function () {
-      "foo".should.be.finite;
-    }, "expected 'foo' to be a finite number");
+    err(function(){
+      ('foo').should.be.finite;
+    }, "expected \'foo\' to be a finite number");
 
-    err(function () {
-      [].should.be.finite;
+    err(function(){
+      ([]).should.be.finite;
     }, "expected [] to be a finite number");
 
-    err(function () {
+    err(function(){
       ({}).should.be.finite;
     }, "expected {} to be a finite number");
   });
 
-  it("property(name)", function () {
-    "test".should.have.property("length");
-    (4).should.not.have.property("length");
+  it('property(name)', function(){
+    'test'.should.have.property('length');
+    (4).should.not.have.property('length');
     ({ 1: 1 }).should.have.property(1);
-    ({ a: 1 }).should.have.property("toString");
+    ({ a: 1 }).should.have.property('toString');
 
-    err(function () {
-      "asd".should.have.property("foo");
+    err(function(){
+      'asd'.should.have.property('foo');
     }, "expected 'asd' to have property 'foo'");
 
-    err(function () {
-      ({ a: { b: 1 } }).should.have.own.nested.property("a.b");
-    }, 'The "nested" and "own" flags cannot be combined.');
+    err(function() {
+      ({a: {b: 1}}).should.have.own.nested.property("a.b");
+    }, "The \"nested\" and \"own\" flags cannot be combined.");
 
     err(function () {
-      ({ a: 1 }).should.have.property(undefined);
+      ({a:1}).should.have.property(undefined);
     }, "the argument to property must be a string, number, or symbol");
   });
 
-  it("property(name, val)", function () {
-    "test".should.have.property("length", 4);
-    "asd".should.have.property("constructor", String);
+  it('property(name, val)', function(){
+    'test'.should.have.property('length', 4);
+    'asd'.should.have.property('constructor', String);
     ({ 1: 1 }).should.have.property(1, 1);
-    ({ a: 1 }).should.have.property("toString", Object.prototype.toString);
-    "test".should.not.have.property("length", 3);
-    "test".should.not.have.property("foo", 4);
-    ({ a: { b: 1 } }).should.not.have.property("a", { b: 1 });
+    ({ a: 1 }).should.have.property('toString', Object.prototype.toString);
+    'test'.should.not.have.property('length', 3);
+    'test'.should.not.have.property('foo', 4);
+    ({a: {b: 1}}).should.not.have.property('a', {b: 1});
 
-    err(function () {
-      "asd".should.have.property("length", 4, "blah");
+    err(function(){
+      'asd'.should.have.property('length', 4, 'blah');
     }, "blah: expected 'asd' to have property 'length' of 4, but got 3");
 
-    err(function () {
-      "asd".should.not.have.property("length", 3, "blah");
+    err(function(){
+      'asd'.should.not.have.property('length', 3, 'blah');
     }, "blah: expected 'asd' to not have property 'length' of 3");
 
-    err(function () {
-      "asd".should.have.property("constructor", Number, "blah");
+    err(function(){
+      'asd'.should.have.property('constructor', Number, 'blah');
     }, "blah: expected 'asd' to have property 'constructor' of [Function Number], but got [Function String]");
 
-    err(function () {
-      ({ a: { b: 1 } }).should.have.own.nested.property("a.b", 1, "blah");
-    }, 'blah: The "nested" and "own" flags cannot be combined.');
+    err(function() {
+      ({a: {b: 1}}).should.have.own.nested.property("a.b", 1, 'blah');
+    }, "blah: The \"nested\" and \"own\" flags cannot be combined.");
   });
 
-  it("deep.property(name, val)", function () {
-    var obj = { a: { b: 1 } };
-    obj.should.have.deep.property("a", { b: 1 });
-    obj.should.not.have.deep.property("a", { b: 7 });
-    obj.should.not.have.deep.property("a", { z: 1 });
-    obj.should.not.have.deep.property("z", { b: 1 });
+  it('deep.property(name, val)', function () {
+    var obj = {a: {b: 1}};
+    obj.should.have.deep.property('a', {b: 1});
+    obj.should.not.have.deep.property('a', {b: 7});
+    obj.should.not.have.deep.property('a', {z: 1});
+    obj.should.not.have.deep.property('z', {b: 1});
 
     err(function () {
-      obj.should.have.deep.property("a", { b: 7 }, "blah");
+      obj.should.have.deep.property('a', {b: 7}, 'blah');
     }, "blah: expected { a: { b: 1 } } to have deep property 'a' of { b: 7 }, but got { b: 1 }");
 
     err(function () {
-      obj.should.have.deep.property("z", { b: 1 }, "blah");
+      obj.should.have.deep.property('z', {b: 1}, 'blah');
     }, "blah: expected { a: { b: 1 } } to have deep property 'z'");
 
     err(function () {
-      obj.should.not.have.deep.property("a", { b: 1 }, "blah");
+      obj.should.not.have.deep.property('a', {b: 1}, 'blah');
     }, "blah: expected { a: { b: 1 } } to not have deep property 'a' of { b: 1 }");
   });
 
-  it("ownProperty(name)", function () {
-    "test".should.have.own.property("length");
-    "test".should.have.ownProperty("length");
-    "test".should.haveOwnProperty("length");
-    "test".should.not.have.own.property("iDontExist");
-    "test".should.not.have.ownProperty("iDontExist");
-    "test".should.not.haveOwnProperty("iDontExist");
-    ({ a: 1 }).should.not.have.own.property("toString");
-    ({ a: 1 }).should.not.have.ownProperty("toString");
-    ({ a: 1 }).should.not.haveOwnProperty("toString");
+  it('ownProperty(name)', function(){
+    'test'.should.have.own.property('length');
+    'test'.should.have.ownProperty('length');
+    'test'.should.haveOwnProperty('length');
+    'test'.should.not.have.own.property('iDontExist');
+    'test'.should.not.have.ownProperty('iDontExist');
+    'test'.should.not.haveOwnProperty('iDontExist');
+    ({ a: 1 }).should.not.have.own.property('toString');
+    ({ a: 1 }).should.not.have.ownProperty('toString');
+    ({ a: 1 }).should.not.haveOwnProperty('toString');
 
-    ({ length: 12 }).should.have.own.property("length");
-    ({ length: 12 }).should.have.ownProperty("length");
-    ({ length: 12 }).should.haveOwnProperty("length");
-    ({ length: 12 }).should.not.have.own.property("iDontExist");
-    ({ length: 12 }).should.not.have.ownProperty("iDontExist");
-    ({ length: 12 }).should.not.haveOwnProperty("iDontExist");
+    ({ length: 12 }).should.have.own.property('length');
+    ({ length: 12 }).should.have.ownProperty('length');
+    ({ length: 12 }).should.haveOwnProperty('length');
+    ({ length: 12 }).should.not.have.own.property('iDontExist');
+    ({ length: 12 }).should.not.have.ownProperty('iDontExist');
+    ({ length: 12 }).should.not.haveOwnProperty('iDontExist');
     ({ 1: 1 }).should.have.ownProperty(1);
 
-    var objNoHasOwnProperty = { hasOwnProperty: null };
-    objNoHasOwnProperty.a = "a";
-    objNoHasOwnProperty.should.have.own.property("a");
-    objNoHasOwnProperty.should.have.ownProperty("a");
-    objNoHasOwnProperty.should.haveOwnProperty("a");
+    var objNoHasOwnProperty = {hasOwnProperty: null};
+    objNoHasOwnProperty.a = 'a';
+    objNoHasOwnProperty.should.have.own.property('a');
+    objNoHasOwnProperty.should.have.ownProperty('a');
+    objNoHasOwnProperty.should.haveOwnProperty('a');
 
     // Chaining property's value
-    "test".should.have.own.property("length").that.is.a("number");
-    "test".should.have.ownProperty("length").that.is.a("number");
-    "test".should.haveOwnProperty("length").that.is.a("number");
+    'test'.should.have.own.property('length').that.is.a('number');
+    'test'.should.have.ownProperty('length').that.is.a('number');
+    'test'.should.haveOwnProperty('length').that.is.a('number');
 
-    err(function () {
-      ({ length: 12 }).should.have.own.property("iDontExist");
+    err(function(){
+      ({ length: 12 }).should.have.own.property('iDontExist');
     }, "expected { length: 12 } to have own property 'iDontExist'");
 
-    err(function () {
-      ({ length: 12 }).should.not.have.own.property("length");
+    err(function(){
+      ({ length: 12 }).should.not.have.own.property('length');
     }, "expected { length: 12 } to not have own property 'length'");
 
-    err(function () {
-      ({ length: 12 }).should.have.ownProperty("iDontExist");
+    err(function(){
+      ({ length: 12 }).should.have.ownProperty('iDontExist');
     }, "expected { length: 12 } to have own property 'iDontExist'");
 
-    err(function () {
-      ({ length: 12 }).should.not.have.ownProperty("length");
+    err(function(){
+      ({ length: 12 }).should.not.have.ownProperty('length');
     }, "expected { length: 12 } to not have own property 'length'");
 
-    err(function () {
-      ({ length: 12 }).should.haveOwnProperty("iDontExist");
+    err(function(){
+      ({ length: 12 }).should.haveOwnProperty('iDontExist');
     }, "expected { length: 12 } to have own property 'iDontExist'");
 
-    err(function () {
-      ({ length: 12 }).should.not.haveOwnProperty("length");
+    err(function(){
+      ({ length: 12 }).should.not.haveOwnProperty('length');
     }, "expected { length: 12 } to not have own property 'length'");
   });
 
-  it("ownProperty(name, value)", function () {
-    "test".should.have.own.property("length", 4);
-    "test".should.have.ownProperty("length", 4);
-    "test".should.haveOwnProperty("length", 4);
-    "test".should.not.have.own.property("length", 1337);
-    "test".should.not.have.ownProperty("length", 1337);
-    "test".should.not.haveOwnProperty("length", 1337);
-    "test".should.not.have.own.property("toString", Object.prototype.toString);
-    "test".should.not.have.ownProperty("toString", Object.prototype.toString);
-    "test".should.not.haveOwnProperty("toString", Object.prototype.toString);
-    ({ a: { b: 1 } }).should.not.have.own.property("a", { b: 1 });
-    ({ a: { b: 1 } }).should.not.have.ownProperty("a", { b: 1 });
-    ({ a: { b: 1 } }).should.not.haveOwnProperty("a", { b: 1 });
+  it('ownProperty(name, value)', function(){
+    'test'.should.have.own.property('length', 4);
+    'test'.should.have.ownProperty('length', 4);
+    'test'.should.haveOwnProperty('length', 4);
+    'test'.should.not.have.own.property('length', 1337);
+    'test'.should.not.have.ownProperty('length', 1337);
+    'test'.should.not.haveOwnProperty('length', 1337);
+    'test'.should.not.have.own.property('toString', Object.prototype.toString);
+    'test'.should.not.have.ownProperty('toString', Object.prototype.toString);
+    'test'.should.not.haveOwnProperty('toString', Object.prototype.toString);
+    ({a: {b: 1}}).should.not.have.own.property('a', {b: 1});
+    ({a: {b: 1}}).should.not.have.ownProperty('a', {b: 1});
+    ({a: {b: 1}}).should.not.haveOwnProperty('a', {b: 1});
 
-    ({ length: 12 }).should.have.own.property("length", 12);
-    ({ length: 12 }).should.have.ownProperty("length", 12);
-    ({ length: 12 }).should.haveOwnProperty("length", 12);
-    ({ length: 12 }).should.not.have.own.property("length", 15);
-    ({ length: 12 }).should.not.have.ownProperty("length", 15);
-    ({ length: 12 }).should.not.haveOwnProperty("length", 15);
+    ({ length: 12 }).should.have.own.property('length', 12);
+    ({ length: 12 }).should.have.ownProperty('length', 12);
+    ({ length: 12 }).should.haveOwnProperty('length', 12);
+    ({ length: 12 }).should.not.have.own.property('length', 15);
+    ({ length: 12 }).should.not.have.ownProperty('length', 15);
+    ({ length: 12 }).should.not.haveOwnProperty('length', 15);
 
     // Chaining property's value
-    "test".should.have.own.property("length", 4).that.is.a("number");
-    "test".should.have.ownProperty("length", 4).that.is.a("number");
-    "test".should.haveOwnProperty("length", 4).that.is.a("number");
+    'test'.should.have.own.property('length', 4).that.is.a('number');
+    'test'.should.have.ownProperty('length', 4).that.is.a('number');
+    'test'.should.haveOwnProperty('length', 4).that.is.a('number');
 
-    err(function () {
-      ({ length: 12 }).should.have.own.property("iDontExist", 12, "blah");
+    err(function(){
+      ({ length: 12 }).should.have.own.property('iDontExist', 12, 'blah');
     }, "blah: expected { length: 12 } to have own property 'iDontExist'");
 
-    err(function () {
-      ({ length: 12 }).should.not.have.own.property("length", 12);
+    err(function() {
+      ({ length: 12 }).should.not.have.own.property('length', 12);
     }, "expected { length: 12 } to not have own property 'length' of 12");
 
-    err(function () {
-      ({ length: 12 }).should.have.own.property("length", 15);
+    err(function() {
+      ({ length: 12 }).should.have.own.property('length', 15);
     }, "expected { length: 12 } to have own property 'length' of 15, but got 12");
 
-    err(function () {
-      ({ length: 12 }).should.have.ownProperty("iDontExist", 12);
+    err(function(){
+      ({ length: 12 }).should.have.ownProperty('iDontExist', 12);
     }, "expected { length: 12 } to have own property 'iDontExist'");
 
-    err(function () {
-      ({ length: 12 }).should.not.have.ownProperty("length", 12);
+    err(function() {
+      ({ length: 12 }).should.not.have.ownProperty('length', 12);
     }, "expected { length: 12 } to not have own property 'length' of 12");
 
-    err(function () {
-      ({ length: 12 }).should.have.ownProperty("length", 15);
+    err(function() {
+      ({ length: 12 }).should.have.ownProperty('length', 15);
     }, "expected { length: 12 } to have own property 'length' of 15, but got 12");
 
-    err(function () {
-      ({ length: 12 }).should.haveOwnProperty("iDontExist", 12);
+    err(function(){
+      ({ length: 12 }).should.haveOwnProperty('iDontExist', 12);
     }, "expected { length: 12 } to have own property 'iDontExist'");
 
-    err(function () {
-      ({ length: 12 }).should.not.haveOwnProperty("length", 12);
+    err(function() {
+      ({ length: 12 }).should.not.haveOwnProperty('length', 12);
     }, "expected { length: 12 } to not have own property 'length' of 12");
 
-    err(function () {
-      ({ length: 12 }).should.haveOwnProperty("length", 15);
+    err(function() {
+      ({ length: 12 }).should.haveOwnProperty('length', 15);
     }, "expected { length: 12 } to have own property 'length' of 15, but got 12");
   });
 
-  it("deep.own.property(name, val)", function () {
-    var obj = { a: { b: 1 } };
-    obj.should.have.deep.own.property("a", { b: 1 });
-    obj.should.have.deep.ownProperty("a", { b: 1 });
-    obj.should.deep.haveOwnProperty("a", { b: 1 });
-    obj.should.not.have.deep.own.property("a", { z: 1 });
-    obj.should.not.have.deep.ownProperty("a", { z: 1 });
-    obj.should.not.deep.haveOwnProperty("a", { z: 1 });
-    obj.should.not.have.deep.own.property("a", { b: 7 });
-    obj.should.not.have.deep.ownProperty("a", { b: 7 });
-    obj.should.not.deep.haveOwnProperty("a", { b: 7 });
-    obj.should.not.have.deep.own.property(
-      "toString",
-      Object.prototype.toString,
-    );
-    obj.should.not.have.deep.ownProperty("toString", Object.prototype.toString);
-    obj.should.not.deep.haveOwnProperty("toString", Object.prototype.toString);
+  it('deep.own.property(name, val)', function () {
+    var obj = {a: {b: 1}};
+    obj.should.have.deep.own.property('a', {b: 1});
+    obj.should.have.deep.ownProperty('a', {b: 1});
+    obj.should.deep.haveOwnProperty('a', {b: 1});
+    obj.should.not.have.deep.own.property('a', {z: 1});
+    obj.should.not.have.deep.ownProperty('a', {z: 1});
+    obj.should.not.deep.haveOwnProperty('a', {z: 1});
+    obj.should.not.have.deep.own.property('a', {b: 7});
+    obj.should.not.have.deep.ownProperty('a', {b: 7});
+    obj.should.not.deep.haveOwnProperty('a', {b: 7});
+    obj.should.not.have.deep.own.property('toString', Object.prototype.toString);
+    obj.should.not.have.deep.ownProperty('toString', Object.prototype.toString);
+    obj.should.not.deep.haveOwnProperty('toString', Object.prototype.toString);
 
     err(function () {
-      obj.should.have.deep.own.property("a", { z: 7 }, "blah");
+      obj.should.have.deep.own.property('a', {z: 7}, 'blah');
     }, "blah: expected { a: { b: 1 } } to have deep own property 'a' of { z: 7 }, but got { b: 1 }");
 
     err(function () {
-      obj.should.have.deep.own.property("z", { b: 1 }, "blah");
+      obj.should.have.deep.own.property('z', {b: 1}, 'blah');
     }, "blah: expected { a: { b: 1 } } to have deep own property 'z'");
 
     err(function () {
-      obj.should.not.have.deep.own.property("a", { b: 1 }, "blah");
+      obj.should.not.have.deep.own.property('a', {b: 1}, 'blah');
     }, "blah: expected { a: { b: 1 } } to not have deep own property 'a' of { b: 1 }");
     err(function () {
-      obj.should.have.deep.ownProperty("a", { z: 7 }, "blah");
+      obj.should.have.deep.ownProperty('a', {z: 7}, 'blah');
     }, "blah: expected { a: { b: 1 } } to have deep own property 'a' of { z: 7 }, but got { b: 1 }");
 
     err(function () {
-      obj.should.have.deep.ownProperty("z", { b: 1 }, "blah");
+      obj.should.have.deep.ownProperty('z', {b: 1}, 'blah');
     }, "blah: expected { a: { b: 1 } } to have deep own property 'z'");
 
     err(function () {
-      obj.should.not.have.deep.ownProperty("a", { b: 1 }, "blah");
+      obj.should.not.have.deep.ownProperty('a', {b: 1}, 'blah');
     }, "blah: expected { a: { b: 1 } } to not have deep own property 'a' of { b: 1 }");
 
     err(function () {
-      obj.should.deep.haveOwnProperty("a", { z: 7 }, "blah");
+      obj.should.deep.haveOwnProperty('a', {z: 7}, 'blah');
     }, "blah: expected { a: { b: 1 } } to have deep own property 'a' of { z: 7 }, but got { b: 1 }");
 
     err(function () {
-      obj.should.deep.haveOwnProperty("z", { b: 1 }, "blah");
+      obj.should.deep.haveOwnProperty('z', {b: 1}, 'blah');
     }, "blah: expected { a: { b: 1 } } to have deep own property 'z'");
 
     err(function () {
-      obj.should.not.deep.haveOwnProperty("a", { b: 1 }, "blah");
+      obj.should.not.deep.haveOwnProperty('a', {b: 1}, 'blah');
     }, "blah: expected { a: { b: 1 } } to not have deep own property 'a' of { b: 1 }");
   });
 
-  it("nested.property(name)", function () {
-    ({ "foo.bar": "baz" }).should.not.have.nested.property("foo.bar");
-    ({ foo: { bar: "baz" } }).should.have.nested.property("foo.bar");
+  it('nested.property(name)', function(){
+    ({ 'foo.bar': 'baz'}).should.not.have.nested.property('foo.bar');
+    ({ foo: { bar: 'baz' } }).should.have.nested.property('foo.bar');
 
-    ({ foo: [1, 2, 3] }).should.have.nested.property("foo[1]");
+    ({ 'foo': [1, 2, 3] }).should.have.nested.property('foo[1]');
 
-    ({ "foo.bar[]": "baz" }).should.have.nested.property("foo\\.bar\\[\\]");
+    ({ 'foo.bar[]': 'baz'}).should.have.nested.property('foo\\.bar\\[\\]');
 
-    ({ a: 1 }).should.have.nested.property("a");
+    ({a:1}).should.have.nested.property('a');
 
-    err(function () {
-      ({ a: 1 }).should.have.nested.property({ a: "1" });
+    err(function(){
+      ({a:1}).should.have.nested.property({'a':'1'});
     }, "the argument to property must be a string when using nested syntax");
 
-    err(function () {
-      ({ "foo.bar": "baz" }).should.have.nested.property("foo.bar");
+    err(function(){
+      ({ 'foo.bar': 'baz' }).should.have.nested.property('foo.bar');
     }, "expected { 'foo.bar': 'baz' } to have nested property 'foo.bar'");
   });
 
-  it("nested.property(name, val)", function () {
-    ({ foo: { bar: "baz" } }).should.have.nested.property("foo.bar", "baz");
-    ({ foo: { bar: "baz" } }).should.not.have.nested.property(
-      "foo.bar",
-      "quux",
-    );
-    ({ foo: { bar: "baz" } }).should.not.have.nested.property(
-      "foo.quux",
-      "baz",
-    );
-    ({ a: { b: { c: 1 } } }).should.not.have.nested.property("a.b", { c: 1 });
+  it('nested.property(name, val)', function(){
+    ({ foo: { bar: 'baz' } }).should.have.nested.property('foo.bar', 'baz');
+    ({ foo: { bar: 'baz' } }).should.not.have.nested.property('foo.bar', 'quux');
+    ({ foo: { bar: 'baz' } }).should.not.have.nested.property('foo.quux', 'baz');
+    ({a: {b: {c: 1}}}).should.not.have.nested.property('a.b', {c: 1});
 
-    err(function () {
-      ({ foo: { bar: "baz" } }).should.have.nested.property(
-        "foo.bar",
-        "quux",
-        "blah",
-      );
+    err(function(){
+      ({ foo: { bar: 'baz' } }).should.have.nested.property('foo.bar', 'quux', 'blah');
     }, "blah: expected { foo: { bar: 'baz' } } to have nested property 'foo.bar' of 'quux', but got 'baz'");
-    err(function () {
-      ({ foo: { bar: "baz" } }).should.not.have.nested.property(
-        "foo.bar",
-        "baz",
-        "blah",
-      );
+    err(function(){
+      ({ foo: { bar: 'baz' } }).should.not.have.nested.property('foo.bar', 'baz', 'blah');
     }, "blah: expected { foo: { bar: 'baz' } } to not have nested property 'foo.bar' of 'baz'");
   });
 
-  it("deep.nested.property(name, val)", function () {
-    var obj = { a: { b: { c: 1 } } };
-    obj.should.have.deep.nested.property("a.b", { c: 1 });
-    obj.should.not.have.deep.nested.property("a.b", { c: 7 });
-    obj.should.not.have.deep.nested.property("a.b", { z: 1 });
-    obj.should.not.have.deep.nested.property("a.z", { c: 1 });
+  it('deep.nested.property(name, val)', function () {
+    var obj = {a: {b: {c: 1}}};
+    obj.should.have.deep.nested.property('a.b', {c: 1});
+    obj.should.not.have.deep.nested.property('a.b', {c: 7});
+    obj.should.not.have.deep.nested.property('a.b', {z: 1});
+    obj.should.not.have.deep.nested.property('a.z', {c: 1});
 
     err(function () {
-      obj.should.have.deep.nested.property("a.b", { c: 7 }, "blah");
+      obj.should.have.deep.nested.property('a.b', {c: 7}, 'blah');
     }, "blah: expected { a: { b: { c: 1 } } } to have deep nested property 'a.b' of { c: 7 }, but got { c: 1 }");
 
     err(function () {
-      obj.should.have.deep.nested.property("a.z", { c: 1 }, "blah");
+      obj.should.have.deep.nested.property('a.z', {c: 1}, 'blah');
     }, "blah: expected { a: { b: { c: 1 } } } to have deep nested property 'a.z'");
 
     err(function () {
-      obj.should.not.have.deep.nested.property("a.b", { c: 1 }, "blah");
+      obj.should.not.have.deep.nested.property('a.b', {c: 1}, 'blah');
     }, "blah: expected { a: { b: { c: 1 } } } to not have deep nested property 'a.b' of { c: 1 }");
   });
 
-  it("ownPropertyDescriptor(name)", function () {
-    "test".should.haveOwnPropertyDescriptor("length");
-    "test".should.have.ownPropertyDescriptor("length");
-    "test".should.not.have.ownPropertyDescriptor("foo");
+  it('ownPropertyDescriptor(name)', function(){
+    'test'.should.haveOwnPropertyDescriptor('length');
+    'test'.should.have.ownPropertyDescriptor('length');
+    'test'.should.not.have.ownPropertyDescriptor('foo');
 
     ({ 1: 1 }).should.have.ownPropertyDescriptor(1);
 
-    var obj = {},
-      obj2 = {};
+    var obj = { },
+        obj2 = { };
     var descriptor = {
       configurable: false,
       enumerable: true,
       writable: true,
-      value: NaN,
+      value: NaN
     };
-    Object.defineProperty(obj, "test", descriptor);
-    obj.should.haveOwnPropertyDescriptor("test", descriptor);
+    Object.defineProperty(obj, 'test', descriptor);
+    obj.should.haveOwnPropertyDescriptor('test', descriptor);
 
     Object.defineProperty(obj2, 1, descriptor);
     obj2.should.haveOwnPropertyDescriptor(1, descriptor);
 
-    err(function () {
-      obj.should.not.haveOwnPropertyDescriptor("test", descriptor, "blah");
+    err(function(){
+      obj.should.not.haveOwnPropertyDescriptor('test', descriptor, 'blah');
     }, /^blah: expected the own property descriptor for 'test' on \{ test: NaN \} to not match \{ [^\}]+ \}$/);
-    err(function () {
+    err(function(){
       var wrongDescriptor = {
         configurable: false,
         enumerable: true,
         writable: false,
-        value: NaN,
+        value: NaN
       };
-      obj.should.haveOwnPropertyDescriptor("test", wrongDescriptor, "blah");
+      obj.should.haveOwnPropertyDescriptor('test', wrongDescriptor, 'blah');
     }, /^blah: expected the own property descriptor for 'test' on \{ test: NaN \} to match \{ [^\}]+ \}, got \{ [^\}]+ \}$/);
 
-    err(function () {
-      obj.should.haveOwnPropertyDescriptor("test2", "blah");
+    err(function(){
+      obj.should.haveOwnPropertyDescriptor('test2', 'blah');
     }, "blah: expected { test: NaN } to have an own property descriptor for 'test2'");
 
-    obj.should.have
-      .ownPropertyDescriptor("test")
-      .and.have.property("enumerable", true);
+    obj.should.have.ownPropertyDescriptor('test').and.have.property('enumerable', true);
   });
 
-  it("string()", function () {
-    "foobar".should.contain.string("bar");
-    "foobar".should.contain.string("foo");
-    "foobar".should.not.contain.string("baz");
+  it('string()', function(){
+    'foobar'.should.contain.string('bar');
+    'foobar'.should.contain.string('foo');
+    'foobar'.should.not.contain.string('baz');
 
-    err(function () {
-      (3).should.contain.string("baz", "blah");
+    err(function(){
+      (3).should.contain.string('baz', 'blah');
     }, "blah: expected 3 to be a string");
 
-    err(function () {
-      "foobar".should.contain.string("baz", "blah");
+    err(function(){
+      'foobar'.should.contain.string('baz', 'blah');
     }, "blah: expected 'foobar' to contain 'baz'");
 
-    err(function () {
-      "foobar".should.not.contain.string("bar", "blah");
+    err(function(){
+      'foobar'.should.not.contain.string('bar', 'blah');
     }, "blah: expected 'foobar' to not contain 'bar'");
   });
 
-  it("oneOf()", function () {
-    "foo".should.be.oneOf(["foo", "bar"]);
-    "bar".should.be.oneOf(["foo", "bar"]);
-    "baz".should.not.be.oneOf(["foo", "bar"]);
-    "baz".should.not.be.oneOf([]);
+  it('oneOf()', function(){
+    'foo'.should.be.oneOf(['foo', 'bar']);
+    'bar'.should.be.oneOf(['foo', 'bar']);
+    'baz'.should.not.be.oneOf(['foo', 'bar']);
+    'baz'.should.not.be.oneOf([]);
 
     err(function () {
-      (1).should.be.oneOf([2, 3], "blah");
+      (1).should.be.oneOf([2, 3], 'blah');
     }, "blah: expected 1 to be one of [ 2, 3 ]");
 
     err(function () {
-      (1).should.not.be.oneOf([1, 2, 3], "blah");
+      (1).should.not.be.oneOf([1, 2, 3], 'blah');
     }, "blah: expected 1 to not be one of [ 1, 2, 3 ]");
 
     err(function () {
-      (1).should.be.oneOf({}, "blah");
+      (1).should.be.oneOf({}, 'blah');
     }, "blah: expected {} to be an array");
   });
 
-  it("include()", function () {
-    ["foo", "bar"].should.include("foo");
-    ["foo", "bar"].should.contain("foo");
-    ["foo", "bar"].should.include("bar");
-    [1, 2].should.include(1);
-    ["foo", "bar"].should.not.include("baz");
-    ["foo", "bar"].should.not.include(1);
+  it('include()', function(){
+    ['foo', 'bar'].should.include('foo');
+    ['foo', 'bar'].should.contain('foo');
+    ['foo', 'bar'].should.include('bar');
+    [1,2].should.include(1);
+    ['foo', 'bar'].should.not.include('baz');
+    ['foo', 'bar'].should.not.include(1);
 
     // .include should work with Error objects and objects with a custom
     // `@@toStringTag`.
-    new Error("foo").should.include({ message: "foo" });
-    if (
-      typeof Symbol !== "undefined" &&
-      typeof Symbol.toStringTag !== "undefined"
-    ) {
-      var customObj = { a: 1 };
-      customObj[Symbol.toStringTag] = "foo";
+    (new Error('foo')).should.include({message: 'foo'});
+    if (typeof Symbol !== 'undefined'
+        && typeof Symbol.toStringTag !== 'undefined') {
+      var customObj = {a: 1};
+      customObj[Symbol.toStringTag] = 'foo';
 
-      customObj.should.include({ a: 1 });
+      customObj.should.include({a: 1});
     }
 
-    ({ a: 1 }).should.include({ toString: Object.prototype.toString });
+    ({a: 1}).should.include({'toString': Object.prototype.toString});
 
-    var obj1 = { a: 1 },
-      obj2 = { b: 2 };
+    var obj1 = {a: 1}
+      , obj2 = {b: 2};
     [obj1, obj2].should.include(obj1);
-    [obj1, obj2].should.not.include({ a: 1 });
-    ({ foo: obj1, bar: obj2 }).should.include({ foo: obj1 });
-    ({ foo: obj1, bar: obj2 }).should.include({ foo: obj1, bar: obj2 });
-    ({ foo: obj1, bar: obj2 }).should.not.include({ foo: { a: 1 } });
-    ({ foo: obj1, bar: obj2 }).should.not.include({ foo: obj1, bar: { b: 2 } });
+    [obj1, obj2].should.not.include({a: 1});
+    ({foo: obj1, bar: obj2}).should.include({foo: obj1});
+    ({foo: obj1, bar: obj2}).should.include({foo: obj1, bar: obj2});
+    ({foo: obj1, bar: obj2}).should.not.include({foo: {a: 1}});
+    ({foo: obj1, bar: obj2}).should.not.include({foo: obj1, bar: {b: 2}});
 
     var map = new Map();
-    var val = [{ a: 1 }];
-    map.set("a", val);
-    map.set("b", 2);
-    map.set("c", -0);
-    map.set("d", NaN);
+    var val = [{a: 1}];
+    map.set('a', val);
+    map.set('b', 2);
+    map.set('c', -0);
+    map.set('d', NaN);
 
     map.should.include(val);
-    map.should.not.include([{ a: 1 }]);
+    map.should.not.include([{a: 1}]);
     map.should.include(2);
     map.should.not.include(3);
     map.should.include(0);
     map.should.include(NaN);
 
     var set = new Set();
-    var val = [{ a: 1 }];
+    var val = [{a: 1}];
     set.add(val);
     set.add(2);
     set.add(-0);
     set.add(NaN);
 
     set.should.include(val);
-    set.should.not.include([{ a: 1 }]);
+    set.should.not.include([{a: 1}]);
     set.should.include(2);
     set.should.not.include(3);
     if (set.has(0)) {
@@ -2084,587 +1852,499 @@ describe("should", function () {
     set.should.include(NaN);
 
     var ws = new WeakSet();
-    var val = [{ a: 1 }];
+    var val = [{a: 1}];
     ws.add(val);
 
     ws.should.include(val);
-    ws.should.not.include([{ a: 1 }]);
+    ws.should.not.include([{a: 1}]);
     ws.should.not.include({});
 
-    var sym1 = Symbol(),
-      sym2 = Symbol(),
-      sym3 = Symbol();
+    var sym1 = Symbol()
+    , sym2 = Symbol()
+    , sym3 = Symbol();
     [sym1, sym2].should.include(sym1);
     [sym1, sym2].should.not.include(sym3);
 
-    err(function () {
-      ["foo"].should.include("bar", "blah");
+    err(function(){
+      ['foo'].should.include('bar', 'blah');
     }, "blah: expected [ 'foo' ] to include 'bar'");
 
-    err(function () {
-      ["bar", "foo"].should.not.include("foo", "blah");
+    err(function(){
+      ['bar', 'foo'].should.not.include('foo', 'blah');
     }, "blah: expected [ 'bar', 'foo' ] to not include 'foo'");
 
-    err(function () {
-      ({ a: 1 }).should.include({ b: 2 }, "blah");
+    err(function(){
+      ({a:1}).should.include({b:2}, 'blah');
     }, "blah: expected { a: 1 } to have property 'b'");
 
     err(function () {
-      [{ a: 1 }, { b: 2 }].should.include({ a: 1 });
+      [{a: 1}, {b: 2}].should.include({a: 1});
     }, "expected [ { a: 1 }, { b: 2 } ] to include { a: 1 }");
 
     err(function () {
-      var obj1 = { a: 1 },
-        obj2 = { b: 2 };
+      var obj1 = {a: 1}
+        , obj2 = {b: 2};
       [obj1, obj2].should.not.include(obj1);
     }, "expected [ { a: 1 }, { b: 2 } ] to not include { a: 1 }");
 
     err(function () {
-      ({ foo: { a: 1 }, bar: { b: 2 } }).should.include({ foo: { a: 1 } });
+      ({foo: {a: 1}, bar: {b: 2}}).should.include({foo: {a: 1}});
     }, "expected { foo: { a: 1 }, bar: { b: 2 } } to have property 'foo' of { a: 1 }, but got { a: 1 }");
 
     err(function () {
-      var obj1 = { a: 1 },
-        obj2 = { b: 2 };
-      ({ foo: obj1, bar: obj2 }).should.not.include({ foo: obj1, bar: obj2 });
+      var obj1 = {a: 1}
+        , obj2 = {b: 2};
+      ({foo: obj1, bar: obj2}).should.not.include({foo: obj1, bar: obj2});
     }, "expected { foo: { a: 1 }, bar: { b: 2 } } to not have property 'foo' of { a: 1 }");
 
-    err(function () {
-      true.should.include(true, "blah");
-    }, "blah: the given combination of arguments (boolean and boolean) is invalid for this assertion. " + "You can use an array, a map, an object, a set, a string, or a weakset instead of a boolean");
+    err(function(){
+      (true).should.include(true, 'blah');
+    },
+      "blah: the given combination of arguments (boolean and boolean) is invalid for this assertion. " +
+      "You can use an array, a map, an object, a set, a string, or a weakset instead of a boolean"
+    );
 
-    err(function () {
+    err(function(){
       (42).should.include(4);
-    }, "the given combination of arguments (number and number) is invalid for this assertion. " + "You can use an array, a map, an object, a set, a string, or a weakset instead of a number");
+    },
+      "the given combination of arguments (number and number) is invalid for this assertion. " +
+      "You can use an array, a map, an object, a set, a string, or a weakset instead of a number"
+    );
 
-    err(function () {
-      true.should.not.include(true);
-    }, "the given combination of arguments (boolean and boolean) is invalid for this assertion. " + "You can use an array, a map, an object, a set, a string, or a weakset instead of a boolean");
+    err(function(){
+      (true).should.not.include(true);
+    },
+      "the given combination of arguments (boolean and boolean) is invalid for this assertion. " +
+      "You can use an array, a map, an object, a set, a string, or a weakset instead of a boolean"
+    );
 
-    err(function () {
+    err(function(){
       (42).should.not.include(4);
-    }, "the given combination of arguments (number and number) is invalid for this assertion. " + "You can use an array, a map, an object, a set, a string, or a weakset instead of a number");
+    },
+      "the given combination of arguments (number and number) is invalid for this assertion. " +
+      "You can use an array, a map, an object, a set, a string, or a weakset instead of a number"
+    );
   });
 
-  it("deep.include()", function () {
-    var obj1 = { a: 1 },
-      obj2 = { b: 2 };
-    [obj1, obj2].should.deep.include({ a: 1 });
-    [obj1, obj2].should.not.deep.include({ a: 9 });
-    [obj1, obj2].should.not.deep.include({ z: 1 });
-    ({ foo: obj1, bar: obj2 }).should.deep.include({ foo: { a: 1 } });
-    ({ foo: obj1, bar: obj2 }).should.deep.include({
-      foo: { a: 1 },
-      bar: { b: 2 },
-    });
-    ({ foo: obj1, bar: obj2 }).should.not.deep.include({ foo: { a: 9 } });
-    ({ foo: obj1, bar: obj2 }).should.not.deep.include({ foo: { z: 1 } });
-    ({ foo: obj1, bar: obj2 }).should.not.deep.include({ baz: { a: 1 } });
-    ({ foo: obj1, bar: obj2 }).should.not.deep.include({
-      foo: { a: 1 },
-      bar: { b: 9 },
-    });
+  it('deep.include()', function () {
+    var obj1 = {a: 1}
+      , obj2 = {b: 2};
+    [obj1, obj2].should.deep.include({a: 1});
+    [obj1, obj2].should.not.deep.include({a: 9});
+    [obj1, obj2].should.not.deep.include({z: 1});
+    ({foo: obj1, bar: obj2}).should.deep.include({foo: {a: 1}});
+    ({foo: obj1, bar: obj2}).should.deep.include({foo: {a: 1}, bar: {b: 2}});
+    ({foo: obj1, bar: obj2}).should.not.deep.include({foo: {a: 9}});
+    ({foo: obj1, bar: obj2}).should.not.deep.include({foo: {z: 1}});
+    ({foo: obj1, bar: obj2}).should.not.deep.include({baz: {a: 1}});
+    ({foo: obj1, bar: obj2}).should.not.deep.include({foo: {a: 1}, bar: {b: 9}});
 
     var map = new Map();
 
-    map.set(1, [{ a: 1 }]);
-    map.should.deep.include([{ a: 1 }]);
+    map.set(1, [{a: 1}]);
+    map.should.deep.include([{a: 1}]);
 
     var set = new Set();
 
-    set.add([{ a: 1 }]);
-    set.should.deep.include([{ a: 1 }]);
+    set.add([{a: 1}]);
+    set.should.deep.include([{a: 1}]);
+
+    err(function() {
+      new WeakSet().should.deep.include({}, 'foo');
+    }, 'foo: unable to use .deep.include with WeakSet');
 
     err(function () {
-      new WeakSet().should.deep.include({}, "foo");
-    }, "foo: unable to use .deep.include with WeakSet");
-
-    err(function () {
-      [obj1, obj2].should.deep.include({ a: 9 }, "blah");
+      [obj1, obj2].should.deep.include({a: 9}, 'blah');
     }, "blah: expected [ { a: 1 }, { b: 2 } ] to deep include { a: 9 }");
 
     err(function () {
-      [obj1, obj2].should.not.deep.include({ a: 1 });
+      [obj1, obj2].should.not.deep.include({a: 1});
     }, "expected [ { a: 1 }, { b: 2 } ] to not deep include { a: 1 }");
 
     err(function () {
-      ({ foo: obj1, bar: obj2 }).should.deep.include({
-        foo: { a: 1 },
-        bar: { b: 9 },
-      });
+      ({foo: obj1, bar: obj2}).should.deep.include({foo: {a: 1}, bar: {b: 9}});
     }, "expected { foo: { a: 1 }, bar: { b: 2 } } to have deep property 'bar' of { b: 9 }, but got { b: 2 }");
 
     err(function () {
-      ({ foo: obj1, bar: obj2 }).should.not.deep.include(
-        { foo: { a: 1 }, bar: { b: 2 } },
-        "blah",
-      );
+      ({foo: obj1, bar: obj2}).should.not.deep.include({foo: {a: 1}, bar: {b: 2}}, 'blah');
     }, "blah: expected { foo: { a: 1 }, bar: { b: 2 } } to not have deep property 'foo' of { a: 1 }");
   });
 
-  it("nested.include()", function () {
-    ({ a: { b: ["x", "y"] } }).should.nested.include({ "a.b[1]": "y" });
-    ({ a: { b: ["x", "y"] } }).should.not.nested.include({ "a.b[1]": "x" });
-    ({ a: { b: ["x", "y"] } }).should.not.nested.include({ "a.c": "y" });
+  it('nested.include()', function () {
+    ({a: {b: ['x', 'y']}}).should.nested.include({'a.b[1]': 'y'});
+    ({a: {b: ['x', 'y']}}).should.not.nested.include({'a.b[1]': 'x'});
+    ({a: {b: ['x', 'y']}}).should.not.nested.include({'a.c': 'y'});
 
-    ({ a: { b: [{ x: 1 }] } }).should.not.nested.include({
-      "a.b[0]": { x: 1 },
-    });
+    ({a: {b: [{x: 1}]}}).should.not.nested.include({'a.b[0]': {x: 1}});
 
-    ({ ".a": { "[b]": "x" } }).should.nested.include({ "\\.a.\\[b\\]": "x" });
-    ({ ".a": { "[b]": "x" } }).should.not.nested.include({
-      "\\.a.\\[b\\]": "y",
-    });
+    ({'.a': {'[b]': 'x'}}).should.nested.include({'\\.a.\\[b\\]': 'x'});
+    ({'.a': {'[b]': 'x'}}).should.not.nested.include({'\\.a.\\[b\\]': 'y'});
 
     err(function () {
-      ({ a: { b: ["x", "y"] } }).should.nested.include(
-        { "a.b[1]": "x" },
-        "blah",
-      );
+      ({a: {b: ['x', 'y']}}).should.nested.include({'a.b[1]': 'x'}, 'blah');
     }, "blah: expected { a: { b: [ 'x', 'y' ] } } to have nested property 'a.b[1]' of 'x', but got 'y'");
 
     err(function () {
-      ({ a: { b: ["x", "y"] } }).should.nested.include({ "a.c": "y" });
+      ({a: {b: ['x', 'y']}}).should.nested.include({'a.c': 'y'});
     }, "expected { a: { b: [ 'x', 'y' ] } } to have nested property 'a.c'");
 
     err(function () {
-      ({ a: { b: ["x", "y"] } }).should.not.nested.include(
-        { "a.b[1]": "y" },
-        "blah",
-      );
+      ({a: {b: ['x', 'y']}}).should.not.nested.include({'a.b[1]': 'y'}, 'blah');
     }, "blah: expected { a: { b: [ 'x', 'y' ] } } to not have nested property 'a.b[1]' of 'y'");
   });
 
-  it("deep.nested.include()", function () {
-    ({ a: { b: [{ x: 1 }] } }).should.deep.nested.include({
-      "a.b[0]": { x: 1 },
-    });
-    ({ a: { b: [{ x: 1 }] } }).should.not.deep.nested.include({
-      "a.b[0]": { y: 2 },
-    });
-    ({ a: { b: [{ x: 1 }] } }).should.not.deep.nested.include({
-      "a.c": { x: 1 },
-    });
+  it('deep.nested.include()', function () {
+    ({a: {b: [{x: 1}]}}).should.deep.nested.include({'a.b[0]': {x: 1}});
+    ({a: {b: [{x: 1}]}}).should.not.deep.nested.include({'a.b[0]': {y: 2}});
+    ({a: {b: [{x: 1}]}}).should.not.deep.nested.include({'a.c': {x: 1}});
 
-    ({ ".a": { "[b]": { x: 1 } } }).should.deep.nested.include({
-      "\\.a.\\[b\\]": { x: 1 },
-    });
-    ({ ".a": { "[b]": { x: 1 } } }).should.not.deep.nested.include({
-      "\\.a.\\[b\\]": { y: 2 },
-    });
+    ({'.a': {'[b]': {x: 1}}})
+      .should.deep.nested.include({'\\.a.\\[b\\]': {x: 1}});
+    ({'.a': {'[b]': {x: 1}}})
+      .should.not.deep.nested.include({'\\.a.\\[b\\]': {y: 2}});
 
     err(function () {
-      ({ a: { b: [{ x: 1 }] } }).should.deep.nested.include(
-        { "a.b[0]": { y: 2 } },
-        "blah",
-      );
+      ({a: {b: [{x: 1}]}}).should.deep.nested.include({'a.b[0]': {y: 2}}, 'blah');
     }, "blah: expected { a: { b: [ { x: 1 } ] } } to have deep nested property 'a.b[0]' of { y: 2 }, but got { x: 1 }");
 
     err(function () {
-      ({ a: { b: [{ x: 1 }] } }).should.deep.nested.include({
-        "a.c": { x: 1 },
-      });
+      ({a: {b: [{x: 1}]}}).should.deep.nested.include({'a.c': {x: 1}});
     }, "expected { a: { b: [ { x: 1 } ] } } to have deep nested property 'a.c'");
 
     err(function () {
-      ({ a: { b: [{ x: 1 }] } }).should.not.deep.nested.include(
-        { "a.b[0]": { x: 1 } },
-        "blah",
-      );
+      ({a: {b: [{x: 1}]}}).should.not.deep.nested.include({'a.b[0]': {x: 1}}, 'blah');
     }, "blah: expected { a: { b: [ { x: 1 } ] } } to not have deep nested property 'a.b[0]' of { x: 1 }");
   });
 
-  it("own.include()", function () {
-    ({ a: 1 }).should.own.include({ a: 1 });
-    ({ a: 1 }).should.not.own.include({ a: 3 });
-    ({ a: 1 }).should.not.own.include({ toString: Object.prototype.toString });
+  it('own.include()', function () {
+    ({a: 1}).should.own.include({a: 1});
+    ({a: 1}).should.not.own.include({a: 3});
+    ({a: 1}).should.not.own.include({'toString': Object.prototype.toString});
 
-    ({ a: { b: 2 } }).should.not.own.include({ a: { b: 2 } });
+    ({a: {b: 2}}).should.not.own.include({a: {b: 2}});
 
     err(function () {
-      ({ a: 1 }).should.own.include({ a: 3 }, "blah");
+      ({a: 1}).should.own.include({a: 3}, 'blah');
     }, "blah: expected { a: 1 } to have own property 'a' of 3, but got 1");
 
     err(function () {
-      ({ a: 1 }).should.own.include({ toString: Object.prototype.toString });
+      ({a: 1}).should.own.include({'toString': Object.prototype.toString});
     }, "expected { a: 1 } to have own property 'toString'");
 
     err(function () {
-      ({ a: 1 }).should.not.own.include({ a: 1 }, "blah");
+      ({a: 1}).should.not.own.include({a: 1}, 'blah');
     }, "blah: expected { a: 1 } to not have own property 'a' of 1");
   });
 
-  it("deep.own.include()", function () {
-    ({ a: { b: 2 } }).should.deep.own.include({ a: { b: 2 } });
-    ({ a: { b: 2 } }).should.not.deep.own.include({ a: { c: 3 } });
-    ({ a: { b: 2 } }).should.not.deep.own.include({
-      toString: Object.prototype.toString,
-    });
+  it('deep.own.include()', function () {
+    ({a: {b: 2}}).should.deep.own.include({a: {b: 2}});
+    ({a: {b: 2}}).should.not.deep.own.include({a: {c: 3}});
+    ({a: {b: 2}})
+      .should.not.deep.own.include({'toString': Object.prototype.toString});
 
     err(function () {
-      ({ a: { b: 2 } }).should.deep.own.include({ a: { c: 3 } }, "blah");
+      ({a: {b: 2}}).should.deep.own.include({a: {c: 3}}, 'blah');
     }, "blah: expected { a: { b: 2 } } to have deep own property 'a' of { c: 3 }, but got { b: 2 }");
 
     err(function () {
-      ({ a: { b: 2 } }).should.deep.own.include({
-        toString: Object.prototype.toString,
-      });
+      ({a: {b: 2}}).should.deep.own.include({'toString': Object.prototype.toString});
     }, "expected { a: { b: 2 } } to have deep own property 'toString'");
 
     err(function () {
-      ({ a: { b: 2 } }).should.not.deep.own.include({ a: { b: 2 } }, "blah");
+      ({a: {b: 2}}).should.not.deep.own.include({a: {b: 2}}, 'blah');
     }, "blah: expected { a: { b: 2 } } to not have deep own property 'a' of { b: 2 }");
   });
 
-  it("keys(array|Object|arguments)", function () {
-    ({ foo: 1 }).should.have.keys(["foo"]);
-    ({ foo: 1 }).should.have.keys({ foo: 6 });
+  it('keys(array|Object|arguments)', function(){
+    ({ foo: 1 }).should.have.keys(['foo']);
+    ({ foo: 1 }).should.have.keys({ 'foo': 6 });
 
-    ({ foo: 1, bar: 2 }).should.have.keys(["foo", "bar"]);
-    ({ foo: 1, bar: 2 }).should.have.keys("foo", "bar");
-    ({ foo: 1, bar: 2 }).should.have.keys({ foo: 6, bar: 7 });
+    ({ foo: 1, bar: 2 }).should.have.keys(['foo', 'bar']);
+    ({ foo: 1, bar: 2 }).should.have.keys('foo', 'bar');
+    ({ foo: 1, bar: 2 }).should.have.keys({ 'foo': 6, 'bar': 7 });
 
-    ({ foo: 1, bar: 2, baz: 3 }).should.include.keys("foo", "bar");
-    ({ foo: 1, bar: 2, baz: 3 }).should.contain.keys("bar", "foo");
-    ({ foo: 1, bar: 2, baz: 3 }).should.contain.keys("baz");
+    ({ foo: 1, bar: 2, baz: 3 }).should.include.keys('foo', 'bar');
+    ({ foo: 1, bar: 2, baz: 3 }).should.contain.keys('bar', 'foo');
+    ({ foo: 1, bar: 2, baz: 3 }).should.contain.keys('baz');
 
-    ({ foo: 1, bar: 2 }).should.contain.keys("foo");
-    ({ foo: 1, bar: 2 }).should.contain.keys("bar", "foo");
-    ({ foo: 1, bar: 2 }).should.contain.keys(["foo"]);
-    ({ foo: 1, bar: 2 }).should.contain.keys(["bar"]);
-    ({ foo: 1, bar: 2 }).should.contain.keys(["bar", "foo"]);
-    ({ foo: 1, bar: 2 }).should.contain.keys({ foo: 6 });
-    ({ foo: 1, bar: 2 }).should.contain.keys({ bar: 7 });
-    ({ foo: 1, bar: 2 }).should.contain.keys({ foo: 6 });
+    ({ foo: 1, bar: 2 }).should.contain.keys('foo');
+    ({ foo: 1, bar: 2 }).should.contain.keys('bar', 'foo');
+    ({ foo: 1, bar: 2 }).should.contain.keys(['foo']);
+    ({ foo: 1, bar: 2 }).should.contain.keys(['bar']);
+    ({ foo: 1, bar: 2 }).should.contain.keys(['bar', 'foo']);
+    ({ foo: 1, bar: 2 }).should.contain.keys({ 'foo': 6 });
+    ({ foo: 1, bar: 2 }).should.contain.keys({ 'bar': 7 });
+    ({ foo: 1, bar: 2 }).should.contain.keys({ 'foo': 6 });
 
-    ({ foo: 1, bar: 2 }).should.not.have.keys("baz");
-    ({ foo: 1, bar: 2 }).should.not.have.keys("foo");
-    ({ foo: 1, bar: 2 }).should.not.have.keys("foo", "baz");
-    ({ foo: 1, bar: 2 }).should.not.contain.keys("baz");
-    ({ foo: 1, bar: 2 }).should.not.contain.keys("foo", "baz");
-    ({ foo: 1, bar: 2 }).should.not.contain.keys("baz", "foo");
+    ({ foo: 1, bar: 2 }).should.not.have.keys('baz');
+    ({ foo: 1, bar: 2 }).should.not.have.keys('foo');
+    ({ foo: 1, bar: 2 }).should.not.have.keys('foo', 'baz');
+    ({ foo: 1, bar: 2 }).should.not.contain.keys('baz');
+    ({ foo: 1, bar: 2 }).should.not.contain.keys('foo', 'baz');
+    ({ foo: 1, bar: 2 }).should.not.contain.keys('baz', 'foo');
 
-    ({ foo: 1, bar: 2 }).should.have.any.keys("foo", "baz");
-    ({ foo: 1, bar: 2 }).should.have.any.keys("foo");
-    ({ foo: 1, bar: 2 }).should.contain.any.keys("bar", "baz");
-    ({ foo: 1, bar: 2 }).should.contain.any.keys(["foo"]);
-    ({ foo: 1, bar: 2 }).should.have.all.keys(["bar", "foo"]);
-    ({ foo: 1, bar: 2 }).should.contain.all.keys(["bar", "foo"]);
-    ({ foo: 1, bar: 2 }).should.contain.any.keys({ foo: 6 });
-    ({ foo: 1, bar: 2 }).should.have.all.keys({ foo: 6, bar: 7 });
-    ({ foo: 1, bar: 2 }).should.contain.all.keys({ bar: 7, foo: 6 });
+    ({ foo: 1, bar: 2 }).should.have.any.keys('foo', 'baz');
+    ({ foo: 1, bar: 2 }).should.have.any.keys('foo');
+    ({ foo: 1, bar: 2 }).should.contain.any.keys('bar', 'baz');
+    ({ foo: 1, bar: 2 }).should.contain.any.keys(['foo']);
+    ({ foo: 1, bar: 2 }).should.have.all.keys(['bar', 'foo']);
+    ({ foo: 1, bar: 2 }).should.contain.all.keys(['bar', 'foo']);
+    ({ foo: 1, bar: 2 }).should.contain.any.keys({ 'foo': 6 });
+    ({ foo: 1, bar: 2 }).should.have.all.keys({ 'foo': 6, 'bar': 7 });
+    ({ foo: 1, bar: 2 }).should.contain.all.keys({ 'bar': 7, 'foo': 6 });
 
-    ({ foo: 1, bar: 2 }).should.not.have.any.keys("baz", "abc", "def");
-    ({ foo: 1, bar: 2 }).should.not.have.any.keys("baz");
-    ({ foo: 1, bar: 2 }).should.not.contain.any.keys("baz");
-    ({ foo: 1, bar: 2 }).should.not.have.all.keys(["baz", "foo"]);
-    ({ foo: 1, bar: 2 }).should.not.contain.all.keys(["baz", "foo"]);
-    ({ foo: 1, bar: 2 }).should.not.have.all.keys({ baz: 8, foo: 7 });
+    ({ foo: 1, bar: 2 }).should.not.have.any.keys('baz', 'abc', 'def');
+    ({ foo: 1, bar: 2 }).should.not.have.any.keys('baz');
+    ({ foo: 1, bar: 2 }).should.not.contain.any.keys('baz');
+    ({ foo: 1, bar: 2 }).should.not.have.all.keys(['baz', 'foo']);
+    ({ foo: 1, bar: 2 }).should.not.contain.all.keys(['baz', 'foo']);
+    ({ foo: 1, bar: 2 }).should.not.have.all.keys({ 'baz': 8, 'foo': 7 });
 
-    ({ foo: 1, bar: 2 }).should.not.contain.all.keys({ baz: 8, foo: 7 });
+    ({ foo: 1, bar: 2 }).should.not.contain.all.keys({ 'baz': 8, 'foo': 7 });
 
     ({ 1: 1, 2: 2 }).should.have.keys(1, 2);
     ({ 1: 1, 2: 2 }).should.have.any.keys(1, 3);
     ({ 1: 1, 2: 2 }).should.contain.keys(1);
 
-    var enumProp1 = "enumProp1",
-      enumProp2 = "enumProp2",
-      nonEnumProp = "nonEnumProp",
-      obj = {};
+    var enumProp1 = 'enumProp1'
+      , enumProp2 = 'enumProp2'
+      , nonEnumProp = 'nonEnumProp'
+      , obj = {};
 
-    obj[enumProp1] = "enumProp1";
-    obj[enumProp2] = "enumProp2";
+    obj[enumProp1] = 'enumProp1';
+    obj[enumProp2] = 'enumProp2';
 
     Object.defineProperty(obj, nonEnumProp, {
-      enumerable: false,
-      value: "nonEnumProp",
+        enumerable: false,
+        value: 'nonEnumProp'
     });
 
     obj.should.have.all.keys([enumProp1, enumProp2]);
     obj.should.not.have.all.keys([enumProp1, enumProp2, nonEnumProp]);
 
-    var sym1 = Symbol("sym1"),
-      sym2 = Symbol("sym2"),
-      sym3 = Symbol("sym3"),
-      str = "str",
-      obj = {};
+      var sym1 = Symbol('sym1')
+        , sym2 = Symbol('sym2')
+        , sym3 = Symbol('sym3')
+        , str = 'str'
+        , obj = {};
 
-    obj[sym1] = "sym1";
-    obj[sym2] = "sym2";
-    obj[str] = "str";
+      obj[sym1] = 'sym1';
+      obj[sym2] = 'sym2';
+      obj[str] = 'str';
 
-    Object.defineProperty(obj, sym3, {
-      enumerable: false,
-      value: "sym3",
-    });
+      Object.defineProperty(obj, sym3, {
+        enumerable: false,
+        value: 'sym3'
+      });
 
-    obj.should.have.all.keys([sym1, sym2, str]);
-    obj.should.not.have.all.keys([sym1, sym2, sym3, str]);
+      obj.should.have.all.keys([sym1, sym2, str]);
+      obj.should.not.have.all.keys([sym1, sym2, sym3, str]);
 
-    // Not using Map constructor args because not supported in IE 11.
-    var aKey = { thisIs: "anExampleObject" },
-      anotherKey = { doingThisBecauseOf: "referential equality" },
-      testMap = new Map();
+      // Not using Map constructor args because not supported in IE 11.
+      var aKey = {thisIs: 'anExampleObject'}
+        , anotherKey = {doingThisBecauseOf: 'referential equality'}
+        , testMap = new Map();
 
-    testMap.set(aKey, "aValue");
-    testMap.set(anotherKey, "anotherValue");
+      testMap.set(aKey, 'aValue');
+      testMap.set(anotherKey, 'anotherValue');
 
-    testMap.should.have.any.keys(aKey);
-    testMap.should.have.any.keys("thisDoesNotExist", "thisToo", aKey);
-    testMap.should.have.all.keys(aKey, anotherKey);
+      testMap.should.have.any.keys(aKey);
+      testMap.should.have.any.keys('thisDoesNotExist', 'thisToo', aKey);
+      testMap.should.have.all.keys(aKey, anotherKey);
 
-    testMap.should.contain.all.keys(aKey);
-    testMap.should.not.contain.all.keys(aKey, "thisDoesNotExist");
-    testMap.should.not.have.any.keys({ iDoNot: "exist" });
-    testMap.should.not.have.all.keys("thisDoesNotExist", "thisToo", anotherKey);
+      testMap.should.contain.all.keys(aKey);
+      testMap.should.not.contain.all.keys(aKey, 'thisDoesNotExist');
+      testMap.should.not.have.any.keys({iDoNot: 'exist'});
+      testMap.should.not.have.all.keys('thisDoesNotExist', 'thisToo', anotherKey);
 
-    testMap.should.have.any.keys([aKey]);
-    testMap.should.have.any.keys([20, 1, aKey]);
-    testMap.should.have.all.keys([aKey, anotherKey]);
+      testMap.should.have.any.keys([aKey]);
+      testMap.should.have.any.keys([20, 1, aKey]);
+      testMap.should.have.all.keys([aKey, anotherKey]);
 
-    testMap.should.not.have.any.keys([
-      { 13: 37 },
-      "thisDoesNotExist",
-      "thisToo",
-    ]);
-    testMap.should.not.have.any.keys([20, 1, { 13: 37 }]);
-    testMap.should.not.have.all.keys([aKey, { iDoNot: "exist" }]);
+      testMap.should.not.have.any.keys([{13: 37}, 'thisDoesNotExist', 'thisToo']);
+      testMap.should.not.have.any.keys([20, 1, {13: 37}]);
+      testMap.should.not.have.all.keys([aKey, {'iDoNot': 'exist'}]);
 
-    // Ensure the assertions above use strict equality
-    err(function () {
-      testMap.should.have.any.keys({ thisIs: "anExampleObject" });
-    });
+      // Ensure the assertions above use strict equality
+      err(function() {
+        testMap.should.have.any.keys({thisIs: 'anExampleObject'});
+      });
 
-    err(function () {
-      testMap.should.have.all.keys(
-        { thisIs: "anExampleObject" },
-        { doingThisBecauseOf: "referential equality" },
-      );
-    });
+      err(function() {
+        testMap.should.have.all.keys({thisIs: 'anExampleObject'}, {doingThisBecauseOf: 'referential equality'});
+      });
 
-    err(function () {
-      testMap.should.contain.all.keys({ thisIs: "anExampleObject" });
-    });
+      err(function() {
+        testMap.should.contain.all.keys({thisIs: 'anExampleObject'});
+      });
 
-    err(function () {
-      testMap.should.have.any.keys([{ thisIs: "anExampleObject" }]);
-    });
+      err(function() {
+        testMap.should.have.any.keys([{thisIs: 'anExampleObject'}]);
+      });
 
-    err(function () {
-      testMap.should.have.all.keys([
-        { thisIs: "anExampleObject" },
-        { doingThisBecauseOf: "referential equality" },
-      ]);
-    });
+      err(function() {
+        testMap.should.have.all.keys([{thisIs: 'anExampleObject'}, {doingThisBecauseOf: 'referential equality'}]);
+      });
 
-    // Using the same assertions as above but with `.deep` flag instead of using referential equality
-    testMap.should.have.any.deep.keys({ thisIs: "anExampleObject" });
-    testMap.should.have.any.deep.keys("thisDoesNotExist", "thisToo", {
-      thisIs: "anExampleObject",
-    });
+      // Using the same assertions as above but with `.deep` flag instead of using referential equality
+      testMap.should.have.any.deep.keys({thisIs: 'anExampleObject'});
+      testMap.should.have.any.deep.keys('thisDoesNotExist', 'thisToo', {thisIs: 'anExampleObject'});
 
-    testMap.should.contain.all.deep.keys({ thisIs: "anExampleObject" });
-    testMap.should.not.contain.all.deep.keys(
-      { thisIs: "anExampleObject" },
-      "thisDoesNotExist",
-    );
-    testMap.should.not.have.any.deep.keys({ iDoNot: "exist" });
-    testMap.should.not.have.all.deep.keys("thisDoesNotExist", "thisToo", {
-      doingThisBecauseOf: "referential equality",
-    });
+      testMap.should.contain.all.deep.keys({thisIs: 'anExampleObject'});
+      testMap.should.not.contain.all.deep.keys({thisIs: 'anExampleObject'}, 'thisDoesNotExist');
+      testMap.should.not.have.any.deep.keys({iDoNot: 'exist'});
+      testMap.should.not.have.all.deep.keys('thisDoesNotExist', 'thisToo', {doingThisBecauseOf: 'referential equality'});
 
-    testMap.should.have.any.deep.keys([{ thisIs: "anExampleObject" }]);
-    testMap.should.have.any.deep.keys([20, 1, { thisIs: "anExampleObject" }]);
+      testMap.should.have.any.deep.keys([{thisIs: 'anExampleObject'}]);
+      testMap.should.have.any.deep.keys([20, 1, {thisIs: 'anExampleObject'}]);
 
-    testMap.should.have.all.deep.keys([
-      { thisIs: "anExampleObject" },
-      { doingThisBecauseOf: "referential equality" },
-    ]);
+      testMap.should.have.all.deep.keys([{thisIs: 'anExampleObject'}, {doingThisBecauseOf: 'referential equality'}]);
 
-    testMap.should.not.have.any.deep.keys([
-      { 13: 37 },
-      "thisDoesNotExist",
-      "thisToo",
-    ]);
-    testMap.should.not.have.any.deep.keys([20, 1, { 13: 37 }]);
+      testMap.should.not.have.any.deep.keys([{13: 37}, 'thisDoesNotExist', 'thisToo']);
+      testMap.should.not.have.any.deep.keys([20, 1, {13: 37}]);
 
-    var weirdMapKey1 = Object.create(null),
-      weirdMapKey2 = { toString: NaN },
-      weirdMapKey3 = [],
-      weirdMap = new Map();
+      var weirdMapKey1 = Object.create(null)
+        , weirdMapKey2 = {toString: NaN}
+        , weirdMapKey3 = []
+        , weirdMap = new Map();
 
-    weirdMap.set(weirdMapKey1, "val1");
-    weirdMap.set(weirdMapKey2, "val2");
+      weirdMap.set(weirdMapKey1, 'val1');
+      weirdMap.set(weirdMapKey2, 'val2');
 
-    weirdMap.should.have.all.keys([weirdMapKey1, weirdMapKey2]);
-    weirdMap.should.not.have.all.keys([weirdMapKey1, weirdMapKey3]);
+      weirdMap.should.have.all.keys([weirdMapKey1, weirdMapKey2]);
+      weirdMap.should.not.have.all.keys([weirdMapKey1, weirdMapKey3]);
 
-    var symMapKey1 = Symbol(),
-      symMapKey2 = Symbol(),
-      symMapKey3 = Symbol(),
-      symMap = new Map();
+        var symMapKey1 = Symbol()
+          , symMapKey2 = Symbol()
+          , symMapKey3 = Symbol()
+          , symMap = new Map();
 
-    symMap.set(symMapKey1, "val1");
-    symMap.set(symMapKey2, "val2");
+        symMap.set(symMapKey1, 'val1');
+        symMap.set(symMapKey2, 'val2');
 
-    symMap.should.have.all.keys(symMapKey1, symMapKey2);
-    symMap.should.have.any.keys(symMapKey1, symMapKey3);
-    symMap.should.contain.all.keys(symMapKey2, symMapKey1);
-    symMap.should.contain.any.keys(symMapKey3, symMapKey1);
+        symMap.should.have.all.keys(symMapKey1, symMapKey2);
+        symMap.should.have.any.keys(symMapKey1, symMapKey3);
+        symMap.should.contain.all.keys(symMapKey2, symMapKey1);
+        symMap.should.contain.any.keys(symMapKey3, symMapKey1);
 
-    symMap.should.not.have.all.keys(symMapKey1, symMapKey3);
-    symMap.should.not.have.any.keys(symMapKey3);
-    symMap.should.not.contain.all.keys(symMapKey3, symMapKey1);
-    symMap.should.not.contain.any.keys(symMapKey3);
+        symMap.should.not.have.all.keys(symMapKey1, symMapKey3);
+        symMap.should.not.have.any.keys(symMapKey3);
+        symMap.should.not.contain.all.keys(symMapKey3, symMapKey1);
+        symMap.should.not.contain.any.keys(symMapKey3);
 
-    var errMap = new Map();
+      var errMap = new Map();
 
-    errMap.set({ foo: 1 });
+      errMap.set({ foo: 1 });
 
-    err(function () {
-      errMap.should.have.keys();
-    }, "keys required");
+      err(function(){
+        errMap.should.have.keys();
+      }, "keys required");
 
-    err(function () {
-      errMap.should.have.keys([]);
-    }, "keys required");
+      err(function(){
+        errMap.should.have.keys([]);
+      }, "keys required");
 
-    err(function () {
-      errMap.should.contain.keys();
-    }, "keys required");
+      err(function(){
+        errMap.should.contain.keys();
+      }, "keys required");
 
-    err(function () {
-      errMap.should.contain.keys([]);
-    }, "keys required");
+      err(function(){
+        errMap.should.contain.keys([]);
+      }, "keys required");
 
-    // Uncomment these after solving https://github.com/chaijs/chai/issues/662
-    // This should fail because of referential equality (this is a strict comparison)
-    // err(function(){
-    //   new Map([[{foo: 1}, 'bar']]).should.contain.keys({ foo: 1 });
-    // }, 'expected [ [ { foo: 1 }, 'bar' ] ] to contain key { foo: 1 }');
+      // Uncomment these after solving https://github.com/chaijs/chai/issues/662
+      // This should fail because of referential equality (this is a strict comparison)
+      // err(function(){
+      //   new Map([[{foo: 1}, 'bar']]).should.contain.keys({ foo: 1 });
+      // }, 'expected [ [ { foo: 1 }, 'bar' ] ] to contain key { foo: 1 }');
 
-    // err(function(){
-    //   new Map([[{foo: 1}, 'bar']]).should.contain.deep.keys({ iDoNotExist: 0 });
-    // }, 'expected [ { foo: 1 } ] to deeply contain key { iDoNotExist: 0 }');
+      // err(function(){
+      //   new Map([[{foo: 1}, 'bar']]).should.contain.deep.keys({ iDoNotExist: 0 });
+      // }, 'expected [ { foo: 1 } ] to deeply contain key { iDoNotExist: 0 }');
 
-    // Not using Set constructor args because not supported in IE 11.
-    var aKey = { thisIs: "anExampleObject" },
-      anotherKey = { doingThisBecauseOf: "referential equality" },
-      testSet = new Set();
+      // Not using Set constructor args because not supported in IE 11.
+      var aKey = {thisIs: 'anExampleObject'}
+        , anotherKey = {doingThisBecauseOf: 'referential equality'}
+        , testSet = new Set();
 
-    testSet.add(aKey);
-    testSet.add(anotherKey);
+      testSet.add(aKey);
+      testSet.add(anotherKey);
 
-    testSet.should.have.any.keys(aKey);
-    testSet.should.have.any.keys("thisDoesNotExist", "thisToo", aKey);
-    testSet.should.have.all.keys(aKey, anotherKey);
+      testSet.should.have.any.keys(aKey);
+      testSet.should.have.any.keys('thisDoesNotExist', 'thisToo', aKey);
+      testSet.should.have.all.keys(aKey, anotherKey);
 
-    testSet.should.contain.all.keys(aKey);
-    testSet.should.not.contain.all.keys(aKey, "thisDoesNotExist");
+      testSet.should.contain.all.keys(aKey);
+      testSet.should.not.contain.all.keys(aKey, 'thisDoesNotExist');
 
-    testSet.should.not.have.any.keys({ iDoNot: "exist" });
-    testSet.should.not.have.any.keys(
-      "thisIsNotAkey",
-      { iDoNot: "exist" },
-      { 33: 20 },
-    );
-    testSet.should.not.have.all.keys("thisDoesNotExist", "thisToo", anotherKey);
+      testSet.should.not.have.any.keys({iDoNot: 'exist'});
+      testSet.should.not.have.any.keys('thisIsNotAkey', {iDoNot: 'exist'}, {33: 20});
+      testSet.should.not.have.all.keys('thisDoesNotExist', 'thisToo', anotherKey);
 
-    testSet.should.have.any.keys([aKey]);
-    testSet.should.have.any.keys([20, 1, aKey]);
-    testSet.should.have.all.keys([aKey, anotherKey]);
+      testSet.should.have.any.keys([aKey]);
+      testSet.should.have.any.keys([20, 1, aKey]);
+      testSet.should.have.all.keys([aKey, anotherKey]);
 
-    testSet.should.not.have.any.keys([
-      { 13: 37 },
-      "thisDoesNotExist",
-      "thisToo",
-    ]);
-    testSet.should.not.have.any.keys([20, 1, { 13: 37 }]);
-    testSet.should.not.have.all.keys([aKey, { iDoNot: "exist" }]);
+      testSet.should.not.have.any.keys([{13: 37}, 'thisDoesNotExist', 'thisToo']);
+      testSet.should.not.have.any.keys([20, 1, {13: 37}]);
+      testSet.should.not.have.all.keys([aKey, {'iDoNot': 'exist'}]);
 
-    // Ensure the assertions above use strict equality
-    err(function () {
-      testSet.should.have.any.keys({ thisIs: "anExampleObject" });
-    });
+      // Ensure the assertions above use strict equality
+      err(function() {
+        testSet.should.have.any.keys({thisIs: 'anExampleObject'});
+      });
 
-    err(function () {
-      testSet.should.have.all.keys(
-        { thisIs: "anExampleObject" },
-        { doingThisBecauseOf: "referential equality" },
-      );
-    });
+      err(function() {
+        testSet.should.have.all.keys({thisIs: 'anExampleObject'}, {doingThisBecauseOf: 'referential equality'});
+      });
 
-    err(function () {
-      testSet.should.contain.all.keys({ thisIs: "anExampleObject" });
-    });
+      err(function() {
+        testSet.should.contain.all.keys({thisIs: 'anExampleObject'});
+      });
 
-    err(function () {
-      testSet.should.have.any.keys([{ thisIs: "anExampleObject" }]);
-    });
+      err(function() {
+        testSet.should.have.any.keys([{thisIs: 'anExampleObject'}]);
+      });
 
-    err(function () {
-      testSet.should.have.all.keys([
-        { thisIs: "anExampleObject" },
-        { doingThisBecauseOf: "referential equality" },
-      ]);
-    });
+      err(function() {
+        testSet.should.have.all.keys([{thisIs: 'anExampleObject'}, {doingThisBecauseOf: 'referential equality'}]);
+      });
 
-    // Using the same assertions as above but with `.deep` flag instead of using referential equality
-    testSet.should.have.any.deep.keys({ thisIs: "anExampleObject" });
-    testSet.should.have.any.deep.keys("thisDoesNotExist", "thisToo", {
-      thisIs: "anExampleObject",
-    });
+      // Using the same assertions as above but with `.deep` flag instead of using referential equality
+      testSet.should.have.any.deep.keys({thisIs: 'anExampleObject'});
+      testSet.should.have.any.deep.keys('thisDoesNotExist', 'thisToo', {thisIs: 'anExampleObject'});
 
-    testSet.should.contain.all.deep.keys({ thisIs: "anExampleObject" });
-    testSet.should.not.contain.all.deep.keys(
-      { thisIs: "anExampleObject" },
-      "thisDoesNotExist",
-    );
+      testSet.should.contain.all.deep.keys({thisIs: 'anExampleObject'});
+      testSet.should.not.contain.all.deep.keys({thisIs: 'anExampleObject'}, 'thisDoesNotExist');
 
-    testSet.should.not.have.any.deep.keys({ iDoNot: "exist" });
-    testSet.should.not.have.any.deep.keys(
-      "thisIsNotAkey",
-      { iDoNot: "exist" },
-      { 33: 20 },
-    );
-    testSet.should.not.have.all.deep.keys("thisDoesNotExist", "thisToo", {
-      anotherObj: "foo",
-    });
+      testSet.should.not.have.any.deep.keys({iDoNot: 'exist'});
+      testSet.should.not.have.any.deep.keys('thisIsNotAkey', {iDoNot: 'exist'}, {33: 20});
+      testSet.should.not.have.all.deep.keys('thisDoesNotExist', 'thisToo', {anotherObj: 'foo'});
 
-    testSet.should.have.any.deep.keys([{ thisIs: "anExampleObject" }]);
-    testSet.should.have.any.deep.keys([20, 1, { thisIs: "anExampleObject" }]);
+      testSet.should.have.any.deep.keys([{thisIs: 'anExampleObject'}]);
+      testSet.should.have.any.deep.keys([20, 1, {thisIs: 'anExampleObject'}]);
 
-    testSet.should.have.all.deep.keys(
-      { thisIs: "anExampleObject" },
-      { doingThisBecauseOf: "referential equality" },
-    );
+      testSet.should.have.all.deep.keys({thisIs: 'anExampleObject'}, {doingThisBecauseOf: 'referential equality'});
 
-    testSet.should.not.have.any.deep.keys([
-      { 13: 37 },
-      "thisDoesNotExist",
-      "thisToo",
-    ]);
-    testSet.should.not.have.any.deep.keys([20, 1, { 13: 37 }]);
-    testSet.should.not.have.all.deep.keys([
-      { thisIs: "anExampleObject" },
-      { iDoNot: "exist" },
-    ]);
+      testSet.should.not.have.any.deep.keys([{13: 37}, 'thisDoesNotExist', 'thisToo']);
+      testSet.should.not.have.any.deep.keys([20, 1, {13: 37}]);
+      testSet.should.not.have.all.deep.keys([{thisIs: 'anExampleObject'}, {'iDoNot': 'exist'}])
 
-    var weirdSetKey1 = Object.create(null),
-      weirdSetKey2 = { toString: NaN },
-      weirdSetKey3 = [],
-      weirdSet = new Set();
+      var weirdSetKey1 = Object.create(null)
+        , weirdSetKey2 = {toString: NaN}
+        , weirdSetKey3 = []
+        , weirdSet = new Set();
 
-    weirdSet.add(weirdSetKey1);
-    weirdSet.add(weirdSetKey2);
+      weirdSet.add(weirdSetKey1);
+      weirdSet.add(weirdSetKey2);
 
-    weirdSet.should.have.all.keys([weirdSetKey1, weirdSetKey2]);
-    weirdSet.should.not.have.all.keys([weirdSetKey1, weirdSetKey3]);
+      weirdSet.should.have.all.keys([weirdSetKey1, weirdSetKey2]);
+      weirdSet.should.not.have.all.keys([weirdSetKey1, weirdSetKey3]);
 
-    var symSetKey1 = Symbol(),
-      symSetKey2 = Symbol(),
-      symSetKey3 = Symbol(),
-      symSet = new Set();
+    var symSetKey1 = Symbol()
+    , symSetKey2 = Symbol()
+    , symSetKey3 = Symbol()
+    , symSet = new Set();
 
     symSet.add(symSetKey1);
     symSet.add(symSetKey2);
@@ -2683,240 +2363,222 @@ describe("should", function () {
 
     errSet.add({ foo: 1 });
 
-    err(function () {
+    err(function(){
       errSet.should.have.keys();
     }, "keys required");
 
-    err(function () {
+    err(function(){
       errSet.should.have.keys([]);
     }, "keys required");
 
-    err(function () {
+    err(function(){
       errSet.should.contain.keys();
     }, "keys required");
 
-    err(function () {
+    err(function(){
       errSet.should.contain.keys([]);
     }, "keys required");
 
-    err(function () {
-      new Set([{ foo: 1 }]).should.contain.keys({ foo: 1 });
-    }, "expected Set{ { foo: 1 } } to contain key { foo: 1 }");
+    err(function(){
+      new Set([{foo: 1}]).should.contain.keys({ foo: 1 });
+    }, 'expected Set{ { foo: 1 } } to contain key { foo: 1 }');
 
-    err(function () {
-      new Set([{ foo: 1 }]).should.contain.deep.keys({ iDoNotExist: 0 });
-    }, "expected Set{ { foo: 1 } } to deeply contain key { iDoNotExist: +0 }");
+    err(function(){
+      new Set([{foo: 1}]).should.contain.deep.keys({ iDoNotExist: 0 });
+    }, 'expected Set{ { foo: 1 } } to deeply contain key { iDoNotExist: +0 }');
 
-    err(function () {
+    err(function(){
       ({ foo: 1 }).should.have.keys();
     }, "keys required");
 
-    err(function () {
+    err(function(){
       ({ foo: 1 }).should.have.keys([]);
     }, "keys required");
 
-    err(function () {
+    err(function(){
       ({ foo: 1 }).should.not.have.keys([]);
     }, "keys required");
 
-    err(function () {
+    err(function(){
       ({ foo: 1 }).should.contain.keys([]);
     }, "keys required");
 
-    var mixedArgsMsg =
-      "when testing keys against an object or an array you must give a single Array|Object|String argument or multiple String arguments";
+    var mixedArgsMsg = 'when testing keys against an object or an array you must give a single Array|Object|String argument or multiple String arguments'
 
-    err(function () {
-      ({}).should.contain.keys(["a"], "b");
+    err(function(){
+      ({}).should.contain.keys(['a'], "b");
     }, mixedArgsMsg);
 
-    err(function () {
-      ({}).should.contain.keys({ a: 1 }, "b");
+    err(function(){
+      ({}).should.contain.keys({ 'a': 1 }, "b");
     }, mixedArgsMsg);
 
-    err(function () {
-      ({ foo: 1 }).should.have.keys(["bar"]);
+    err(function(){
+      ({ foo: 1 }).should.have.keys(['bar']);
     }, "expected { foo: 1 } to have key 'bar'");
 
-    err(function () {
-      ({ foo: 1 }).should.have.keys(["bar", "baz"]);
+    err(function(){
+      ({ foo: 1 }).should.have.keys(['bar', 'baz']);
     }, "expected { foo: 1 } to have keys 'bar', and 'baz'");
 
-    err(function () {
-      ({ foo: 1 }).should.have.keys(["foo", "bar", "baz"]);
+    err(function(){
+      ({ foo: 1 }).should.have.keys(['foo', 'bar', 'baz']);
     }, "expected { foo: 1 } to have keys 'foo', 'bar', and 'baz'");
 
-    err(function () {
-      ({ foo: 1 }).should.not.have.keys(["foo"]);
+    err(function(){
+      ({ foo: 1 }).should.not.have.keys(['foo']);
     }, "expected { foo: 1 } to not have key 'foo'");
 
-    err(function () {
-      ({ foo: 1 }).should.not.have.keys(["foo"]);
+    err(function(){
+      ({ foo: 1 }).should.not.have.keys(['foo']);
     }, "expected { foo: 1 } to not have key 'foo'");
 
-    err(function () {
-      ({ foo: 1, bar: 2 }).should.not.have.keys(["foo", "bar"]);
+    err(function(){
+      ({ foo: 1, bar: 2 }).should.not.have.keys(['foo', 'bar']);
     }, "expected { foo: 1, bar: 2 } to not have keys 'foo', and 'bar'");
 
-    err(function () {
-      ({ foo: 1 }).should.not.contain.keys(["foo"]);
+    err(function(){
+      ({ foo: 1 }).should.not.contain.keys(['foo']);
     }, "expected { foo: 1 } to not contain key 'foo'");
 
-    err(function () {
-      ({ foo: 1 }).should.contain.keys("foo", "bar");
+    err(function(){
+      ({ foo: 1 }).should.contain.keys('foo', 'bar');
     }, "expected { foo: 1 } to contain keys 'foo', and 'bar'");
 
-    err(function () {
-      ({ foo: 1 }).should.have.any.keys("baz");
+    err(function() {
+      ({ foo: 1 }).should.have.any.keys('baz');
     }, "expected { foo: 1 } to have key 'baz'");
 
-    err(function () {
-      ({ foo: 1, bar: 2 }).should.not.have.all.keys(["foo", "bar"]);
+    err(function(){
+      ({ foo: 1, bar: 2 }).should.not.have.all.keys(['foo', 'bar']);
     }, "expected { foo: 1, bar: 2 } to not have keys 'foo', and 'bar'");
 
-    err(function () {
-      ({ foo: 1, bar: 2 }).should.not.have.any.keys(["foo", "baz"]);
+    err(function(){
+      ({ foo: 1, bar: 2 }).should.not.have.any.keys(['foo', 'baz']);
     }, "expected { foo: 1, bar: 2 } to not have keys 'foo', or 'baz'");
 
     // repeat previous tests with Object as arg.
-    err(function () {
-      ({ foo: 1 }).should.have.keys({ bar: 1 });
+    err(function(){
+      ({ foo: 1 }).should.have.keys({ 'bar': 1 });
     }, "expected { foo: 1 } to have key 'bar'");
 
-    err(function () {
-      ({ foo: 1 }).should.have.keys({ bar: 1, baz: 1 });
+    err(function(){
+      ({ foo: 1 }).should.have.keys({ 'bar': 1, 'baz': 1});
     }, "expected { foo: 1 } to have keys 'bar', and 'baz'");
 
-    err(function () {
-      ({ foo: 1 }).should.have.keys({ foo: 1, bar: 1, baz: 1 });
+    err(function(){
+      ({ foo: 1 }).should.have.keys({ 'foo': 1, 'bar': 1, 'baz': 1});
     }, "expected { foo: 1 } to have keys 'foo', 'bar', and 'baz'");
 
-    err(function () {
-      ({ foo: 1 }).should.not.have.keys({ foo: 1 });
+    err(function(){
+      ({ foo: 1 }).should.not.have.keys({ 'foo': 1 });
     }, "expected { foo: 1 } to not have key 'foo'");
 
-    err(function () {
-      ({ foo: 1 }).should.not.have.keys({ foo: 1 });
+    err(function(){
+      ({ foo: 1 }).should.not.have.keys({ 'foo': 1 });
     }, "expected { foo: 1 } to not have key 'foo'");
 
-    err(function () {
-      ({ foo: 1, bar: 2 }).should.not.have.keys({ foo: 1, bar: 1 });
+    err(function(){
+      ({ foo: 1, bar: 2 }).should.not.have.keys({ 'foo': 1, 'bar': 1});
     }, "expected { foo: 1, bar: 2 } to not have keys 'foo', and 'bar'");
 
-    err(function () {
-      ({ foo: 1 }).should.not.contain.keys({ foo: 1 });
+    err(function(){
+      ({ foo: 1 }).should.not.contain.keys({ 'foo': 1 });
     }, "expected { foo: 1 } to not contain key 'foo'");
 
-    err(function () {
-      ({ foo: 1 }).should.contain.keys("foo", "bar");
+    err(function(){
+      ({ foo: 1 }).should.contain.keys('foo', 'bar');
     }, "expected { foo: 1 } to contain keys 'foo', and 'bar'");
 
-    err(function () {
-      ({ foo: 1 }).should.have.any.keys("baz");
+    err(function() {
+      ({ foo: 1 }).should.have.any.keys('baz');
     }, "expected { foo: 1 } to have key 'baz'");
 
-    err(function () {
-      ({ foo: 1, bar: 2 }).should.not.have.all.keys({ foo: 1, bar: 1 });
+    err(function(){
+      ({ foo: 1, bar: 2 }).should.not.have.all.keys({ 'foo': 1, 'bar': 1});
     }, "expected { foo: 1, bar: 2 } to not have keys 'foo', and 'bar'");
 
-    err(function () {
-      ({ foo: 1, bar: 2 }).should.not.have.any.keys({ foo: 1, baz: 1 });
+    err(function(){
+      ({ foo: 1, bar: 2 }).should.not.have.any.keys({ 'foo': 1, 'baz': 1});
     }, "expected { foo: 1, bar: 2 } to not have keys 'foo', or 'baz'");
+
   });
 
-  it("keys(array) will not mutate array (#359)", function () {
-    var expected = ["b", "a"];
-    var original_order = ["b", "a"];
-    var obj = { b: 1, a: 1 };
-    expected.should.deep.equal(original_order);
-    obj.should.keys(original_order);
-    expected.should.deep.equal(original_order);
+  it('keys(array) will not mutate array (#359)', function () {
+      var expected = [ 'b', 'a' ];
+      var original_order = [ 'b', 'a' ];
+      var obj = { "b": 1, "a": 1 };
+      expected.should.deep.equal(original_order);
+      obj.should.keys(original_order);
+      expected.should.deep.equal(original_order);
   });
 
-  it("throw", function () {
+  it('throw', function () {
     // See GH-45: some poorly-constructed custom errors don't have useful names
     // on either their constructor or their constructor prototype, but instead
     // only set the name inside the constructor itself.
     var PoorlyConstructedError = function () {
-      this.name = "PoorlyConstructedError";
+      this.name = 'PoorlyConstructedError';
     };
     PoorlyConstructedError.prototype = Object.create(Error.prototype);
 
     function CustomError(message) {
-      this.name = "CustomError";
-      this.message = message;
+        this.name = 'CustomError';
+        this.message = message;
     }
     CustomError.prototype = Error.prototype;
 
-    var specificError = new RangeError("boo");
+    var specificError = new RangeError('boo');
 
-    var goodFn = function () {
-        1 == 1;
-      },
-      badFn = function () {
-        throw new Error("testing");
-      },
-      stringErrFn = function () {
-        throw "testing";
-      },
-      refErrFn = function () {
-        throw new ReferenceError("hello");
-      },
-      ickyErrFn = function () {
-        throw new PoorlyConstructedError();
-      },
-      specificErrFn = function () {
-        throw specificError;
-      },
-      customErrFn = function () {
-        throw new CustomError("foo");
-      },
-      emptyErrFn = function () {
-        throw new Error();
-      },
-      emptyStringErrFn = function () {
-        throw new Error("");
-      };
+    var goodFn = function () { 1==1; }
+      , badFn = function () { throw new Error('testing'); }
+      , stringErrFn = function () { throw 'testing'; }
+      , refErrFn = function () { throw new ReferenceError('hello'); }
+      , ickyErrFn = function () { throw new PoorlyConstructedError(); }
+      , specificErrFn = function () { throw specificError; }
+      , customErrFn = function () { throw new CustomError('foo'); }
+      , emptyErrFn = function () { throw new Error(); }
+      , emptyStringErrFn = function () { throw new Error(''); };
 
-    goodFn.should.not.throw();
-    goodFn.should.not.throw(Error);
-    goodFn.should.not.throw(specificError);
-    badFn.should.throw();
-    badFn.should.throw(Error);
-    badFn.should.not.throw(ReferenceError);
-    badFn.should.not.throw(specificError);
-    stringErrFn.should.throw();
-    stringErrFn.should.not.throw(ReferenceError);
-    stringErrFn.should.not.throw(specificError);
-    refErrFn.should.throw();
-    refErrFn.should.throw(ReferenceError);
-    refErrFn.should.throw(Error);
-    refErrFn.should.not.throw(TypeError);
-    refErrFn.should.not.throw(specificError);
-    ickyErrFn.should.throw();
-    ickyErrFn.should.throw(PoorlyConstructedError);
-    ickyErrFn.should.throw(Error);
-    ickyErrFn.should.not.throw(specificError);
-    specificErrFn.should.throw(specificError);
+    (goodFn).should.not.throw();
+    (goodFn).should.not.throw(Error);
+    (goodFn).should.not.throw(specificError);
+    (badFn).should.throw();
+    (badFn).should.throw(Error);
+    (badFn).should.not.throw(ReferenceError);
+    (badFn).should.not.throw(specificError);
+    (stringErrFn).should.throw();
+    (stringErrFn).should.not.throw(ReferenceError);
+    (stringErrFn).should.not.throw(specificError);
+    (refErrFn).should.throw();
+    (refErrFn).should.throw(ReferenceError);
+    (refErrFn).should.throw(Error);
+    (refErrFn).should.not.throw(TypeError);
+    (refErrFn).should.not.throw(specificError);
+    (ickyErrFn).should.throw();
+    (ickyErrFn).should.throw(PoorlyConstructedError);
+    (ickyErrFn).should.throw(Error);
+    (ickyErrFn).should.not.throw(specificError);
+    (specificErrFn).should.throw(specificError);
 
-    goodFn.should.not.throw("testing");
-    goodFn.should.not.throw(/testing/);
-    badFn.should.throw(/testing/);
-    badFn.should.throw("testing");
-    badFn.should.not.throw(/hello/);
-    badFn.should.not.throw("hello");
-    emptyStringErrFn.should.throw("");
-    emptyStringErrFn.should.not.throw("testing");
-    badFn.should.throw("");
+    (goodFn).should.not.throw('testing');
+    (goodFn).should.not.throw(/testing/);
+    (badFn).should.throw(/testing/);
+    (badFn).should.throw('testing');
+    (badFn).should.not.throw(/hello/);
+    (badFn).should.not.throw('hello');
+    (emptyStringErrFn).should.throw('');
+    (emptyStringErrFn).should.not.throw('testing');
+    (badFn).should.throw('');
 
-    badFn.should.throw(Error, /testing/);
-    badFn.should.throw(Error, "testing");
-    emptyErrFn.should.not.throw(Error, "testing");
+    (badFn).should.throw(Error, /testing/);
+    (badFn).should.throw(Error, 'testing');
+    (emptyErrFn).should.not.throw(Error, 'testing');
 
-    stringErrFn.should.throw(/testing/);
-    stringErrFn.should.throw("testing");
-    stringErrFn.should.not.throw(/hello/);
-    stringErrFn.should.not.throw("hello");
+    (stringErrFn).should.throw(/testing/);
+    (stringErrFn).should.throw('testing');
+    (stringErrFn).should.not.throw(/hello/);
+    (stringErrFn).should.not.throw('hello');
 
     should.throw(badFn);
     should.throw(refErrFn, ReferenceError);
@@ -2928,109 +2590,109 @@ describe("should", function () {
     should.not.throw(badFn, specificError);
 
     should.throw(badFn, Error, /testing/);
-    should.throw(badFn, Error, "testing");
+    should.throw(badFn, Error, 'testing');
 
-    badFn.should.not.throw(Error, "I am the wrong error message");
-    badFn.should.not.throw(TypeError, "testing");
+    (badFn).should.not.throw(Error, 'I am the wrong error message');
+    (badFn).should.not.throw(TypeError, 'testing');
 
-    err(function () {
-      goodFn.should.throw();
+    err(function(){
+      (goodFn).should.throw();
     }, /^expected \[Function( goodFn)*\] to throw an error$/);
 
-    err(function () {
-      goodFn.should.throw(ReferenceError);
+    err(function(){
+      (goodFn).should.throw(ReferenceError);
     }, /^expected \[Function( goodFn)*\] to throw ReferenceError$/);
 
-    err(function () {
-      goodFn.should.throw(specificError);
+    err(function(){
+      (goodFn).should.throw(specificError);
     }, /^expected \[Function( goodFn)*\] to throw 'RangeError: boo'$/);
 
-    err(function () {
-      badFn.should.not.throw();
+    err(function(){
+      (badFn).should.not.throw();
     }, /^expected \[Function( badFn)*\] to not throw an error but 'Error: testing' was thrown$/);
 
-    err(function () {
-      badFn.should.throw(ReferenceError);
+    err(function(){
+      (badFn).should.throw(ReferenceError);
     }, /^expected \[Function( badFn)*\] to throw 'ReferenceError' but 'Error: testing' was thrown$/);
 
-    err(function () {
-      badFn.should.throw(specificError);
+    err(function(){
+      (badFn).should.throw(specificError);
     }, /^expected \[Function( badFn)*\] to throw 'RangeError: boo' but 'Error: testing' was thrown$/);
 
-    err(function () {
-      badFn.should.not.throw(Error);
+    err(function(){
+      (badFn).should.not.throw(Error);
     }, /^expected \[Function( badFn)*\] to not throw 'Error' but 'Error: testing' was thrown$/);
 
-    err(function () {
-      stringErrFn.should.not.throw();
+    err(function(){
+      (stringErrFn).should.not.throw();
     }, /^expected \[Function( stringErrFn)*\] to not throw an error but 'testing' was thrown$/);
 
-    err(function () {
-      stringErrFn.should.throw(ReferenceError);
+    err(function(){
+      (stringErrFn).should.throw(ReferenceError);
     }, /^expected \[Function( stringErrFn)*\] to throw 'ReferenceError' but 'testing' was thrown$/);
 
-    err(function () {
-      stringErrFn.should.throw(specificError);
+    err(function(){
+      (stringErrFn).should.throw(specificError);
     }, /^expected \[Function( stringErrFn)*\] to throw 'RangeError: boo' but 'testing' was thrown$/);
 
-    err(function () {
-      stringErrFn.should.not.throw("testing");
+    err(function(){
+      (stringErrFn).should.not.throw('testing');
     }, /^expected \[Function( stringErrFn)*\] to throw error not including 'testing'$/);
 
-    err(function () {
-      refErrFn.should.not.throw(ReferenceError);
+    err(function(){
+      (refErrFn).should.not.throw(ReferenceError);
     }, /^expected \[Function( refErrFn)*\] to not throw 'ReferenceError' but 'ReferenceError: hello' was thrown$/);
 
-    err(function () {
-      badFn.should.throw(PoorlyConstructedError);
+    err(function(){
+      (badFn).should.throw(PoorlyConstructedError);
     }, /^expected \[Function( badFn)*\] to throw 'PoorlyConstructedError' but 'Error: testing' was thrown$/);
 
-    err(function () {
-      ickyErrFn.should.not.throw(PoorlyConstructedError);
+    err(function(){
+      (ickyErrFn).should.not.throw(PoorlyConstructedError);
     }, /^(expected \[Function( ickyErrFn)*\] to not throw 'PoorlyConstructedError' but)(.*)(PoorlyConstructedError|\{ Object \()(.*)(was thrown)$/);
 
-    err(function () {
-      ickyErrFn.should.throw(ReferenceError);
+    err(function(){
+      (ickyErrFn).should.throw(ReferenceError);
     }, /^(expected \[Function( ickyErrFn)*\] to throw 'ReferenceError' but)(.*)(PoorlyConstructedError|\{ Object \()(.*)(was thrown)$/);
 
-    err(function () {
-      specificErrFn.should.throw(new ReferenceError("eek"));
+    err(function(){
+      (specificErrFn).should.throw(new ReferenceError('eek'));
     }, /^expected \[Function( specificErrFn)*\] to throw 'ReferenceError: eek' but 'RangeError: boo' was thrown$/);
 
-    err(function () {
-      specificErrFn.should.not.throw(specificError);
+    err(function(){
+      (specificErrFn).should.not.throw(specificError);
     }, /^expected \[Function( specificErrFn)*\] to not throw 'RangeError: boo'$/);
 
-    err(function () {
-      badFn.should.not.throw(/testing/);
+    err(function (){
+      (badFn).should.not.throw(/testing/);
     }, /^expected \[Function( badFn)*\] to throw error not matching \/testing\/$/);
 
     err(function () {
-      badFn.should.throw(/hello/);
+      (badFn).should.throw(/hello/);
     }, /^expected \[Function( badFn)*\] to throw error matching \/hello\/ but got \'testing\'$/);
 
     err(function () {
-      badFn.should.throw(Error, /hello/, "blah");
+      (badFn).should.throw(Error, /hello/, 'blah');
     }, /^blah: expected \[Function( badFn)*\] to throw error matching \/hello\/ but got 'testing'$/);
 
     err(function () {
-      badFn.should.throw(Error, "hello", "blah");
+      (badFn).should.throw(Error, 'hello', 'blah');
     }, /^blah: expected \[Function( badFn)*\] to throw error including 'hello' but got 'testing'$/);
 
     err(function () {
-      customErrFn.should.not.throw();
+      (customErrFn).should.not.throw();
     }, /^expected \[Function( customErrFn)*\] to not throw an error but 'CustomError: foo' was thrown$/);
 
-    err(function () {
-      badFn.should.not.throw(Error, "testing");
+    err(function(){
+      (badFn).should.not.throw(Error, 'testing');
     }, /^expected \[Function( badFn)*\] to not throw 'Error' but 'Error: testing' was thrown$/);
 
-    err(function () {
-      emptyStringErrFn.should.not.throw(Error, "");
+    err(function(){
+      (emptyStringErrFn).should.not.throw(Error, '');
     }, /^expected \[Function( emptyStringErrFn)*\] to not throw 'Error' but 'Error' was thrown$/);
 
-    err(function () {
-      emptyStringErrFn.should.not.throw("");
+    err(function(){
+      (emptyStringErrFn).should.not.throw('');
     }, /^expected \[Function( emptyStringErrFn)*\] to throw error not including ''$/);
 
     err(function () {
@@ -3038,95 +2700,95 @@ describe("should", function () {
     }, "expected {} to be a function");
 
     err(function () {
-      ({}).should.throw(Error, "testing", "blah");
+      ({}).should.throw(Error, 'testing', 'blah');
     }, "blah: expected {} to be a function");
   });
 
-  it("respondTo", function () {
-    function Foo() {}
-    Foo.prototype.bar = function () {};
-    Foo.func = function () {};
+  it('respondTo', function(){
+    function Foo(){};
+    Foo.prototype.bar = function(){};
+    Foo.func = function(){};
 
     var bar = {};
-    bar.foo = function () {};
+    bar.foo = function(){};
 
-    Foo.should.respondTo("bar");
-    Foo.should.not.respondTo("foo");
-    Foo.should.itself.respondTo("func");
-    Foo.should.itself.not.respondTo("bar");
+    Foo.should.respondTo('bar');
+    Foo.should.not.respondTo('foo');
+    Foo.should.itself.respondTo('func');
+    Foo.should.itself.not.respondTo('bar');
 
-    bar.should.respondTo("foo");
+    bar.should.respondTo('foo');
 
-    err(function () {
-      Foo.should.respondTo("baz", "constructor");
+    err(function(){
+      Foo.should.respondTo('baz', 'constructor');
     }, /^(constructor: expected)(.*)(\[Function Foo\])(.*)(to respond to \'baz\')$/);
 
-    err(function () {
-      bar.should.respondTo("baz", "object");
+    err(function(){
+      bar.should.respondTo('baz', 'object');
     }, /^(object: expected)(.*)(\{ foo: \[Function\] \}|\{ Object \()(.*)(to respond to \'baz\')$/);
   });
 
-  it("satisfy", function () {
-    var matcher = function (num) {
+  it('satisfy', function(){
+    var matcher = function (num){
       return num === 1;
     };
 
     (1).should.satisfy(matcher);
 
-    err(function () {
-      (2).should.satisfy(matcher, "blah");
+    err(function(){
+      (2).should.satisfy(matcher, 'blah');
     }, /^blah: expected 2 to satisfy \[Function( matcher)*\]$/);
   });
 
-  it("closeTo", function () {
+  it('closeTo', function(){
     (1.5).should.be.closeTo(1.0, 0.5);
 
-    err(function () {
-      (2).should.be.closeTo(1.0, 0.5, "blah");
+    err(function(){
+      (2).should.be.closeTo(1.0, 0.5, 'blah');
     }, "blah: expected 2 to be close to 1 +/- 0.5");
 
-    err(function () {
-      [1.5].should.be.closeTo(1.0, 0.5, "blah");
+    err(function() {
+      [1.5].should.be.closeTo(1.0, 0.5, 'blah');
     }, "blah: expected [ 1.5 ] to be a number");
 
-    err(function () {
-      (1.5).should.be.closeTo("1.0", 0.5, "blah");
+    err(function() {
+      (1.5).should.be.closeTo("1.0", 0.5, 'blah');
     }, "blah: the arguments to closeTo or approximately must be numbers");
 
-    err(function () {
-      (1.5).should.be.closeTo(1.0, true, "blah");
+    err(function() {
+      (1.5).should.be.closeTo(1.0, true, 'blah');
     }, "blah: the arguments to closeTo or approximately must be numbers");
 
-    err(function () {
-      (1.5).should.be.closeTo(1.0, undefined, "blah");
+    err(function() {
+      (1.5).should.be.closeTo(1.0, undefined, 'blah');
     }, "blah: the arguments to closeTo or approximately must be numbers, and a delta is required");
   });
 
-  it("approximately", function () {
+  it('approximately', function(){
     (1.5).should.be.approximately(1.0, 0.5);
 
-    err(function () {
-      (2).should.be.approximately(1.0, 0.5, "blah");
+    err(function(){
+      (2).should.be.approximately(1.0, 0.5, 'blah');
     }, "blah: expected 2 to be close to 1 +/- 0.5");
 
-    err(function () {
+    err(function() {
       [1.5].should.be.approximately(1.0, 0.5);
     }, "expected [ 1.5 ] to be a number");
 
-    err(function () {
+    err(function() {
       (1.5).should.be.approximately("1.0", 0.5);
     }, "the arguments to closeTo or approximately must be numbers");
 
-    err(function () {
+    err(function() {
       (1.5).should.be.approximately(1.0, true);
     }, "the arguments to closeTo or approximately must be numbers");
 
-    err(function () {
+    err(function() {
       (1.5).should.be.approximately(1.0);
     }, "the arguments to closeTo or approximately must be numbers, and a delta is required");
   });
 
-  it("include.members", function () {
+  it('include.members', function() {
     [1, 2, 3].should.include.members([3]);
     [1, 2, 3].should.include.members([]);
     [1, 2, 3].should.include.members([2, 1]);
@@ -3134,26 +2796,26 @@ describe("should", function () {
 
     [1, 2, 3].should.not.include.members([999]);
     [].should.not.include.members([23]);
-    [{ a: 1 }].should.not.include.members([{ a: 1 }]);
+    [{a: 1}].should.not.include.members([{a: 1}]);
 
-    err(function () {
-      [].should.include.members([43], "blah");
-    }, "blah: expected [] to be a superset of [ 43 ]");
+    err(function() {
+      [].should.include.members([43], 'blah');
+    }, 'blah: expected [] to be a superset of [ 43 ]');
 
-    err(function () {
+    err(function() {
       [5, 2, 1].should.not.include.members([2]);
-    }, "expected [ 5, 2, 1 ] to not be a superset of [ 2 ]");
+    }, 'expected [ 5, 2, 1 ] to not be a superset of [ 2 ]');
 
-    err(function () {
-      "foo".should.include.members([12], "blah");
+    err(function() {
+      'foo'.should.include.members([12], 'blah');
     }, "blah: expected 'foo' to be an array");
 
-    err(function () {
-      [1, 2, 3].should.include.members("o", "blah");
+    err(function() {
+      [1, 2, 3].should.include.members('o', 'blah');
     }, "blah: expected 'o' to be an array");
   });
 
-  it("memberEquals", function () {
+  it('memberEquals', function() {
     [1, 2, 3].should.have.same.members([3, 2, 1]);
     [5, 4].should.have.same.members([5, 4]);
     [5, 4, 4].should.have.same.members([5, 4, 4]);
@@ -3163,76 +2825,43 @@ describe("should", function () {
     [5, 4, 4].should.not.have.same.members([5, 4]);
     [5, 4, 4].should.not.have.same.members([5, 4, 3]);
     [5, 4, 3].should.not.have.same.members([5, 4, 4]);
-    [{ a: 1 }].should.not.have.same.members([{ a: 1 }]);
+    [{a: 1}].should.not.have.same.members([{a: 1}]);
 
-    err(function () {
-      [1, 2, 3].should.have.same.members([], "blah");
-    }, "blah: expected [ 1, 2, 3 ] to have the same members as []");
+    err(function() {
+      [1, 2, 3].should.have.same.members([], 'blah');
+    }, 'blah: expected [ 1, 2, 3 ] to have the same members as []');
 
-    err(function () {
-      [1, 2, 3].should.have.same.members(4, "blah");
-    }, "blah: expected 4 to be an array");
+    err(function() {
+      [1, 2, 3].should.have.same.members(4, 'blah');
+    }, 'blah: expected 4 to be an array');
   });
 
-  it("deep.members", function () {
+  it('deep.members', function() {
     [{ id: 1 }].should.have.deep.members([{ id: 1 }]);
-    [{ a: 1 }, { b: 2 }, { b: 2 }].should.have.deep.members([
-      { a: 1 },
-      { b: 2 },
-      { b: 2 },
-    ]);
+    [{a: 1}, {b: 2}, {b: 2}].should.have.deep.members([{a: 1}, {b: 2}, {b: 2}]);
 
     [{ id: 2 }].should.not.have.deep.members([{ id: 1 }]);
-    [{ a: 1 }, { b: 2 }].should.not.have.deep.members([
-      { a: 1 },
-      { b: 2 },
-      { b: 2 },
-    ]);
-    [{ a: 1 }, { b: 2 }, { b: 2 }].should.not.have.deep.members([
-      { a: 1 },
-      { b: 2 },
-    ]);
-    [{ a: 1 }, { b: 2 }, { b: 2 }].should.not.have.deep.members([
-      { a: 1 },
-      { b: 2 },
-      { c: 3 },
-    ]);
-    [{ a: 1 }, { b: 2 }, { c: 3 }].should.not.have.deep.members([
-      { a: 1 },
-      { b: 2 },
-      { b: 2 },
-    ]);
+    [{a: 1}, {b: 2}].should.not.have.deep.members([{a: 1}, {b: 2}, {b: 2}]);
+    [{a: 1}, {b: 2}, {b: 2}].should.not.have.deep.members([{a: 1}, {b: 2}]);
+    [{a: 1}, {b: 2}, {b: 2}].should.not.have.deep.members([{a: 1}, {b: 2}, {c: 3}]);
+    [{a: 1}, {b: 2}, {c: 3}].should.not.have.deep.members([{a: 1}, {b: 2}, {b: 2}]);
 
-    err(function () {
-      [{ id: 1 }].should.have.deep.members([{ id: 2 }], "blah");
-    }, "blah: expected [ { id: 1 } ] to have the same members as [ { id: 2 } ]");
+    err(function(){
+      [{ id: 1 }].should.have.deep.members([{ id: 2 }], 'blah')
+    }, 'blah: expected [ { id: 1 } ] to have the same members as [ { id: 2 } ]');
   });
 
-  it("include.deep.members", function () {
-    [{ a: 1 }, { b: 2 }, { c: 3 }].should.include.deep.members([
-      { b: 2 },
-      { a: 1 },
-    ]);
-    [{ a: 1 }, { b: 2 }, { c: 3 }].should.include.deep.members([
-      { b: 2 },
-      { a: 1 },
-      { a: 1 },
-    ]);
-    [{ a: 1 }, { b: 2 }, { c: 3 }].should.not.include.deep.members([
-      { b: 2 },
-      { a: 1 },
-      { f: 5 },
-    ]);
+  it('include.deep.members', function() {
+    [{a: 1}, {b: 2}, {c: 3}].should.include.deep.members([{b: 2}, {a: 1}]);
+    [{a: 1}, {b: 2}, {c: 3}].should.include.deep.members([{b: 2}, {a: 1}, {a: 1}]);
+    [{a: 1}, {b: 2}, {c: 3}].should.not.include.deep.members([{b: 2}, {a: 1}, {f: 5}]);
 
-    err(function () {
-      [{ a: 1 }, { b: 2 }, { c: 3 }].should.include.deep.members(
-        [{ b: 2 }, { a: 1 }, { f: 5 }],
-        "blah",
-      );
-    }, "blah: expected [ { a: 1 }, { b: 2 }, { c: 3 } ] to be a superset of [ { b: 2 }, { a: 1 }, { f: 5 } ]");
+    err(function() {
+      [{a: 1}, {b: 2}, {c: 3}].should.include.deep.members([{b: 2}, {a: 1}, {f: 5}], 'blah');
+    }, 'blah: expected [ { a: 1 }, { b: 2 }, { c: 3 } ] to be a superset of [ { b: 2 }, { a: 1 }, { f: 5 } ]');
   });
 
-  it("ordered.members", function () {
+  it('ordered.members', function() {
     [1, 2, 3].should.ordered.members([1, 2, 3]);
     [1, 2, 2].should.ordered.members([1, 2, 2]);
 
@@ -3243,155 +2872,88 @@ describe("should", function () {
     [1, 2, 2].should.not.ordered.members([1, 2, 3]);
     [1, 2, 3].should.not.ordered.members([1, 2, 2]);
 
-    err(function () {
-      [1, 2, 3].should.ordered.members([2, 1, 3], "blah");
-    }, "blah: expected [ 1, 2, 3 ] to have the same ordered members as [ 2, 1, 3 ]");
+    err(function() {
+      [1, 2, 3].should.ordered.members([2, 1, 3], 'blah');
+    }, 'blah: expected [ 1, 2, 3 ] to have the same ordered members as [ 2, 1, 3 ]');
 
-    err(function () {
+    err(function() {
       [1, 2, 3].should.not.ordered.members([1, 2, 3]);
-    }, "expected [ 1, 2, 3 ] to not have the same ordered members as [ 1, 2, 3 ]");
+    }, 'expected [ 1, 2, 3 ] to not have the same ordered members as [ 1, 2, 3 ]');
   });
 
-  it("include.ordered.members", function () {
+  it('include.ordered.members', function() {
     [1, 2, 3].should.include.ordered.members([1, 2]);
     [1, 2, 3].should.not.include.ordered.members([2, 1]);
     [1, 2, 3].should.not.include.ordered.members([2, 3]);
     [1, 2, 3].should.not.include.ordered.members([1, 2, 2]);
 
-    err(function () {
-      [1, 2, 3].should.include.ordered.members([2, 1], "blah");
-    }, "blah: expected [ 1, 2, 3 ] to be an ordered superset of [ 2, 1 ]");
+    err(function() {
+      [1, 2, 3].should.include.ordered.members([2, 1], 'blah');
+    }, 'blah: expected [ 1, 2, 3 ] to be an ordered superset of [ 2, 1 ]');
 
-    err(function () {
+    err(function() {
       [1, 2, 3].should.not.include.ordered.members([1, 2]);
-    }, "expected [ 1, 2, 3 ] to not be an ordered superset of [ 1, 2 ]");
+    }, 'expected [ 1, 2, 3 ] to not be an ordered superset of [ 1, 2 ]');
   });
 
-  it("deep.ordered.members", function () {
-    [{ a: 1 }, { b: 2 }, { c: 3 }].should.deep.ordered.members([
-      { a: 1 },
-      { b: 2 },
-      { c: 3 },
-    ]);
-    [{ a: 1 }, { b: 2 }, { b: 2 }].should.deep.ordered.members([
-      { a: 1 },
-      { b: 2 },
-      { b: 2 },
-    ]);
+  it('deep.ordered.members', function() {
+    [{a: 1}, {b: 2}, {c: 3}].should.deep.ordered.members([{a: 1}, {b: 2}, {c: 3}]);
+    [{a: 1}, {b: 2}, {b: 2}].should.deep.ordered.members([{a: 1}, {b: 2}, {b: 2}]);
 
-    [{ a: 1 }, { b: 2 }, { c: 3 }].should.not.deep.ordered.members([
-      { b: 2 },
-      { a: 1 },
-      { c: 3 },
-    ]);
-    [{ a: 1 }, { b: 2 }].should.not.deep.ordered.members([
-      { a: 1 },
-      { b: 2 },
-      { b: 2 },
-    ]);
-    [{ a: 1 }, { b: 2 }, { b: 2 }].should.not.deep.ordered.members([
-      { a: 1 },
-      { b: 2 },
-    ]);
-    [{ a: 1 }, { b: 2 }, { b: 2 }].should.not.deep.ordered.members([
-      { a: 1 },
-      { b: 2 },
-      { c: 3 },
-    ]);
-    [{ a: 1 }, { b: 2 }, { c: 3 }].should.not.deep.ordered.members([
-      { a: 1 },
-      { b: 2 },
-      { b: 2 },
-    ]);
+    [{a: 1}, {b: 2}, {c: 3}].should.not.deep.ordered.members([{b: 2}, {a: 1}, {c: 3}]);
+    [{a: 1}, {b: 2}].should.not.deep.ordered.members([{a: 1}, {b: 2}, {b: 2}]);
+    [{a: 1}, {b: 2}, {b: 2}].should.not.deep.ordered.members([{a: 1}, {b: 2}]);
+    [{a: 1}, {b: 2}, {b: 2}].should.not.deep.ordered.members([{a: 1}, {b: 2}, {c: 3}]);
+    [{a: 1}, {b: 2}, {c: 3}].should.not.deep.ordered.members([{a: 1}, {b: 2}, {b: 2}]);
 
-    err(function () {
-      [{ a: 1 }, { b: 2 }, { c: 3 }].should.deep.ordered.members(
-        [{ b: 2 }, { a: 1 }, { c: 3 }],
-        "blah",
-      );
-    }, "blah: expected [ { a: 1 }, { b: 2 }, { c: 3 } ] to have the same ordered members as [ { b: 2 }, { a: 1 }, { c: 3 } ]");
+    err(function() {
+      [{a: 1}, {b: 2}, {c: 3}].should.deep.ordered.members([{b: 2}, {a: 1}, {c: 3}], 'blah');
+    }, 'blah: expected [ { a: 1 }, { b: 2 }, { c: 3 } ] to have the same ordered members as [ { b: 2 }, { a: 1 }, { c: 3 } ]');
 
-    err(function () {
-      [{ a: 1 }, { b: 2 }, { c: 3 }].should.not.deep.ordered.members([
-        { a: 1 },
-        { b: 2 },
-        { c: 3 },
-      ]);
-    }, "expected [ { a: 1 }, { b: 2 }, { c: 3 } ] to not have the same ordered members as [ { a: 1 }, { b: 2 }, { c: 3 } ]");
+    err(function() {
+      [{a: 1}, {b: 2}, {c: 3}].should.not.deep.ordered.members([{a: 1}, {b: 2}, {c: 3}]);
+    }, 'expected [ { a: 1 }, { b: 2 }, { c: 3 } ] to not have the same ordered members as [ { a: 1 }, { b: 2 }, { c: 3 } ]');
   });
 
-  it("include.deep.ordered.members", function () {
-    [{ a: 1 }, { b: 2 }, { c: 3 }].should.include.deep.ordered.members([
-      { a: 1 },
-      { b: 2 },
-    ]);
-    [{ a: 1 }, { b: 2 }, { c: 3 }].should.not.include.deep.ordered.members([
-      { b: 2 },
-      { a: 1 },
-    ]);
-    [{ a: 1 }, { b: 2 }, { c: 3 }].should.not.include.deep.ordered.members([
-      { b: 2 },
-      { c: 3 },
-    ]);
-    [{ a: 1 }, { b: 2 }, { c: 3 }].should.not.include.deep.ordered.members([
-      { a: 1 },
-      { b: 2 },
-      { b: 2 },
-    ]);
+  it('include.deep.ordered.members', function() {
+    [{a: 1}, {b: 2}, {c: 3}].should.include.deep.ordered.members([{a: 1}, {b: 2}]);
+    [{a: 1}, {b: 2}, {c: 3}].should.not.include.deep.ordered.members([{b: 2}, {a: 1}]);
+    [{a: 1}, {b: 2}, {c: 3}].should.not.include.deep.ordered.members([{b: 2}, {c: 3}]);
+    [{a: 1}, {b: 2}, {c: 3}].should.not.include.deep.ordered.members([{a: 1}, {b: 2}, {b: 2}]);
 
-    err(function () {
-      [{ a: 1 }, { b: 2 }, { c: 3 }].should.include.deep.ordered.members(
-        [{ b: 2 }, { a: 1 }],
-        "blah",
-      );
-    }, "blah: expected [ { a: 1 }, { b: 2 }, { c: 3 } ] to be an ordered superset of [ { b: 2 }, { a: 1 } ]");
+    err(function() {
+      [{a: 1}, {b: 2}, {c: 3}].should.include.deep.ordered.members([{b: 2}, {a: 1}], 'blah');
+    }, 'blah: expected [ { a: 1 }, { b: 2 }, { c: 3 } ] to be an ordered superset of [ { b: 2 }, { a: 1 } ]');
 
-    err(function () {
-      [{ a: 1 }, { b: 2 }, { c: 3 }].should.not.include.deep.ordered.members([
-        { a: 1 },
-        { b: 2 },
-      ]);
-    }, "expected [ { a: 1 }, { b: 2 }, { c: 3 } ] to not be an ordered superset of [ { a: 1 }, { b: 2 } ]");
+    err(function() {
+      [{a: 1}, {b: 2}, {c: 3}].should.not.include.deep.ordered.members([{a: 1}, {b: 2}]);
+    }, 'expected [ { a: 1 }, { b: 2 }, { c: 3 } ] to not be an ordered superset of [ { a: 1 }, { b: 2 } ]');
   });
 
-  it("change", function () {
-    var obj = { value: 10, str: "foo" },
-      heroes = ["spiderman", "superman"],
-      fn = function () {
-        obj.value += 5;
-      },
-      sameFn = function () {
-        obj.value += 0;
-      },
-      decFn = function () {
-        obj.value -= 20;
-      },
-      bangFn = function () {
-        obj.str += "!";
-      },
-      batFn = function () {
-        heroes.push("batman");
-      },
-      lenFn = function () {
-        return heroes.length;
-      },
-      noFn = function () {
-        return null;
-      };
+  it('change', function() {
+    var obj = { value: 10, str: 'foo' },
+        heroes = ['spiderman', 'superman'],
+        fn     = function() { obj.value += 5 },
+        sameFn = function() { obj.value += 0 },
+        decFn  = function() { obj.value -= 20 },
+        bangFn = function() { obj.str += '!' },
+        batFn  = function() { heroes.push('batman') },
+        lenFn  = function() { return heroes.length },
+        noFn   = function() { return null };
 
-    fn.should.change(obj, "value");
-    fn.should.change(obj, "value").by(5);
-    fn.should.change(obj, "value").by(-5);
-    fn.should.change(obj, "value").but.not.by(10);
+    fn.should.change(obj, 'value');
+    fn.should.change(obj, 'value').by(5);
+    fn.should.change(obj, 'value').by(-5);
+    fn.should.change(obj, 'value').but.not.by(10);
 
-    decFn.should.change(obj, "value");
-    decFn.should.change(obj, "value").by(20);
-    decFn.should.change(obj, "value").but.not.by(19);
+    decFn.should.change(obj, 'value');
+    decFn.should.change(obj, 'value').by(20);
+    decFn.should.change(obj, 'value').but.not.by(19);
 
-    sameFn.should.not.change(obj, "value");
+    sameFn.should.not.change(obj, 'value');
 
-    sameFn.should.not.change(obj, "str");
-    bangFn.should.change(obj, "str");
+    sameFn.should.not.change(obj, 'str');
+    bangFn.should.change(obj, 'str');
 
     batFn.should.change(lenFn);
     batFn.should.change(lenFn).by(1);
@@ -3399,66 +2961,52 @@ describe("should", function () {
     noFn.should.not.change(lenFn);
 
     err(function () {
-      sameFn.should.change(obj, "value", "blah");
+      (sameFn).should.change(obj, 'value', 'blah');
     }, "blah: expected .value to change");
 
     err(function () {
-      fn.should.not.change(obj, "value", "blah");
+      (fn).should.not.change(obj, 'value', 'blah');
     }, "blah: expected .value to not change");
 
     err(function () {
-      ({}).should.change(obj, "value", "blah");
+      ({}).should.change(obj, 'value', 'blah');
     }, "blah: expected {} to be a function");
 
     err(function () {
-      fn.should.change({}, "badprop", "blah");
+      (fn).should.change({}, 'badprop', 'blah');
     }, "blah: expected {} to have property 'badprop'");
 
     err(function () {
-      fn.should.change(obj, "value").by(10, "blah");
+      (fn).should.change(obj, 'value').by(10, 'blah');
     }, "blah: expected .value to change by 10");
 
     err(function () {
-      fn.should.change(obj, "value").but.not.by(5, "blah");
+      (fn).should.change(obj, 'value').but.not.by(5, 'blah');
     }, "blah: expected .value to not change by 5");
   });
 
-  it("increase, decrease", function () {
+  it('increase, decrease', function() {
     var obj = { value: 10, noop: null },
-      arr = ["one", "two"],
-      pFn = function () {
-        arr.push("three");
-      },
-      popFn = function () {
-        arr.pop();
-      },
-      lenFn = function () {
-        return arr.length;
-      },
-      nFn = function () {
-        return null;
-      },
-      incFn = function () {
-        obj.value += 2;
-      },
-      decFn = function () {
-        obj.value -= 3;
-      },
-      smFn = function () {
-        obj.value += 0;
-      };
+        arr = ['one', 'two'],
+        pFn   = function() { arr.push('three') },
+        popFn = function() { arr.pop() },
+        lenFn = function() { return arr.length },
+        nFn   = function() { return null },
+        incFn = function() { obj.value += 2 },
+        decFn = function() { obj.value -= 3 },
+        smFn  = function() { obj.value += 0 };
 
-    smFn.should.not.increase(obj, "value");
-    decFn.should.not.increase(obj, "value");
-    incFn.should.increase(obj, "value");
-    incFn.should.increase(obj, "value").by(2);
-    incFn.should.increase(obj, "value").but.not.by(1);
+    smFn.should.not.increase(obj, 'value');
+    decFn.should.not.increase(obj, 'value');
+    incFn.should.increase(obj, 'value');
+    incFn.should.increase(obj, 'value').by(2);
+    incFn.should.increase(obj, 'value').but.not.by(1);
 
-    smFn.should.not.decrease(obj, "value");
-    incFn.should.not.decrease(obj, "value");
-    decFn.should.decrease(obj, "value");
-    decFn.should.decrease(obj, "value").by(3);
-    decFn.should.decrease(obj, "value").but.not.by(2);
+    smFn.should.not.decrease(obj, 'value');
+    incFn.should.not.decrease(obj, 'value');
+    decFn.should.decrease(obj, 'value');
+    decFn.should.decrease(obj, 'value').by(3);
+    decFn.should.decrease(obj, 'value').but.not.by(2);
 
     nFn.should.not.increase(lenFn);
     nFn.should.not.decrease(lenFn);
@@ -3476,221 +3024,203 @@ describe("should", function () {
     popFn.should.decrease(lenFn).but.not.by(2);
 
     err(function () {
-      smFn.should.increase(obj, "value", "blah");
+      (smFn).should.increase(obj, 'value', 'blah');
     }, "blah: expected .value to increase");
 
     err(function () {
-      incFn.should.not.increase(obj, "value", "blah");
+      (incFn).should.not.increase(obj, 'value', 'blah');
     }, "blah: expected .value to not increase");
 
     err(function () {
-      ({}).should.increase(obj, "value", "blah");
+      ({}).should.increase(obj, 'value', 'blah');
     }, "blah: expected {} to be a function");
 
     err(function () {
-      incFn.should.increase({}, "badprop", "blah");
+      (incFn).should.increase({}, 'badprop', 'blah');
     }, "blah: expected {} to have property 'badprop'");
 
-    err(function () {
-      incFn.should.increase(obj, "noop", "blah");
-    }, "blah: expected null to be a number");
+    err(function() {
+      (incFn).should.increase(obj, 'noop', 'blah');
+    }, 'blah: expected null to be a number');
 
     err(function () {
-      incFn.should.increase(obj, "value").by(10, "blah");
+      (incFn).should.increase(obj, 'value').by(10, 'blah');
     }, "blah: expected .value to increase by 10");
 
     err(function () {
-      incFn.should.increase(obj, "value").but.not.by(2, "blah");
+      (incFn).should.increase(obj, 'value').but.not.by(2, 'blah');
     }, "blah: expected .value to not increase by 2");
 
     err(function () {
-      smFn.should.decrease(obj, "value", "blah");
+      (smFn).should.decrease(obj, 'value', 'blah');
     }, "blah: expected .value to decrease");
 
     err(function () {
-      decFn.should.not.decrease(obj, "value", "blah");
+      (decFn).should.not.decrease(obj, 'value', 'blah');
     }, "blah: expected .value to not decrease");
 
     err(function () {
-      ({}).should.decrease(obj, "value", "blah");
+      ({}).should.decrease(obj, 'value', 'blah');
     }, "blah: expected {} to be a function");
 
     err(function () {
-      decFn.should.decrease({}, "badprop", "blah");
+      (decFn).should.decrease({}, 'badprop', 'blah');
     }, "blah: expected {} to have property 'badprop'");
 
-    err(function () {
-      decFn.should.decrease(obj, "noop", "blah");
-    }, "blah: expected null to be a number");
+    err(function() {
+      (decFn).should.decrease(obj, 'noop', 'blah');
+    }, 'blah: expected null to be a number');
 
     err(function () {
-      decFn.should.decrease(obj, "value").by(10, "blah");
+      (decFn).should.decrease(obj, 'value').by(10, 'blah');
     }, "blah: expected .value to decrease by 10");
 
     err(function () {
-      decFn.should.decrease(obj, "value").but.not.by(3, "blah");
+      (decFn).should.decrease(obj, 'value').but.not.by(3, 'blah');
     }, "blah: expected .value to not decrease by 3");
   });
 
-  it("extensible", function () {
-    var nonExtensibleObject = Object.preventExtensions({});
+  it('extensible', function() {
+     var nonExtensibleObject = Object.preventExtensions({});
 
-    ({}).should.be.extensible;
-    nonExtensibleObject.should.not.be.extensible;
+     ({}).should.be.extensible;
+     nonExtensibleObject.should.not.be.extensible;
 
-    err(function () {
-      nonExtensibleObject.should.be.extensible;
-    }, "expected {} to be extensible");
+     err(function() {
+       nonExtensibleObject.should.be.extensible;
+     }, 'expected {} to be extensible');
 
-    err(function () {
-      ({}).should.not.be.extensible;
-    }, "expected {} to not be extensible");
+     err(function() {
+       ({}).should.not.be.extensible;
+     }, 'expected {} to not be extensible');
 
-    // Making sure ES6-like Object.isExtensible response is respected for all primitive types
+     // Making sure ES6-like Object.isExtensible response is respected for all primitive types
 
-    (42).should.not.be.extensible;
-    "foo".should.not.be.extensible;
-    false.should.not.be.extensible;
+     (42).should.not.be.extensible;
+     'foo'.should.not.be.extensible;
+     false.should.not.be.extensible;
 
-    Symbol().should.not.be.extensible;
+     Symbol().should.not.be.extensible;
 
-    err(function () {
-      (42).should.be.extensible;
-    }, "expected 42 to be extensible");
+     err(function() {
+       (42).should.be.extensible;
+     }, 'expected 42 to be extensible');
 
-    err(function () {
-      "foo".should.be.extensible;
-    }, "expected 'foo' to be extensible");
+     err(function() {
+       'foo'.should.be.extensible;
+     }, 'expected \'foo\' to be extensible');
 
-    err(function () {
-      false.should.be.extensible;
-    }, "expected false to be extensible");
+     err(function() {
+       false.should.be.extensible;
+     }, 'expected false to be extensible');
 
-    var proxy = new Proxy(
-      {},
-      {
-        isExtensible: function () {
-          throw new TypeError();
-        },
-      },
-    );
+    var proxy = new Proxy({}, {
+      isExtensible: function() {
+        throw new TypeError();
+      }
+    });
 
-    err(
-      function () {
-        // .extensible should not suppress errors, thrown in proxy traps
-        proxy.should.be.extensible;
-      },
-      { name: "TypeError" },
-    );
+    err(function() {
+      // .extensible should not suppress errors, thrown in proxy traps
+      proxy.should.be.extensible;
+    }, { name: 'TypeError' });
   });
 
-  it("sealed", function () {
+  it('sealed', function() {
     var sealedObject = Object.seal({});
 
     sealedObject.should.be.sealed;
     ({}).should.not.be.sealed;
 
-    err(function () {
+    err(function() {
       ({}).should.be.sealed;
-    }, "expected {} to be sealed");
+    }, 'expected {} to be sealed');
 
-    err(function () {
+    err(function() {
       sealedObject.should.not.be.sealed;
-    }, "expected {} to not be sealed");
+    }, 'expected {} to not be sealed');
 
     // Making sure ES6-like Object.isSealed response is respected for all primitive types
 
     (42).should.be.sealed;
-    "foo".should.be.sealed;
+    'foo'.should.be.sealed;
     false.should.be.sealed;
 
     Symbol().should.be.sealed;
 
-    err(function () {
+    err(function() {
       (42).should.not.be.sealed;
-    }, "expected 42 to not be sealed");
+    }, 'expected 42 to not be sealed');
 
-    err(function () {
-      "foo".should.not.be.sealed;
-    }, "expected 'foo' to not be sealed");
+    err(function() {
+      'foo'.should.not.be.sealed;
+    }, 'expected \'foo\' to not be sealed');
 
-    err(function () {
+    err(function() {
       false.should.not.be.sealed;
-    }, "expected false to not be sealed");
+    }, 'expected false to not be sealed');
 
-    var proxy = new Proxy(
-      {},
-      {
-        ownKeys: function () {
-          throw new TypeError();
-        },
-      },
-    );
+    var proxy = new Proxy({}, {
+      ownKeys: function() {
+        throw new TypeError();
+      }
+    });
 
     // Object.isSealed will call ownKeys trap only if object is not extensible
     Object.preventExtensions(proxy);
 
-    err(
-      function () {
-        // .sealed should not suppress errors, thrown in proxy traps
-        proxy.should.be.sealed;
-      },
-      { name: "TypeError" },
-    );
+    err(function() {
+      // .sealed should not suppress errors, thrown in proxy traps
+      proxy.should.be.sealed;
+    }, { name: 'TypeError' });
   });
 
-  it("frozen", function () {
+  it('frozen', function() {
     var frozenObject = Object.freeze({});
 
     frozenObject.should.be.frozen;
     ({}).should.not.be.frozen;
 
-    err(function () {
-      ({}).should.be.frozen;
-    }, "expected {} to be frozen");
+    err(function() {
+        ({}).should.be.frozen;
+    }, 'expected {} to be frozen');
 
-    err(function () {
-      frozenObject.should.not.be.frozen;
-    }, "expected {} to not be frozen");
+    err(function() {
+        frozenObject.should.not.be.frozen;
+    }, 'expected {} to not be frozen');
 
     // Making sure ES6-like Object.isFrozen response is respected for all primitive types
 
     (42).should.be.frozen;
-    "foo".should.be.frozen;
+    'foo'.should.be.frozen;
     false.should.be.frozen;
 
     Symbol().should.be.frozen;
 
-    err(function () {
+    err(function() {
       (42).should.not.be.frozen;
-    }, "expected 42 to not be frozen");
+    }, 'expected 42 to not be frozen');
 
-    err(function () {
-      "foo".should.not.be.frozen;
-    }, "expected 'foo' to not be frozen");
+    err(function() {
+      'foo'.should.not.be.frozen;
+    }, 'expected \'foo\' to not be frozen');
 
-    err(function () {
+    err(function() {
       false.should.not.be.frozen;
-    }, "expected false to not be frozen");
+    }, 'expected false to not be frozen');
 
-    var proxy = new Proxy(
-      {},
-      {
-        ownKeys: function () {
-          throw new TypeError();
-        },
-      },
-    );
+    var proxy = new Proxy({}, {
+      ownKeys: function() {
+        throw new TypeError();
+      }
+    });
 
     // Object.isFrozen will call ownKeys trap only if object is not extensible
     Object.preventExtensions(proxy);
 
-    err(
-      function () {
-        // .frozen should not suppress errors, thrown in proxy traps
-        proxy.should.be.frozen;
-      },
-      { name: "TypeError" },
-    );
+    err(function() {
+      // .frozen should not suppress errors, thrown in proxy traps
+      proxy.should.be.frozen;
+    }, { name: 'TypeError' });
   });
 });

--- a/test/should.js
+++ b/test/should.js
@@ -1,49 +1,71 @@
-import * as chai from '../index.js';
-import {globalErr as err} from './bootstrap/index.js';
+import * as chai from "../index.js";
+import { globalErr as err } from "./bootstrap/index.js";
 
-describe('should', function() {
+describe("should", function () {
   var should = chai.Should();
 
-  it('assertion', function(){
-    'test'.should.be.a('string');
-    should.equal('foo', 'foo');
-    should.not.equal('foo', 'bar');
+  it("assertion", function () {
+    "test".should.be.a("string");
+    should.equal("foo", "foo");
+    should.not.equal("foo", "bar");
   });
 
-  describe('safeguards', function () {
+  describe("safeguards", function () {
     before(function () {
-      chai.util.addProperty(chai.Assertion.prototype, 'tmpProperty', function () {
-        new chai.Assertion(42).equal(42);
-      });
-      chai.util.overwriteProperty(chai.Assertion.prototype, 'tmpProperty', function (_super) {
-        return function () {
-          _super.call(this);
-        };
-      });
+      chai.util.addProperty(
+        chai.Assertion.prototype,
+        "tmpProperty",
+        function () {
+          new chai.Assertion(42).equal(42);
+        },
+      );
+      chai.util.overwriteProperty(
+        chai.Assertion.prototype,
+        "tmpProperty",
+        function (_super) {
+          return function () {
+            _super.call(this);
+          };
+        },
+      );
 
-      chai.util.addMethod(chai.Assertion.prototype, 'tmpMethod', function () {
+      chai.util.addMethod(chai.Assertion.prototype, "tmpMethod", function () {
         new chai.Assertion(42).equal(42);
       });
-      chai.util.overwriteMethod(chai.Assertion.prototype, 'tmpMethod', function (_super) {
-        return function () {
-          _super.call(this);
-        };
-      });
+      chai.util.overwriteMethod(
+        chai.Assertion.prototype,
+        "tmpMethod",
+        function (_super) {
+          return function () {
+            _super.call(this);
+          };
+        },
+      );
 
-      chai.util.addChainableMethod(chai.Assertion.prototype, 'tmpChainableMethod', function () {
-        new chai.Assertion(42).equal(42);
-      }, function () {
-        new chai.Assertion(42).equal(42);
-      });
-      chai.util.overwriteChainableMethod(chai.Assertion.prototype, 'tmpChainableMethod', function (_super) {
-        return function () {
-          _super.call(this);
-        };
-      }, function (_super) {
-        return function () {
-          _super.call(this);
-        };
-      });
+      chai.util.addChainableMethod(
+        chai.Assertion.prototype,
+        "tmpChainableMethod",
+        function () {
+          new chai.Assertion(42).equal(42);
+        },
+        function () {
+          new chai.Assertion(42).equal(42);
+        },
+      );
+      chai.util.overwriteChainableMethod(
+        chai.Assertion.prototype,
+        "tmpChainableMethod",
+        function (_super) {
+          return function () {
+            _super.call(this);
+          };
+        },
+        function (_super) {
+          return function () {
+            _super.call(this);
+          };
+        },
+      );
     });
 
     after(function () {
@@ -52,344 +74,447 @@ describe('should', function() {
       delete chai.Assertion.prototype.tmpChainableMethod;
     });
 
-    describe('proxify', function () {
-      it('throws when invalid property follows should', function () {
-        err(function () {
-          (42).should.pizza;
-        }, 'Invalid Chai property: pizza', true);
+    describe("proxify", function () {
+      it("throws when invalid property follows should", function () {
+        err(
+          function () {
+            (42).should.pizza;
+          },
+          "Invalid Chai property: pizza",
+          true,
+        );
       });
 
-      it('throws when invalid property follows language chain', function () {
-        err(function () {
-          (42).should.to.pizza;
-        }, 'Invalid Chai property: pizza', true);
+      it("throws when invalid property follows language chain", function () {
+        err(
+          function () {
+            (42).should.to.pizza;
+          },
+          "Invalid Chai property: pizza",
+          true,
+        );
       });
 
-      it('throws when invalid property follows property assertion', function () {
-        err(function () {
-          (42).should.ok.pizza;
-        }, 'Invalid Chai property: pizza', true);
+      it("throws when invalid property follows property assertion", function () {
+        err(
+          function () {
+            (42).should.ok.pizza;
+          },
+          "Invalid Chai property: pizza",
+          true,
+        );
       });
 
-      it('throws when invalid property follows overwritten property assertion', function () {
-        err(function () {
-          (42).should.tmpProperty.pizza;
-        }, 'Invalid Chai property: pizza', true);
+      it("throws when invalid property follows overwritten property assertion", function () {
+        err(
+          function () {
+            (42).should.tmpProperty.pizza;
+          },
+          "Invalid Chai property: pizza",
+          true,
+        );
       });
 
-      it('throws when invalid property follows uncalled method assertion', function () {
-        err(function () {
-          (42).should.equal.pizza;
-        }, 'Invalid Chai property: equal.pizza. See docs for proper usage of "equal".', true);
+      it("throws when invalid property follows uncalled method assertion", function () {
+        err(
+          function () {
+            (42).should.equal.pizza;
+          },
+          'Invalid Chai property: equal.pizza. See docs for proper usage of "equal".',
+          true,
+        );
       });
 
-      it('throws when invalid property follows called method assertion', function () {
-        err(function () {
-          (42).should.equal(42).pizza;
-        }, 'Invalid Chai property: pizza', true);
+      it("throws when invalid property follows called method assertion", function () {
+        err(
+          function () {
+            (42).should.equal(42).pizza;
+          },
+          "Invalid Chai property: pizza",
+          true,
+        );
       });
 
-      it('throws when invalid property follows uncalled overwritten method assertion', function () {
-        err(function () {
-          (42).should.tmpMethod.pizza;
-        }, 'Invalid Chai property: tmpMethod.pizza. See docs for proper usage of "tmpMethod".', true);
+      it("throws when invalid property follows uncalled overwritten method assertion", function () {
+        err(
+          function () {
+            (42).should.tmpMethod.pizza;
+          },
+          'Invalid Chai property: tmpMethod.pizza. See docs for proper usage of "tmpMethod".',
+          true,
+        );
       });
 
-      it('throws when invalid property follows called overwritten method assertion', function () {
-        err(function () {
-          (42).should.tmpMethod().pizza;
-        }, 'Invalid Chai property: pizza', true);
+      it("throws when invalid property follows called overwritten method assertion", function () {
+        err(
+          function () {
+            (42).should.tmpMethod().pizza;
+          },
+          "Invalid Chai property: pizza",
+          true,
+        );
       });
 
-      it('throws when invalid property follows uncalled chainable method assertion', function () {
-        err(function () {
-          (42).should.a.pizza;
-        }, 'Invalid Chai property: pizza', true);
+      it("throws when invalid property follows uncalled chainable method assertion", function () {
+        err(
+          function () {
+            (42).should.a.pizza;
+          },
+          "Invalid Chai property: pizza",
+          true,
+        );
       });
 
-      it('throws when invalid property follows called chainable method assertion', function () {
-        err(function () {
-          (42).should.a('number').pizza;
-        }, 'Invalid Chai property: pizza', true);
+      it("throws when invalid property follows called chainable method assertion", function () {
+        err(
+          function () {
+            (42).should.a("number").pizza;
+          },
+          "Invalid Chai property: pizza",
+          true,
+        );
       });
 
-      it('throws when invalid property follows uncalled overwritten chainable method assertion', function () {
-        err(function () {
-          (42).should.tmpChainableMethod.pizza;
-        }, 'Invalid Chai property: pizza', true);
+      it("throws when invalid property follows uncalled overwritten chainable method assertion", function () {
+        err(
+          function () {
+            (42).should.tmpChainableMethod.pizza;
+          },
+          "Invalid Chai property: pizza",
+          true,
+        );
       });
 
-      it('throws when invalid property follows called overwritten chainable method assertion', function () {
-        err(function () {
-          (42).should.tmpChainableMethod().pizza;
-        }, 'Invalid Chai property: pizza', true);
+      it("throws when invalid property follows called overwritten chainable method assertion", function () {
+        err(
+          function () {
+            (42).should.tmpChainableMethod().pizza;
+          },
+          "Invalid Chai property: pizza",
+          true,
+        );
       });
 
-      it('doesn\'t throw if invalid property is excluded via config', function () {
+      it("doesn't throw if invalid property is excluded via config", function () {
         (function () {
           (42).should.then;
         }).should.not.throw();
       });
     });
 
-    describe('length guard', function () {
-      var fnLengthDesc = Object.getOwnPropertyDescriptor(function () {}, 'length');
+    describe("length guard", function () {
+      var fnLengthDesc = Object.getOwnPropertyDescriptor(
+        function () {},
+        "length",
+      );
       if (!fnLengthDesc.configurable) return;
 
-      it('doesn\'t throw when `.length` follows `.should`', function () {
+      it("doesn't throw when `.length` follows `.should`", function () {
         (function () {
-          ('foo').should.length;
+          "foo".should.length;
         }).should.not.throw();
       });
 
-      it('doesn\'t throw when `.length` follows language chain', function () {
+      it("doesn't throw when `.length` follows language chain", function () {
         (function () {
-          ('foo').should.to.length;
+          "foo".should.to.length;
         }).should.not.throw();
       });
 
-      it('doesn\'t throw when `.length` follows property assertion', function () {
+      it("doesn't throw when `.length` follows property assertion", function () {
         (function () {
-          ('foo').should.ok.length;
+          "foo".should.ok.length;
         }).should.not.throw();
       });
 
-      it('doesn\'t throw when `.length` follows overwritten property assertion', function () {
+      it("doesn't throw when `.length` follows overwritten property assertion", function () {
         (function () {
-          ('foo').should.tmpProperty.length;
+          "foo".should.tmpProperty.length;
         }).should.not.throw();
       });
 
-      it('throws when `.length` follows uncalled method assertion', function () {
-        err(function () {
-          ('foo').should.equal.length;
-        }, 'Invalid Chai property: equal.length. See docs for proper usage of "equal".', true);
+      it("throws when `.length` follows uncalled method assertion", function () {
+        err(
+          function () {
+            "foo".should.equal.length;
+          },
+          'Invalid Chai property: equal.length. See docs for proper usage of "equal".',
+          true,
+        );
       });
 
-      it('doesn\'t throw when `.length` follows called method assertion', function () {
+      it("doesn't throw when `.length` follows called method assertion", function () {
         (function () {
-          ('foo').should.equal('foo').length;
+          "foo".should.equal("foo").length;
         }).should.not.throw();
       });
 
-      it('throws when `.length` follows uncalled overwritten method assertion', function () {
-        err(function () {
-          ('foo').should.tmpMethod.length;
-        }, 'Invalid Chai property: tmpMethod.length. See docs for proper usage of "tmpMethod".', true);
+      it("throws when `.length` follows uncalled overwritten method assertion", function () {
+        err(
+          function () {
+            "foo".should.tmpMethod.length;
+          },
+          'Invalid Chai property: tmpMethod.length. See docs for proper usage of "tmpMethod".',
+          true,
+        );
       });
 
-      it('doesn\'t throw when `.length` follows called overwritten method assertion', function () {
+      it("doesn't throw when `.length` follows called overwritten method assertion", function () {
         (function () {
-          ('foo').should.tmpMethod().length;
+          "foo".should.tmpMethod().length;
         }).should.not.throw();
       });
 
-      it('throws when `.length` follows uncalled chainable method assertion', function () {
-        err(function () {
-          ('foo').should.a.length;
-        }, 'Invalid Chai property: a.length. Due to a compatibility issue, "length" cannot directly follow "a". Use "a.lengthOf" instead.', true);
+      it("throws when `.length` follows uncalled chainable method assertion", function () {
+        err(
+          function () {
+            "foo".should.a.length;
+          },
+          'Invalid Chai property: a.length. Due to a compatibility issue, "length" cannot directly follow "a". Use "a.lengthOf" instead.',
+          true,
+        );
       });
 
-      it('doesn\'t throw when `.length` follows called chainable method assertion', function () {
+      it("doesn't throw when `.length` follows called chainable method assertion", function () {
         (function () {
-          ('foo').should.a('string').length;
+          "foo".should.a("string").length;
         }).should.not.throw();
       });
 
-      it('throws when `.length` follows uncalled overwritten chainable method assertion', function () {
-        err(function () {
-          ('foo').should.tmpChainableMethod.length;
-        }, 'Invalid Chai property: tmpChainableMethod.length. Due to a compatibility issue, "length" cannot directly follow "tmpChainableMethod". Use "tmpChainableMethod.lengthOf" instead.', true);
+      it("throws when `.length` follows uncalled overwritten chainable method assertion", function () {
+        err(
+          function () {
+            "foo".should.tmpChainableMethod.length;
+          },
+          'Invalid Chai property: tmpChainableMethod.length. Due to a compatibility issue, "length" cannot directly follow "tmpChainableMethod". Use "tmpChainableMethod.lengthOf" instead.',
+          true,
+        );
       });
 
-      it('doesn\'t throw when `.length` follows called overwritten chainable method assertion', function () {
+      it("doesn't throw when `.length` follows called overwritten chainable method assertion", function () {
         (function () {
-          ('foo').should.tmpChainableMethod().length;
+          "foo".should.tmpChainableMethod().length;
         }).should.not.throw();
       });
     });
   });
 
-  it('no-op chains', function() {
+  it("no-op chains", function () {
     function test(chain) {
       // tests that chain exists
-      ((1).should[chain]).should.not.undefined;
+      (1).should[chain].should.not.undefined;
 
       // tests methods
       (1).should[chain].equal(1);
 
       // tests properties that assert
-      (false).should[chain].false;
+      false.should[chain].false;
 
       // tests not
-      (false).should[chain].not.true;
+      false.should[chain].not.true;
 
       // tests chainable methods
       [1, 2, 3].should[chain].contains(1);
     }
 
-    [ 'to', 'be', 'been', 'is'
-    , 'and', 'has', 'have', 'with'
-    , 'that', 'which', 'at', 'of'
-    , 'same', 'but', 'does', 'still' ].forEach(test);
+    [
+      "to",
+      "be",
+      "been",
+      "is",
+      "and",
+      "has",
+      "have",
+      "with",
+      "that",
+      "which",
+      "at",
+      "of",
+      "same",
+      "but",
+      "does",
+      "still",
+    ].forEach(test);
   });
 
-  describe("fail", function() {
-    it('should accept a message as the 3rd argument', function () {
-      err(function() {
-        should.fail(0, 1, 'this has failed');
+  describe("fail", function () {
+    it("should accept a message as the 3rd argument", function () {
+      err(function () {
+        should.fail(0, 1, "this has failed");
       }, /this has failed/);
     });
 
-    it('should accept a message as the only argument', function () {
-      err(function() {
-        should.fail('this has failed');
+    it("should accept a message as the only argument", function () {
+      err(function () {
+        should.fail("this has failed");
       }, /this has failed/);
     });
 
-    it('should produce a default message when called without any arguments', function () {
-      err(function() {
+    it("should produce a default message when called without any arguments", function () {
+      err(function () {
         should.fail();
       }, /should\.fail()/);
     });
   });
 
-  it('root exist', function () {
-    var foo = 'foo'
-      , bar = undefined;
+  it("root exist", function () {
+    var foo = "foo",
+      bar = undefined;
     should.exist(foo);
     should.not.exist(bar);
     should.exist(0);
     should.exist(false);
-    should.exist('');
+    should.exist("");
 
     err(function () {
-      should.exist(bar, 'blah');
+      should.exist(bar, "blah");
     }, "blah: expected undefined to exist");
 
     err(function () {
-      should.not.exist(foo, 'blah');
+      should.not.exist(foo, "blah");
     }, "blah: expected 'foo' to not exist");
   });
 
-  it('root equal', function () {
-    var value1 = 'value'
-      , value2 = 'value'
-      , foo = 'foo';
+  it("root equal", function () {
+    var value1 = "value",
+      value2 = "value",
+      foo = "foo";
     should.equal(value1, value2);
     should.not.equal(value1, foo);
 
     err(function () {
-      should.equal(value1, foo, 'blah');
+      should.equal(value1, foo, "blah");
     }, "blah: expected 'value' to equal 'foo'");
 
     err(function () {
-      should.not.equal(value1, value2, 'blah');
-    }, "blah: expected 'value' to not equal 'value'")
+      should.not.equal(value1, value2, "blah");
+    }, "blah: expected 'value' to not equal 'value'");
   });
 
-  it('root Throw', function () {
-    should.Throw(function() { throw new Error('error!') }, Error, 'error!');
-    should.not.Throw(function () { });
+  it("root Throw", function () {
+    should.Throw(
+      function () {
+        throw new Error("error!");
+      },
+      Error,
+      "error!",
+    );
+    should.not.Throw(function () {});
 
     err(function () {
-      should.Throw(function () { throw new Error('error!') }, Error, 'needed user!', 'blah');
+      should.Throw(
+        function () {
+          throw new Error("error!");
+        },
+        Error,
+        "needed user!",
+        "blah",
+      );
     }, "blah: expected [Function] to throw error including 'needed user!' but got 'error!'");
 
     err(function () {
-      should.not.Throw(function () { throw new Error('error!') }, Error, 'error!', 'blah');
+      should.not.Throw(
+        function () {
+          throw new Error("error!");
+        },
+        Error,
+        "error!",
+        "blah",
+      );
     }, "blah: expected [Function] to not throw 'Error' but 'Error: error!' was thrown");
   });
 
-  it('true', function(){
-    (true).should.be.true;
+  it("true", function () {
+    true.should.be.true;
     false.should.not.be.true;
-    (1).should.not.be.true;false
+    (1).should.not.be.true;
+    false;
     false.should.have.been.false;
 
-    err(function(){
-      'test'.should.be.true;
-    }, "expected 'test' to be true")
+    err(function () {
+      "test".should.be.true;
+    }, "expected 'test' to be true");
   });
 
-  it('ok', function(){
+  it("ok", function () {
     true.should.be.ok;
     false.should.not.be.ok;
     (1).should.be.ok;
     (0).should.not.be.ok;
 
-    err(function(){
-      ''.should.be.ok;
+    err(function () {
+      "".should.be.ok;
     }, "expected '' to be truthy");
 
-    err(function(){
-      'test'.should.not.be.ok;
+    err(function () {
+      "test".should.not.be.ok;
     }, "expected 'test' to be falsy");
   });
 
-  it('false', function(){
+  it("false", function () {
     false.should.be.false;
     true.should.not.be.false;
     (0).should.not.be.false;
 
-    err(function(){
-      ''.should.be.false;
-    }, "expected '' to be false")
+    err(function () {
+      "".should.be.false;
+    }, "expected '' to be false");
   });
 
-  it('null', function(){
+  it("null", function () {
     (0).should.not.be.null;
 
-    err(function(){
-      ''.should.be.null;
-    }, "expected '' to be null")
+    err(function () {
+      "".should.be.null;
+    }, "expected '' to be null");
   });
 
-  it('NaN', function(){
+  it("NaN", function () {
     NaN.should.be.NaN;
 
     Infinity.should.not.be.NaN;
-    'foo'.should.not.be.NaN;
+    "foo".should.not.be.NaN;
     ({}).should.not.be.NaN;
     should.not.equal(undefined, NaN);
     (4).should.not.be.NaN;
 
-    err(function(){
+    err(function () {
       NaN.should.not.be.NaN;
     }, "expected NaN not to be NaN");
 
-    err(function(){
+    err(function () {
       Infinity.should.be.NaN;
     }, "expected Infinity to be NaN");
 
-    err(function(){
-      'foo'.should.be.NaN;
+    err(function () {
+      "foo".should.be.NaN;
     }, "expected 'foo' to be NaN");
 
-    err(function(){
+    err(function () {
       ({}).should.be.NaN;
     }, "expected {} to be NaN");
 
-    err(function(){
+    err(function () {
       should.equal(undefined, NaN);
     }, "expected undefined to equal NaN");
 
-    err(function(){
+    err(function () {
       (4).should.be.NaN;
     }, "expected 4 to be NaN");
-
   });
 
-  it('undefined', function(){
+  it("undefined", function () {
     (0).should.not.be.undefined;
 
-    err(function(){
-      ''.should.be.undefined;
-    }, "expected '' to be undefined")
+    err(function () {
+      "".should.be.undefined;
+    }, "expected '' to be undefined");
   });
 
-  it('arguments', function(){
-    var args = (function(){ return arguments; })(1,2,3);
+  it("arguments", function () {
+    var args = (function () {
+      return arguments;
+    })(1, 2, 3);
     args.should.be.arguments;
     [].should.not.be.arguments;
 
@@ -398,14 +523,16 @@ describe('should', function() {
     }, "expected [] to be arguments but got Array");
   });
 
-  it('".should" getter should unbox primitive values', function(){
+  it('".should" getter should unbox primitive values', function () {
     function assert(value) {
       const AssertionObject = value.should;
       const type = typeof value;
       if (AssertionObject.__flags.object !== value) {
-        throw new Error("value `"+ value.toString() +"` ("+ type +") wasn't unboxed");
+        throw new Error(
+          "value `" + value.toString() + "` (" + type + ") wasn't unboxed",
+        );
       }
-    };
+    }
 
     assert("a");
     assert(0);
@@ -415,37 +542,39 @@ describe('should', function() {
     assert(BigInt(10));
   });
 
-  it('.equal()', function(){
+  it(".equal()", function () {
     var foo;
     should.equal(undefined, foo);
   });
 
-  it('typeof', function(){
-    'test'.should.be.a('string');
+  it("typeof", function () {
+    "test".should.be.a("string");
 
-    err(function(){
-      'test'.should.not.be.a('string');
+    err(function () {
+      "test".should.not.be.a("string");
     }, "expected 'test' not to be a string");
 
-    (5).should.be.a('number');
-    (new Number(1)).should.be.a('number');
-    Number(1).should.be.a('number');
-    (true).should.be.a('boolean');
-    (new Array()).should.be.a('array');
-    (new Object()).should.be.a('object');
-    ({}).should.be.a('object');
-    ([]).should.be.a('array');
-    (function() {}).should.be.a('function');
-    Symbol().should.be.a('symbol');
-    (5).should.be.a('number');
+    (5).should.be.a("number");
+    new Number(1).should.be.a("number");
+    Number(1).should.be.a("number");
+    true.should.be.a("boolean");
+    new Array().should.be.a("array");
+    new Object().should.be.a("object");
+    ({}).should.be.a("object");
+    [].should.be.a("array");
+    (function () {}).should.be.a("function");
+    (async function* () {}).should.be.a("function");
+    (async function () {}).should.be.a("asyncfunction");
+    Symbol().should.be.a("symbol");
+    (5).should.be.a("number");
 
-    err(function(){
-      (5).should.not.be.a('number', 'blah');
+    err(function () {
+      (5).should.not.be.a("number", "blah");
     }, "blah: expected 5 not to be a number");
   });
 
-  it('instanceof', function(){
-    function Foo(){}
+  it("instanceof", function () {
+    function Foo() {}
     new Foo().should.be.an.instanceof(Foo);
 
     // Normally, `instanceof` requires that the constructor be a function or an
@@ -453,48 +582,54 @@ describe('should', function() {
     // as IE11, `instanceof` also accepts DOM-related interfaces such as
     // `HTMLElement`, despite being non-callable objects in those browsers.
     // See: https://github.com/chaijs/chai/issues/1000.
-    if (typeof document !== 'undefined' &&
-        typeof document.createElement !== 'undefined' &&
-        typeof HTMLElement !== 'undefined') {
-      document.createElement('div').should.be.an.instanceof(HTMLElement);
+    if (
+      typeof document !== "undefined" &&
+      typeof document.createElement !== "undefined" &&
+      typeof HTMLElement !== "undefined"
+    ) {
+      document.createElement("div").should.be.an.instanceof(HTMLElement);
     }
 
-    err(function(){
-      new Foo().should.be.an.instanceof(1, 'blah');
+    err(function () {
+      new Foo().should.be.an.instanceof(1, "blah");
     }, "blah: The instanceof assertion needs a constructor but Number was given.");
 
-    err(function(){
-      new Foo().should.be.an.instanceof('batman');
+    err(function () {
+      new Foo().should.be.an.instanceof("batman");
     }, "The instanceof assertion needs a constructor but String was given.");
 
-    err(function(){
+    err(function () {
       new Foo().should.be.an.instanceof({});
     }, "The instanceof assertion needs a constructor but Object was given.");
 
-    err(function(){
+    err(function () {
       new Foo().should.be.an.instanceof(true);
     }, "The instanceof assertion needs a constructor but Boolean was given.");
 
-    err(function(){
+    err(function () {
       new Foo().should.be.an.instanceof(null);
     }, "The instanceof assertion needs a constructor but null was given.");
 
-    err(function(){
+    err(function () {
       new Foo().should.be.an.instanceof(undefined);
     }, "The instanceof assertion needs a constructor but undefined was given.");
 
-    err(function(){
-      function Thing(){};
-      var t = new Thing();
-      Thing.prototype = 1337;
-      t.should.be.an.instanceof(Thing);
-    }, 'The instanceof assertion needs a constructor but Function was given.', true);
+    err(
+      function () {
+        function Thing() {}
+        var t = new Thing();
+        Thing.prototype = 1337;
+        t.should.be.an.instanceof(Thing);
+      },
+      "The instanceof assertion needs a constructor but Function was given.",
+      true,
+    );
 
-    err(function(){
+    err(function () {
       new Foo().should.be.an.instanceof(Symbol());
     }, "The instanceof assertion needs a constructor but Symbol was given.");
 
-    err(function() {
+    err(function () {
       var FakeConstructor = {};
       var fakeInstanceB = 4;
       FakeConstructor[Symbol.hasInstance] = function (val) {
@@ -502,9 +637,9 @@ describe('should', function() {
       };
 
       fakeInstanceB.should.be.an.instanceof(FakeConstructor);
-    }, 'expected 4 to be an instance of an unnamed constructor');
+    }, "expected 4 to be an instance of an unnamed constructor");
 
-    err(function() {
+    err(function () {
       var FakeConstructor = {};
       var fakeInstanceB = 4;
       FakeConstructor[Symbol.hasInstance] = function (val) {
@@ -512,90 +647,90 @@ describe('should', function() {
       };
 
       fakeInstanceB.should.not.be.an.instanceof(FakeConstructor);
-    }, 'expected 4 to not be an instance of an unnamed constructor');
+    }, "expected 4 to not be an instance of an unnamed constructor");
 
-    err(function(){
-      (3).should.an.instanceof(Foo, 'blah');
+    err(function () {
+      (3).should.an.instanceof(Foo, "blah");
     }, "blah: expected 3 to be an instance of Foo");
   });
 
-  it('within(start, finish)', function(){
+  it("within(start, finish)", function () {
     (5).should.be.within(5, 10);
-    (5).should.be.within(3,6);
-    (5).should.be.within(3,5);
-    (5).should.not.be.within(1,3);
+    (5).should.be.within(3, 6);
+    (5).should.be.within(3, 5);
+    (5).should.not.be.within(1, 3);
 
-    err(function(){
-      (5).should.not.be.within(4,6, 'blah');
+    err(function () {
+      (5).should.not.be.within(4, 6, "blah");
     }, "blah: expected 5 to not be within 4..6");
 
-    err(function(){
-      (10).should.be.within(50,100, 'blah');
+    err(function () {
+      (10).should.be.within(50, 100, "blah");
     }, "blah: expected 10 to be within 50..100");
 
-    err(function(){
-      ({ foo: 1 }).should.have.length.within(50,100, 'blah');
-    }, "blah: expected { foo: 1 } to have property 'length'");
-
-    err(function(){
-      ({ foo: 1 }).should.have.lengthOf.within(50,100, 'blah');
+    err(function () {
+      ({ foo: 1 }).should.have.length.within(50, 100, "blah");
     }, "blah: expected { foo: 1 } to have property 'length'");
 
     err(function () {
-      ('string').should.be.within(0, 1, 'blah');
+      ({ foo: 1 }).should.have.lengthOf.within(50, 100, "blah");
+    }, "blah: expected { foo: 1 } to have property 'length'");
+
+    err(function () {
+      "string".should.be.within(0, 1, "blah");
     }, "blah: expected 'string' to be a number or a date");
 
     err(function () {
-      (1).should.be.within(null, 1, 'blah');
+      (1).should.be.within(null, 1, "blah");
     }, "blah: the arguments to within must be numbers");
 
     err(function () {
-      (1).should.be.within(0, null, 'blah');
+      (1).should.be.within(0, null, "blah");
     }, "blah: the arguments to within must be numbers");
 
     err(function () {
-      ('string').should.not.be.within(0, 1, 'blah');
+      "string".should.not.be.within(0, 1, "blah");
     }, "blah: expected 'string' to be a number or a date");
 
     err(function () {
-      (1).should.not.be.within(null, 1, 'blah');
+      (1).should.not.be.within(null, 1, "blah");
     }, "blah: the arguments to within must be numbers");
 
     err(function () {
-      (1).should.not.be.within(0, null, 'blah');
+      (1).should.not.be.within(0, null, "blah");
     }, "blah: the arguments to within must be numbers");
 
     err(function () {
-      (1).should.have.length.within(5,7, 'blah');
+      (1).should.have.length.within(5, 7, "blah");
     }, "blah: expected 1 to have property 'length'");
 
     err(function () {
-      (1).should.have.lengthOf.within(5,7, 'blah');
+      (1).should.have.lengthOf.within(5, 7, "blah");
     }, "blah: expected 1 to have property 'length'");
 
-    (new Map).should.have.length.within(0, 0);
-    (new Map).should.have.lengthOf.within(0, 0);
+    new Map().should.have.length.within(0, 0);
+    new Map().should.have.lengthOf.within(0, 0);
 
-    var map = new Map;
-    map.set('a', 1);
-    map.set('b', 2);
-    map.set('c', 3);
+    var map = new Map();
+    map.set("a", 1);
+    map.set("b", 2);
+    map.set("c", 3);
 
     map.should.have.length.within(2, 4);
     map.should.have.lengthOf.within(2, 4);
 
     err(function () {
-      map.should.have.length.within(5, 7, 'blah');
+      map.should.have.length.within(5, 7, "blah");
     }, "blah: expected Map{ 'a' => 1, 'b' => 2, 'c' => 3 } to have a size within 5..7");
 
     err(function () {
-      map.should.have.lengthOf.within(5, 7, 'blah');
+      map.should.have.lengthOf.within(5, 7, "blah");
     }, "blah: expected Map{ 'a' => 1, 'b' => 2, 'c' => 3 } to have a size within 5..7");
 
-    (new Set).should.have.length.within(0, 0);
-    (new Set).should.have.lengthOf.within(0, 0);
+    new Set().should.have.length.within(0, 0);
+    new Set().should.have.lengthOf.within(0, 0);
 
-    var set = new Set;
+    var set = new Set();
     set.add(1);
     set.add(2);
     set.add(3);
@@ -604,15 +739,15 @@ describe('should', function() {
     set.should.have.lengthOf.within(2, 4);
 
     err(function () {
-      set.should.have.length.within(5, 7, 'blah');
+      set.should.have.length.within(5, 7, "blah");
     }, "blah: expected Set{ 1, 2, 3 } to have a size within 5..7");
 
     err(function () {
-      set.should.have.lengthOf.within(5, 7, 'blah');
+      set.should.have.lengthOf.within(5, 7, "blah");
     }, "blah: expected Set{ 1, 2, 3 } to have a size within 5..7");
   });
 
-  it('within(start, finish) (dates)', function(){
+  it("within(start, finish) (dates)", function () {
     var now = new Date();
     var oneSecondBefore = new Date(now.getTime() - 1000);
     var oneSecondAfter = new Date(now.getTime() + 1000);
@@ -625,120 +760,142 @@ describe('should', function() {
     now.should.be.within(now, now);
     oneSecondAfter.should.not.be.within(oneSecondAfter, oneSecondBefore);
 
-    err(function(){
-      now.should.not.be.within(now, oneSecondAfter, 'blah');
-    }, "blah: expected " + nowISO + " to not be within " + nowISO + ".." + afterISO);
+    err(
+      function () {
+        now.should.not.be.within(now, oneSecondAfter, "blah");
+      },
+      "blah: expected " +
+        nowISO +
+        " to not be within " +
+        nowISO +
+        ".." +
+        afterISO,
+    );
 
-    err(function(){
-      oneSecondBefore.should.be.within(now, oneSecondAfter, 'blah');
-    }, "blah: expected " + beforeISO + " to be within " + nowISO + ".." + afterISO);
+    err(
+      function () {
+        oneSecondBefore.should.be.within(now, oneSecondAfter, "blah");
+      },
+      "blah: expected " +
+        beforeISO +
+        " to be within " +
+        nowISO +
+        ".." +
+        afterISO,
+    );
 
-    err(function(){
-      ([]).should.have.length.within(now, 100, 'blah');
+    err(function () {
+      [].should.have.length.within(now, 100, "blah");
     }, "blah: the arguments to within must be numbers");
 
-    err(function(){
-      now.should.have.lengthOf.within(50, now, 'blah');
-    }, "blah: expected " + nowISO + " to have property 'length'");
+    err(
+      function () {
+        now.should.have.lengthOf.within(50, now, "blah");
+      },
+      "blah: expected " + nowISO + " to have property 'length'",
+    );
+
+    err(
+      function () {
+        now.should.have.length.within(5, 7);
+      },
+      "expected " + nowISO + " to have property 'length'",
+    );
 
     err(function () {
-      now.should.have.length.within(5, 7);
-    }, "expected " + nowISO + " to have property 'length'");
-
-    err(function () {
-      (0).should.be.within(0, now, 'blah');
+      (0).should.be.within(0, now, "blah");
     }, "blah: the arguments to within must be numbers");
 
     err(function () {
-      (1).should.be.within(now, 1, 'blah');
+      (1).should.be.within(now, 1, "blah");
     }, "blah: the arguments to within must be numbers");
 
     err(function () {
-      now.should.be.within(1, now, 'blah');
+      now.should.be.within(1, now, "blah");
     }, "blah: the arguments to within must be dates");
 
     err(function () {
-      now.should.not.be.within(now, 1, 'blah');
+      now.should.not.be.within(now, 1, "blah");
     }, "blah: the arguments to within must be dates");
 
     err(function () {
-      now.should.not.be.within(null, now, 'blah');
+      now.should.not.be.within(null, now, "blah");
     }, "blah: the arguments to within must be dates");
 
     err(function () {
-      now.should.not.be.within(now, null, 'blah');
+      now.should.not.be.within(now, null, "blah");
     }, "blah: the arguments to within must be dates");
   });
 
-  it('above(n)', function(){
+  it("above(n)", function () {
     (5).should.be.above(2);
     (5).should.be.greaterThan(2);
     (5).should.not.be.above(5);
     (5).should.not.be.above(6);
 
-    err(function(){
-      (5).should.be.above(6, 'blah');
+    err(function () {
+      (5).should.be.above(6, "blah");
     }, "blah: expected 5 to be above 6");
 
-    err(function(){
-      (10).should.not.be.above(6, 'blah');
+    err(function () {
+      (10).should.not.be.above(6, "blah");
     }, "blah: expected 10 to be at most 6");
 
-    err(function(){
-      ({foo: 1}).should.have.length.above(3, 'blah');
-    }, "blah: expected { foo: 1 } to have property 'length'");
-
-    err(function(){
-      ({foo: 1}).should.have.lengthOf.above(3, 'blah');
+    err(function () {
+      ({ foo: 1 }).should.have.length.above(3, "blah");
     }, "blah: expected { foo: 1 } to have property 'length'");
 
     err(function () {
-      ('string').should.be.above(0, 'blah');
+      ({ foo: 1 }).should.have.lengthOf.above(3, "blah");
+    }, "blah: expected { foo: 1 } to have property 'length'");
+
+    err(function () {
+      "string".should.be.above(0, "blah");
     }, "blah: expected 'string' to be a number or a date");
 
     err(function () {
-      (1).should.be.above(null, 'blah');
+      (1).should.be.above(null, "blah");
     }, "blah: the argument to above must be a number");
 
     err(function () {
-      ('string').should.not.be.above(0, 'blah');
+      "string".should.not.be.above(0, "blah");
     }, "blah: expected 'string' to be a number or a date");
 
     err(function () {
-      (1).should.not.be.above(null, 'blah');
+      (1).should.not.be.above(null, "blah");
     }, "blah: the argument to above must be a number");
 
     err(function () {
-      (1).should.have.length.above(0, 'blah');
+      (1).should.have.length.above(0, "blah");
     }, "blah: expected 1 to have property 'length'");
 
     err(function () {
-      (1).should.have.lengthOf.above(0, 'blah');
+      (1).should.have.lengthOf.above(0, "blah");
     }, "blah: expected 1 to have property 'length'");
 
-    (new Map).should.have.length.above(-1);
-    (new Map).should.have.lengthOf.above(-1);
+    new Map().should.have.length.above(-1);
+    new Map().should.have.lengthOf.above(-1);
 
-    var map = new Map;
-    map.set('a', 1);
-    map.set('b', 2);
-    map.set('c', 3);
+    var map = new Map();
+    map.set("a", 1);
+    map.set("b", 2);
+    map.set("c", 3);
 
     map.should.have.length.above(2);
     map.should.have.lengthOf.above(2);
 
     err(function () {
-      map.should.have.length.above(5, 'blah');
+      map.should.have.length.above(5, "blah");
     }, "blah: expected Map{ 'a' => 1, 'b' => 2, 'c' => 3 } to have a size above 5 but got 3");
 
     err(function () {
-      map.should.have.lengthOf.above(5, 'blah');
+      map.should.have.lengthOf.above(5, "blah");
     }, "blah: expected Map{ 'a' => 1, 'b' => 2, 'c' => 3 } to have a size above 5 but got 3");
 
-    (new Set).should.have.length.above(-1);
-    (new Set).should.have.lengthOf.above(-1);
+    new Set().should.have.length.above(-1);
+    new Set().should.have.lengthOf.above(-1);
 
-    var set = new Set;
+    var set = new Set();
     set.add(1);
     set.add(2);
     set.add(3);
@@ -747,15 +904,15 @@ describe('should', function() {
     set.should.have.lengthOf.above(2);
 
     err(function () {
-      set.should.have.length.above(5, 'blah');
+      set.should.have.length.above(5, "blah");
     }, "blah: expected Set{ 1, 2, 3 } to have a size above 5 but got 3");
 
     err(function () {
-      set.should.have.lengthOf.above(5, 'blah');
+      set.should.have.lengthOf.above(5, "blah");
     }, "blah: expected Set{ 1, 2, 3 } to have a size above 5 but got 3");
   });
 
-  it('above(n) (dates)', function(){
+  it("above(n) (dates)", function () {
     var now = new Date();
     var oneSecondAgo = new Date(now.getTime() - 1000);
     var oneSecondAfter = new Date(now.getTime() + 1000);
@@ -765,98 +922,113 @@ describe('should', function() {
     now.should.not.be.above(oneSecondAfter);
     oneSecondAgo.should.not.be.above(oneSecondAfter);
 
-    err(function(){
-      now.should.be.above(oneSecondAfter, 'blah');
-    }, "blah: expected " +  now.toISOString() + " to be above " + oneSecondAfter.toISOString());
+    err(
+      function () {
+        now.should.be.above(oneSecondAfter, "blah");
+      },
+      "blah: expected " +
+        now.toISOString() +
+        " to be above " +
+        oneSecondAfter.toISOString(),
+    );
 
-    err(function(){
-      now.should.not.be.above(oneSecondAgo, 'blah');
-    }, "blah: expected " + now.toISOString() + " to be at most " + oneSecondAgo.toISOString());
+    err(
+      function () {
+        now.should.not.be.above(oneSecondAgo, "blah");
+      },
+      "blah: expected " +
+        now.toISOString() +
+        " to be at most " +
+        oneSecondAgo.toISOString(),
+    );
 
-    err(function(){
-      now.should.have.length.above(3, 'blah');
-    }, "blah: expected " + now.toISOString() + " to have property 'length'");
+    err(
+      function () {
+        now.should.have.length.above(3, "blah");
+      },
+      "blah: expected " + now.toISOString() + " to have property 'length'",
+    );
 
-    err(function(){
-      ('string').should.have.length.above(now, 'blah');
+    err(function () {
+      "string".should.have.length.above(now, "blah");
     }, "blah: the argument to above must be a number");
 
     err(function () {
-      now.should.be.above(1, 'blah');
+      now.should.be.above(1, "blah");
     }, "blah: the argument to above must be a date");
 
     err(function () {
-      now.should.be.above(null, 'blah');
+      now.should.be.above(null, "blah");
     }, "blah: the argument to above must be a date");
 
     err(function () {
-      (1).should.not.be.above(now, 'blah');
+      (1).should.not.be.above(now, "blah");
     }, "blah: the argument to above must be a number");
 
     err(function () {
-      ([]).should.have.length.above(now, 'blah');
+      [].should.have.length.above(now, "blah");
     }, "blah: the argument to above must be a number");
   });
 
-  it('least(n)', function(){
+  it("least(n)", function () {
     (5).should.be.at.least(5);
     (5).should.not.be.at.least(6);
 
-    err(function(){
-      (5).should.be.at.least(6, 'blah');
+    err(function () {
+      (5).should.be.at.least(6, "blah");
     }, "blah: expected 5 to be at least 6");
 
-    err(function(){
-      (10).should.not.be.at.least(6, 'blah');
+    err(function () {
+      (10).should.not.be.at.least(6, "blah");
     }, "blah: expected 10 to be below 6");
 
-    err(function(){
-      ({foo: 1}).should.have.length.of.at.least(3, 'blah');
-    }, "blah: expected { foo: 1 } to have property 'length'");
-
-    err(function(){
-      ({foo: 1}).should.have.lengthOf.at.least(3, 'blah');
+    err(function () {
+      ({ foo: 1 }).should.have.length.of.at.least(3, "blah");
     }, "blah: expected { foo: 1 } to have property 'length'");
 
     err(function () {
-      ('string').should.be.at.least(0, 'blah');
+      ({ foo: 1 }).should.have.lengthOf.at.least(3, "blah");
+    }, "blah: expected { foo: 1 } to have property 'length'");
+
+    err(function () {
+      "string".should.be.at.least(0, "blah");
     }, "blah: expected 'string' to be a number or a date");
 
     err(function () {
-      (1).should.be.at.least(null, 'blah');
+      (1).should.be.at.least(null, "blah");
     }, "blah: the argument to least must be a number");
 
     err(function () {
-      ('string').should.not.be.at.least(0, 'blah');
+      "string".should.not.be.at.least(0, "blah");
     }, "blah: expected 'string' to be a number or a date");
 
     err(function () {
-      (1).should.not.be.at.least(null, 'blah');
+      (1).should.not.be.at.least(null, "blah");
     }, "blah: the argument to least must be a number");
 
-    (new Map).should.have.length.of.at.least(0);
-    (new Map).should.have.lengthOf.at.least(0);
+    new Map().should.have.length.of.at.least(0);
+    new Map().should.have.lengthOf.at.least(0);
 
-    var map = new Map;
-    map.set('a', 1);
-    map.set('b', 2);
-    map.set('c', 3);
+    var map = new Map();
+    map.set("a", 1);
+    map.set("b", 2);
+    map.set("c", 3);
 
     map.should.have.length.of.at.least(3);
     map.should.have.lengthOf.at.least(3);
 
     err(function () {
-      map.should.have.length.of.at.least(4, 'blah');
+      map.should.have.length.of.at.least(4, "blah");
     }, "blah: expected Map{ 'a' => 1, 'b' => 2, 'c' => 3 } to have a size at least 4 but got 3");
 
     err(function () {
-      map.should.have.lengthOf.at.least(4, 'blah');
+      map.should.have.lengthOf.at.least(4, "blah");
     }, "blah: expected Map{ 'a' => 1, 'b' => 2, 'c' => 3 } to have a size at least 4 but got 3");
 
-    (new Set).should.have.length.of.at.least(0);
-    (new Set).should.have.lengthOf.at.least(0);
+    new Set().should.have.length.of.at.least(0);
+    new Set().should.have.lengthOf.at.least(0);
 
-    var set = new Set;
+    var set = new Set();
     set.add(1);
     set.add(2);
     set.add(3);
@@ -865,83 +1037,83 @@ describe('should', function() {
     set.should.have.lengthOf.at.least(3);
 
     err(function () {
-      set.should.have.length.of.at.least(4, 'blah');
+      set.should.have.length.of.at.least(4, "blah");
     }, "blah: expected Set{ 1, 2, 3 } to have a size at least 4 but got 3");
 
     err(function () {
-      set.should.have.lengthOf.at.least(4, 'blah');
+      set.should.have.lengthOf.at.least(4, "blah");
     }, "blah: expected Set{ 1, 2, 3 } to have a size at least 4 but got 3");
   });
 
-  it('below(n)', function(){
+  it("below(n)", function () {
     (2).should.be.below(5);
     (2).should.be.lessThan(5);
     (2).should.not.be.below(2);
     (2).should.not.be.below(1);
 
-    err(function(){
-      (6).should.be.below(5, 'blah');
+    err(function () {
+      (6).should.be.below(5, "blah");
     }, "blah: expected 6 to be below 5");
 
-    err(function(){
-      (6).should.not.be.below(10, 'blah');
+    err(function () {
+      (6).should.not.be.below(10, "blah");
     }, "blah: expected 6 to be at least 10");
 
-    err(function(){
-      ({foo: 1}).should.have.length.below(3, 'blah');
-    }, "blah: expected { foo: 1 } to have property 'length'");
-
-    err(function(){
-      ({foo: 1}).should.have.lengthOf.below(3, 'blah');
+    err(function () {
+      ({ foo: 1 }).should.have.length.below(3, "blah");
     }, "blah: expected { foo: 1 } to have property 'length'");
 
     err(function () {
-      ('string').should.be.below(0, 'blah');
-    },  "blah: expected 'string' to be a number or a date");
+      ({ foo: 1 }).should.have.lengthOf.below(3, "blah");
+    }, "blah: expected { foo: 1 } to have property 'length'");
 
     err(function () {
-      (1).should.be.below(null, 'blah');
-    }, "blah: the argument to below must be a number");
-
-    err(function () {
-      ('string').should.not.be.below(0, 'blah');
+      "string".should.be.below(0, "blah");
     }, "blah: expected 'string' to be a number or a date");
 
     err(function () {
-      (1).should.not.be.below(null, 'blah');
+      (1).should.be.below(null, "blah");
     }, "blah: the argument to below must be a number");
 
     err(function () {
-      (1).should.have.length.below(0, 'blah');
+      "string".should.not.be.below(0, "blah");
+    }, "blah: expected 'string' to be a number or a date");
+
+    err(function () {
+      (1).should.not.be.below(null, "blah");
+    }, "blah: the argument to below must be a number");
+
+    err(function () {
+      (1).should.have.length.below(0, "blah");
     }, "blah: expected 1 to have property 'length'");
 
     err(function () {
-      (1).should.have.lengthOf.below(0, 'blah');
+      (1).should.have.lengthOf.below(0, "blah");
     }, "blah: expected 1 to have property 'length'");
 
-    (new Map).should.have.length.below(1);
-    (new Map).should.have.lengthOf.below(1);
+    new Map().should.have.length.below(1);
+    new Map().should.have.lengthOf.below(1);
 
-    var map = new Map;
-    map.set('a', 1);
-    map.set('b', 2);
-    map.set('c', 3);
+    var map = new Map();
+    map.set("a", 1);
+    map.set("b", 2);
+    map.set("c", 3);
 
     map.should.have.length.below(4);
     map.should.have.lengthOf.below(4);
 
     err(function () {
-      map.should.have.length.below(2, 'blah');
+      map.should.have.length.below(2, "blah");
     }, "blah: expected Map{ 'a' => 1, 'b' => 2, 'c' => 3 } to have a size below 2 but got 3");
 
     err(function () {
-      map.should.have.lengthOf.below(2, 'blah');
+      map.should.have.lengthOf.below(2, "blah");
     }, "blah: expected Map{ 'a' => 1, 'b' => 2, 'c' => 3 } to have a size below 2 but got 3");
 
-    (new Set).should.have.length.below(1);
-    (new Set).should.have.lengthOf.below(1);
+    new Set().should.have.length.below(1);
+    new Set().should.have.lengthOf.below(1);
 
-    var set = new Set;
+    var set = new Set();
     set.add(1);
     set.add(2);
     set.add(3);
@@ -950,15 +1122,15 @@ describe('should', function() {
     set.should.have.lengthOf.below(4);
 
     err(function () {
-      set.should.have.length.below(2, 'blah');
+      set.should.have.length.below(2, "blah");
     }, "blah: expected Set{ 1, 2, 3 } to have a size below 2 but got 3");
 
     err(function () {
-      set.should.have.lengthOf.below(2, 'blah');
+      set.should.have.lengthOf.below(2, "blah");
     }, "blah: expected Set{ 1, 2, 3 } to have a size below 2 but got 3");
   });
 
-  it('below(n) (dates)', function(){
+  it("below(n) (dates)", function () {
     var now = new Date();
     var oneSecondAgo = new Date(now.getTime() - 1000);
     var oneSecondAfter = new Date(now.getTime() + 1000);
@@ -968,106 +1140,121 @@ describe('should', function() {
     now.should.not.be.below(oneSecondAgo);
     oneSecondAfter.should.not.be.below(oneSecondAgo);
 
-    err(function(){
-      now.should.be.below(now, 'blah');
-    }, "blah: expected " + now.toISOString() + " to be below " + now.toISOString());
+    err(
+      function () {
+        now.should.be.below(now, "blah");
+      },
+      "blah: expected " +
+        now.toISOString() +
+        " to be below " +
+        now.toISOString(),
+    );
 
-    err(function(){
-      now.should.not.be.below(oneSecondAfter, 'blah');
-    }, "blah: expected " + now.toISOString() + " to be at least " + oneSecondAfter.toISOString());
+    err(
+      function () {
+        now.should.not.be.below(oneSecondAfter, "blah");
+      },
+      "blah: expected " +
+        now.toISOString() +
+        " to be at least " +
+        oneSecondAfter.toISOString(),
+    );
 
-    err(function(){
-      now.should.have.length.below(3, 'blah');
-    }, "blah: expected " + now.toISOString() + " to have property 'length'");
+    err(
+      function () {
+        now.should.have.length.below(3, "blah");
+      },
+      "blah: expected " + now.toISOString() + " to have property 'length'",
+    );
 
     err(function () {
-      now.should.be.below(null, 'blah');
+      now.should.be.below(null, "blah");
     }, "blah: the argument to below must be a date");
 
     err(function () {
-      (1).should.not.be.below(now, 'blah');
+      (1).should.not.be.below(now, "blah");
     }, "blah: the argument to below must be a number");
 
     err(function () {
-      now.should.not.be.below(1, 'blah');
+      now.should.not.be.below(1, "blah");
     }, "blah: the argument to below must be a date");
 
     err(function () {
-      now.should.not.be.below(null, 'blah');
+      now.should.not.be.below(null, "blah");
     }, "blah: the argument to below must be a date");
 
     err(function () {
-      ('string').should.have.length.below(now, 'blah');
+      "string".should.have.length.below(now, "blah");
     }, "blah: the argument to below must be a number");
   });
 
-  it('most(n)', function(){
+  it("most(n)", function () {
     (2).should.be.at.most(2);
     (2).should.not.be.at.most(1);
 
-    err(function(){
-      (6).should.be.at.most(5, 'blah');
+    err(function () {
+      (6).should.be.at.most(5, "blah");
     }, "blah: expected 6 to be at most 5");
 
-    err(function(){
-      (6).should.not.be.at.most(10, 'blah');
+    err(function () {
+      (6).should.not.be.at.most(10, "blah");
     }, "blah: expected 6 to be above 10");
 
-    err(function(){
-      ({foo: 1}).should.have.length.of.at.most(3, 'blah');
-    }, "blah: expected { foo: 1 } to have property 'length'");
-
-    err(function(){
-      ({foo: 1}).should.have.lengthOf.at.most(3, 'blah');
+    err(function () {
+      ({ foo: 1 }).should.have.length.of.at.most(3, "blah");
     }, "blah: expected { foo: 1 } to have property 'length'");
 
     err(function () {
-      ('string').should.be.at.most(0, 'blah');
+      ({ foo: 1 }).should.have.lengthOf.at.most(3, "blah");
+    }, "blah: expected { foo: 1 } to have property 'length'");
+
+    err(function () {
+      "string".should.be.at.most(0, "blah");
     }, "blah: expected 'string' to be a number or a date");
 
     err(function () {
-      (1).should.be.at.most(null, 'blah');
+      (1).should.be.at.most(null, "blah");
     }, "blah: the argument to most must be a number");
 
     err(function () {
-      ('string').should.not.be.at.most(0, 'blah');
+      "string".should.not.be.at.most(0, "blah");
     }, "blah: expected 'string' to be a number or a date");
 
     err(function () {
-      (1).should.not.be.at.most(null, 'blah');
+      (1).should.not.be.at.most(null, "blah");
     }, "blah: the argument to most must be a number");
 
     err(function () {
-      (1).should.have.length.of.at.most(0, 'blah');
+      (1).should.have.length.of.at.most(0, "blah");
     }, "blah: expected 1 to have property 'length'");
 
     err(function () {
-      (1).should.have.lengthOf.at.most(0, 'blah');
+      (1).should.have.lengthOf.at.most(0, "blah");
     }, "blah: expected 1 to have property 'length'");
 
-    (new Map).should.have.length.of.at.most(0);
-    (new Map).should.have.lengthOf.at.most(0);
+    new Map().should.have.length.of.at.most(0);
+    new Map().should.have.lengthOf.at.most(0);
 
-    var map = new Map;
-    map.set('a', 1);
-    map.set('b', 2);
-    map.set('c', 3);
+    var map = new Map();
+    map.set("a", 1);
+    map.set("b", 2);
+    map.set("c", 3);
 
     map.should.have.length.of.at.most(3);
     map.should.have.lengthOf.at.most(3);
 
     err(function () {
-      map.should.have.length.of.at.most(2, 'blah');
+      map.should.have.length.of.at.most(2, "blah");
     }, "blah: expected Map{ 'a' => 1, 'b' => 2, 'c' => 3 } to have a size at most 2 but got 3");
 
     err(function () {
-      map.should.have.lengthOf.at.most(2, 'blah');
+      map.should.have.lengthOf.at.most(2, "blah");
     }, "blah: expected Map{ 'a' => 1, 'b' => 2, 'c' => 3 } to have a size at most 2 but got 3");
 
-    (new Set).should.have.length.of.at.most(0);
-    (new Set).should.have.lengthOf.at.most(0);
+    new Set().should.have.length.of.at.most(0);
+    new Set().should.have.lengthOf.at.most(0);
 
-    var set = new Set;
+    var set = new Set();
     set.add(1);
     set.add(2);
     set.add(3);
@@ -1076,15 +1263,15 @@ describe('should', function() {
     set.should.have.lengthOf.at.most(3);
 
     err(function () {
-      set.should.have.length.of.at.most(2, 'blah');
+      set.should.have.length.of.at.most(2, "blah");
     }, "blah: expected Set{ 1, 2, 3 } to have a size at most 2 but got 3");
 
     err(function () {
-      set.should.have.lengthOf.at.most(2, 'blah');
+      set.should.have.lengthOf.at.most(2, "blah");
     }, "blah: expected Set{ 1, 2, 3 } to have a size at most 2 but got 3");
   });
 
-  it('most(n) (dates)', function(){
+  it("most(n) (dates)", function () {
     var now = new Date();
     var oneSecondBefore = new Date(now.getTime() - 1000);
     var oneSecondAfter = new Date(now.getTime() + 1000);
@@ -1096,40 +1283,52 @@ describe('should', function() {
     now.should.be.at.most(oneSecondAfter);
     now.should.not.be.at.most(oneSecondBefore);
 
-    err(function(){
-      now.should.be.at.most(oneSecondBefore, 'blah');
-    }, "blah: expected " + nowISO + " to be at most " + beforeISO);
+    err(
+      function () {
+        now.should.be.at.most(oneSecondBefore, "blah");
+      },
+      "blah: expected " + nowISO + " to be at most " + beforeISO,
+    );
 
-    err(function(){
-      now.should.not.be.at.most(oneSecondAfter, 'blah');
-    }, "blah: expected " + nowISO + " to be above " + afterISO);
+    err(
+      function () {
+        now.should.not.be.at.most(oneSecondAfter, "blah");
+      },
+      "blah: expected " + nowISO + " to be above " + afterISO,
+    );
 
-    err(function(){
-      ([]).should.have.length.of.at.most(now, 'blah');
+    err(function () {
+      [].should.have.length.of.at.most(now, "blah");
     }, "blah: the argument to most must be a number");
 
-    err(function(){
-      ('').should.not.have.lengthOf.at.most(now, 'blah');
+    err(function () {
+      "".should.not.have.lengthOf.at.most(now, "blah");
     }, "blah: the argument to most must be a number");
 
-    err(function () {
-      now.should.have.length.of.at.most(0, 'blah');
-    }, "blah: expected " + nowISO + " to have property 'length'");
+    err(
+      function () {
+        now.should.have.length.of.at.most(0, "blah");
+      },
+      "blah: expected " + nowISO + " to have property 'length'",
+    );
+
+    err(
+      function () {
+        now.should.not.have.lengthOf.at.most(0, "blah");
+      },
+      "blah: expected " + nowISO + " to have property 'length'",
+    );
 
     err(function () {
-      now.should.not.have.lengthOf.at.most(0, 'blah');
-    }, "blah: expected " + nowISO + " to have property 'length'");
-
-    err(function () {
-      now.should.be.at.most(0, 'blah');
+      now.should.be.at.most(0, "blah");
     }, "blah: the argument to most must be a date");
 
     err(function () {
-      now.should.be.at.most(null, 'blah');
+      now.should.be.at.most(null, "blah");
     }, "blah: the argument to most must be a date");
 
     err(function () {
-      (1).should.not.be.at.most(now, 'blah');
+      (1).should.not.be.at.most(now, "blah");
     }, "blah: the argument to most must be a number");
 
     err(function () {
@@ -1137,66 +1336,66 @@ describe('should', function() {
     }, "the argument to most must be a date");
   });
 
-  it('match(regexp)', function(){
-    'foobar'.should.match(/^foo/)
-    'foobar'.should.not.match(/^bar/)
+  it("match(regexp)", function () {
+    "foobar".should.match(/^foo/);
+    "foobar".should.not.match(/^bar/);
 
-    err(function(){
-      'foobar'.should.match(/^bar/i, 'blah')
+    err(function () {
+      "foobar".should.match(/^bar/i, "blah");
     }, "blah: expected 'foobar' to match /^bar/i");
 
-    err(function(){
-      'foobar'.should.not.match(/^foo/i, 'blah')
+    err(function () {
+      "foobar".should.not.match(/^foo/i, "blah");
     }, "blah: expected 'foobar' not to match /^foo/i");
   });
 
-  it('lengthOf(n)', function(){
-    'test'.should.have.length(4);
-    'test'.should.have.lengthOf(4);
-    'test'.should.not.have.length(3);
-    'test'.should.not.have.lengthOf(3);
-    [1,2,3].should.have.length(3);
-    [1,2,3].should.have.lengthOf(3);
+  it("lengthOf(n)", function () {
+    "test".should.have.length(4);
+    "test".should.have.lengthOf(4);
+    "test".should.not.have.length(3);
+    "test".should.not.have.lengthOf(3);
+    [1, 2, 3].should.have.length(3);
+    [1, 2, 3].should.have.lengthOf(3);
 
-    err(function(){
-      (4).should.have.length(3, 'blah');
-    }, 'blah: expected 4 to have property \'length\'');
+    err(function () {
+      (4).should.have.length(3, "blah");
+    }, "blah: expected 4 to have property 'length'");
 
-    err(function(){
-      (4).should.have.lengthOf(3, 'blah');
-    }, 'blah: expected 4 to have property \'length\'');
+    err(function () {
+      (4).should.have.lengthOf(3, "blah");
+    }, "blah: expected 4 to have property 'length'");
 
-    err(function(){
-      'asd'.should.not.have.length(3, 'blah');
+    err(function () {
+      "asd".should.not.have.length(3, "blah");
     }, "blah: expected 'asd' to not have a length of 3");
 
-    err(function(){
-      'asd'.should.not.have.lengthOf(3, 'blah');
+    err(function () {
+      "asd".should.not.have.lengthOf(3, "blah");
     }, "blah: expected 'asd' to not have a length of 3");
 
-    (new Map).should.have.length(0);
-    (new Map).should.have.lengthOf(0);
+    new Map().should.have.length(0);
+    new Map().should.have.lengthOf(0);
 
-    var map = new Map;
-    map.set('a', 1);
-    map.set('b', 2);
-    map.set('c', 3);
+    var map = new Map();
+    map.set("a", 1);
+    map.set("b", 2);
+    map.set("c", 3);
 
     map.should.have.length(3);
     map.should.have.lengthOf(3);
 
-    err(function(){
-      map.should.not.have.length(3, 'blah');
+    err(function () {
+      map.should.not.have.length(3, "blah");
     }, "blah: expected Map{ 'a' => 1, 'b' => 2, 'c' => 3 } to not have a size of 3");
 
-    err(function(){
-      map.should.not.have.lengthOf(3, 'blah');
+    err(function () {
+      map.should.not.have.lengthOf(3, "blah");
     }, "blah: expected Map{ 'a' => 1, 'b' => 2, 'c' => 3 } to not have a size of 3");
 
-    (new Set).should.have.length(0);
-    (new Set).should.have.lengthOf(0);
+    new Set().should.have.length(0);
+    new Set().should.have.lengthOf(0);
 
-    var set = new Set;
+    var set = new Set();
     set.add(1);
     set.add(2);
     set.add(3);
@@ -1204,24 +1403,24 @@ describe('should', function() {
     set.should.have.length(3);
     set.should.have.lengthOf(3);
 
-    err(function(){
-      set.should.not.have.length(3, 'blah');
+    err(function () {
+      set.should.not.have.length(3, "blah");
     }, "blah: expected Set{ 1, 2, 3 } to not have a size of 3");
 
-    err(function(){
-      set.should.not.have.lengthOf(3, 'blah');;
+    err(function () {
+      set.should.not.have.lengthOf(3, "blah");
     }, "blah: expected Set{ 1, 2, 3 } to not have a size of 3");
   });
 
-  it('eql(val)', function(){
-    var a = new Date(1, 2, 3)
-      , b = new Date(4, 5, 6);
+  it("eql(val)", function () {
+    var a = new Date(1, 2, 3),
+      b = new Date(4, 5, 6);
 
     a.should.eql(a);
     a.should.not.eql(b);
     a.should.not.eql({});
-    'test'.should.eql('test');
-    ({ foo: 'bar' }).should.eql({ foo: 'bar' });
+    "test".should.eql("test");
+    ({ foo: "bar" }).should.eql({ foo: "bar" });
     /a/.should.eql(/a/);
     /a/.should.not.eql(/b/);
     /a/.should.not.eql({});
@@ -1232,616 +1431,637 @@ describe('should', function() {
     /a/m.should.eql(/a/m);
     /a/m.should.not.eql(/b/m);
     (1).should.eql(1);
-    '4'.should.not.eql(4);
+    "4".should.not.eql(4);
 
     var sym = Symbol();
     sym.should.eql(sym);
 
-    err(function(){
-      (4).should.eql(3, 'blah');
-    }, 'blah: expected 4 to deeply equal 3');
+    err(function () {
+      (4).should.eql(3, "blah");
+    }, "blah: expected 4 to deeply equal 3");
   });
 
-  it('equal(val)', function(){
-    'test'.should.equal('test');
+  it("equal(val)", function () {
+    "test".should.equal("test");
     (1).should.equal(1);
 
     var sym = Symbol();
     sym.should.equal(sym);
 
-    err(function(){
-      (4).should.equal(3, 'blah');
-    }, 'blah: expected 4 to equal 3');
+    err(function () {
+      (4).should.equal(3, "blah");
+    }, "blah: expected 4 to equal 3");
 
-    err(function(){
-      '4'.should.equal(4, 'blah');
+    err(function () {
+      "4".should.equal(4, "blah");
     }, "blah: expected '4' to equal 4");
   });
 
-  it('deep.equal(val)', function(){
-    ({ foo: 'bar' }).should.deep.equal({ foo: 'bar' });
-    ({ foo: 'bar' }).should.not.deep.equal({ foo: 'baz' });
+  it("deep.equal(val)", function () {
+    ({ foo: "bar" }).should.deep.equal({ foo: "bar" });
+    ({ foo: "bar" }).should.not.deep.equal({ foo: "baz" });
 
-    err(function(){
-      ({foo: 'bar'}).should.deep.equal({foo: 'baz'}, 'blah');
+    err(function () {
+      ({ foo: "bar" }).should.deep.equal({ foo: "baz" }, "blah");
     }, "blah: expected { foo: 'bar' } to deeply equal { foo: 'baz' }");
 
-    err(function(){
-      ({foo: 'bar'}).should.not.deep.equal({foo: 'bar'}, 'blah');
+    err(function () {
+      ({ foo: "bar" }).should.not.deep.equal({ foo: "bar" }, "blah");
     }, "blah: expected { foo: 'bar' } to not deeply equal { foo: 'bar' }");
   });
 
-  it('empty', function(){
-    function FakeArgs() {};
+  it("empty", function () {
+    function FakeArgs() {}
     FakeArgs.prototype.length = 0;
 
-    ''.should.be.empty;
-    'foo'.should.not.be.empty;
-    ([]).should.be.empty;
-    (['foo']).should.not.be.empty;
-    (new FakeArgs).should.be.empty;
-    ({arguments: 0}).should.not.be.empty;
+    "".should.be.empty;
+    "foo".should.not.be.empty;
+    [].should.be.empty;
+    ["foo"].should.not.be.empty;
+    new FakeArgs().should.be.empty;
+    ({ arguments: 0 }).should.not.be.empty;
     ({}).should.be.empty;
-    ({foo: 'bar'}).should.not.be.empty;
+    ({ foo: "bar" }).should.not.be.empty;
 
-    err(function(){
-      (new WeakMap).should.not.be.empty;
+    err(function () {
+      new WeakMap().should.not.be.empty;
     }, ".empty was passed a weak collection");
 
-    err(function(){
-      (new WeakSet).should.not.be.empty;
+    err(function () {
+      new WeakSet().should.not.be.empty;
     }, ".empty was passed a weak collection");
 
-    (new Map).should.be.empty;
+    new Map().should.be.empty;
 
     // Not using Map constructor args because not supported in IE 11.
-    var map = new Map;
-    map.set('a', 1);
+    var map = new Map();
+    map.set("a", 1);
     map.should.not.be.empty;
 
-    err(function(){
-      (new Map).should.not.be.empty;
+    err(function () {
+      new Map().should.not.be.empty;
     }, "expected Map{} not to be empty");
 
-    map = new Map;
-    map.key = 'val';
+    map = new Map();
+    map.key = "val";
     map.should.be.empty;
 
-    err(function(){
+    err(function () {
       map.should.not.be.empty;
     }, "expected Map{} not to be empty");
 
-    (new Set).should.be.empty;
+    new Set().should.be.empty;
 
     // Not using Set constructor args because not supported in IE 11.
-    var set = new Set;
+    var set = new Set();
     set.add(1);
     set.should.not.be.empty;
 
-    err(function(){
-      (new Set).should.not.be.empty;
+    err(function () {
+      new Set().should.not.be.empty;
     }, "expected Set{} not to be empty");
 
-    set = new Set;
-    set.key = 'val';
+    set = new Set();
+    set.key = "val";
     set.should.be.empty;
 
-    err(function(){
+    err(function () {
       set.should.not.be.empty;
     }, "expected Set{} not to be empty");
 
-    err(function(){
-      ''.should.not.be.empty;
-    }, "expected \'\' not to be empty");
+    err(function () {
+      "".should.not.be.empty;
+    }, "expected '' not to be empty");
 
-    err(function(){
-      'foo'.should.be.empty;
-    }, "expected \'foo\' to be empty");
+    err(function () {
+      "foo".should.be.empty;
+    }, "expected 'foo' to be empty");
 
-    err(function(){
-      ([]).should.not.be.empty;
+    err(function () {
+      [].should.not.be.empty;
     }, "expected [] not to be empty");
 
-    err(function(){
-      (['foo']).should.be.empty;
-    }, "expected [ \'foo\' ] to be empty");
+    err(function () {
+      ["foo"].should.be.empty;
+    }, "expected [ 'foo' ] to be empty");
 
-    err(function(){
-      (new FakeArgs).should.not.be.empty;
+    err(function () {
+      new FakeArgs().should.not.be.empty;
     }, "expected FakeArgs{} not to be empty");
 
-    err(function(){
-      ({arguments: 0}).should.be.empty;
+    err(function () {
+      ({ arguments: 0 }).should.be.empty;
     }, "expected { arguments: +0 } to be empty");
 
-    err(function(){
+    err(function () {
       ({}).should.not.be.empty;
     }, "expected {} not to be empty");
 
-    err(function(){
-      ({foo: 'bar'}).should.be.empty;
-    }, "expected { foo: \'bar\' } to be empty");
+    err(function () {
+      ({ foo: "bar" }).should.be.empty;
+    }, "expected { foo: 'bar' } to be empty");
 
-    err(function(){
+    err(function () {
       (0).should.be.empty;
     }, ".empty was passed non-string primitive +0");
 
-    err(function(){
+    err(function () {
       (1).should.be.empty;
     }, ".empty was passed non-string primitive 1");
 
-    err(function(){
+    err(function () {
       true.should.be.empty;
     }, ".empty was passed non-string primitive true");
 
-    err(function(){
+    err(function () {
       false.should.be.empty;
     }, ".empty was passed non-string primitive false");
 
-    if (typeof Symbol !== 'undefined') {
-      err(function(){
+    if (typeof Symbol !== "undefined") {
+      err(function () {
         Symbol().should.be.empty;
       }, ".empty was passed non-string primitive Symbol()");
 
-      err(function(){
+      err(function () {
         Symbol.iterator.should.be.empty;
       }, ".empty was passed non-string primitive Symbol(Symbol.iterator)");
     }
 
-    err(function(){
-      (function() {}).should.be.empty;
+    err(function () {
+      (function () {}).should.be.empty;
     }, ".empty was passed a function");
 
-    if (FakeArgs.name === 'FakeArgs') {
-      err(function(){
+    if (FakeArgs.name === "FakeArgs") {
+      err(function () {
         FakeArgs.should.be.empty;
       }, ".empty was passed a function FakeArgs");
     }
   });
 
-  it('finite(value)', function() {
+  it("finite(value)", function () {
     (4).should.be.finite;
     (-10).should.be.finite;
 
-    err(function(){
-      (NaN).should.be.finite;
+    err(function () {
+      NaN.should.be.finite;
     }, "expected NaN to be a finite number");
 
-    err(function(){
-      (Infinity).should.be.finite;
+    err(function () {
+      Infinity.should.be.finite;
     }, "expected Infinity to be a finite number");
 
-    err(function(){
-      ('foo').should.be.finite;
-    }, "expected \'foo\' to be a finite number");
+    err(function () {
+      "foo".should.be.finite;
+    }, "expected 'foo' to be a finite number");
 
-    err(function(){
-      ([]).should.be.finite;
+    err(function () {
+      [].should.be.finite;
     }, "expected [] to be a finite number");
 
-    err(function(){
+    err(function () {
       ({}).should.be.finite;
     }, "expected {} to be a finite number");
   });
 
-  it('property(name)', function(){
-    'test'.should.have.property('length');
-    (4).should.not.have.property('length');
+  it("property(name)", function () {
+    "test".should.have.property("length");
+    (4).should.not.have.property("length");
     ({ 1: 1 }).should.have.property(1);
-    ({ a: 1 }).should.have.property('toString');
-
-    err(function(){
-      'asd'.should.have.property('foo');
-    }, "expected 'asd' to have property 'foo'");
-
-    err(function() {
-      ({a: {b: 1}}).should.have.own.nested.property("a.b");
-    }, "The \"nested\" and \"own\" flags cannot be combined.");
+    ({ a: 1 }).should.have.property("toString");
 
     err(function () {
-      ({a:1}).should.have.property(undefined);
+      "asd".should.have.property("foo");
+    }, "expected 'asd' to have property 'foo'");
+
+    err(function () {
+      ({ a: { b: 1 } }).should.have.own.nested.property("a.b");
+    }, 'The "nested" and "own" flags cannot be combined.');
+
+    err(function () {
+      ({ a: 1 }).should.have.property(undefined);
     }, "the argument to property must be a string, number, or symbol");
   });
 
-  it('property(name, val)', function(){
-    'test'.should.have.property('length', 4);
-    'asd'.should.have.property('constructor', String);
+  it("property(name, val)", function () {
+    "test".should.have.property("length", 4);
+    "asd".should.have.property("constructor", String);
     ({ 1: 1 }).should.have.property(1, 1);
-    ({ a: 1 }).should.have.property('toString', Object.prototype.toString);
-    'test'.should.not.have.property('length', 3);
-    'test'.should.not.have.property('foo', 4);
-    ({a: {b: 1}}).should.not.have.property('a', {b: 1});
-
-    err(function(){
-      'asd'.should.have.property('length', 4, 'blah');
-    }, "blah: expected 'asd' to have property 'length' of 4, but got 3");
-
-    err(function(){
-      'asd'.should.not.have.property('length', 3, 'blah');
-    }, "blah: expected 'asd' to not have property 'length' of 3");
-
-    err(function(){
-      'asd'.should.have.property('constructor', Number, 'blah');
-    }, "blah: expected 'asd' to have property 'constructor' of [Function Number], but got [Function String]");
-
-    err(function() {
-      ({a: {b: 1}}).should.have.own.nested.property("a.b", 1, 'blah');
-    }, "blah: The \"nested\" and \"own\" flags cannot be combined.");
-  });
-
-  it('deep.property(name, val)', function () {
-    var obj = {a: {b: 1}};
-    obj.should.have.deep.property('a', {b: 1});
-    obj.should.not.have.deep.property('a', {b: 7});
-    obj.should.not.have.deep.property('a', {z: 1});
-    obj.should.not.have.deep.property('z', {b: 1});
+    ({ a: 1 }).should.have.property("toString", Object.prototype.toString);
+    "test".should.not.have.property("length", 3);
+    "test".should.not.have.property("foo", 4);
+    ({ a: { b: 1 } }).should.not.have.property("a", { b: 1 });
 
     err(function () {
-      obj.should.have.deep.property('a', {b: 7}, 'blah');
+      "asd".should.have.property("length", 4, "blah");
+    }, "blah: expected 'asd' to have property 'length' of 4, but got 3");
+
+    err(function () {
+      "asd".should.not.have.property("length", 3, "blah");
+    }, "blah: expected 'asd' to not have property 'length' of 3");
+
+    err(function () {
+      "asd".should.have.property("constructor", Number, "blah");
+    }, "blah: expected 'asd' to have property 'constructor' of [Function Number], but got [Function String]");
+
+    err(function () {
+      ({ a: { b: 1 } }).should.have.own.nested.property("a.b", 1, "blah");
+    }, 'blah: The "nested" and "own" flags cannot be combined.');
+  });
+
+  it("deep.property(name, val)", function () {
+    var obj = { a: { b: 1 } };
+    obj.should.have.deep.property("a", { b: 1 });
+    obj.should.not.have.deep.property("a", { b: 7 });
+    obj.should.not.have.deep.property("a", { z: 1 });
+    obj.should.not.have.deep.property("z", { b: 1 });
+
+    err(function () {
+      obj.should.have.deep.property("a", { b: 7 }, "blah");
     }, "blah: expected { a: { b: 1 } } to have deep property 'a' of { b: 7 }, but got { b: 1 }");
 
     err(function () {
-      obj.should.have.deep.property('z', {b: 1}, 'blah');
+      obj.should.have.deep.property("z", { b: 1 }, "blah");
     }, "blah: expected { a: { b: 1 } } to have deep property 'z'");
 
     err(function () {
-      obj.should.not.have.deep.property('a', {b: 1}, 'blah');
+      obj.should.not.have.deep.property("a", { b: 1 }, "blah");
     }, "blah: expected { a: { b: 1 } } to not have deep property 'a' of { b: 1 }");
   });
 
-  it('ownProperty(name)', function(){
-    'test'.should.have.own.property('length');
-    'test'.should.have.ownProperty('length');
-    'test'.should.haveOwnProperty('length');
-    'test'.should.not.have.own.property('iDontExist');
-    'test'.should.not.have.ownProperty('iDontExist');
-    'test'.should.not.haveOwnProperty('iDontExist');
-    ({ a: 1 }).should.not.have.own.property('toString');
-    ({ a: 1 }).should.not.have.ownProperty('toString');
-    ({ a: 1 }).should.not.haveOwnProperty('toString');
+  it("ownProperty(name)", function () {
+    "test".should.have.own.property("length");
+    "test".should.have.ownProperty("length");
+    "test".should.haveOwnProperty("length");
+    "test".should.not.have.own.property("iDontExist");
+    "test".should.not.have.ownProperty("iDontExist");
+    "test".should.not.haveOwnProperty("iDontExist");
+    ({ a: 1 }).should.not.have.own.property("toString");
+    ({ a: 1 }).should.not.have.ownProperty("toString");
+    ({ a: 1 }).should.not.haveOwnProperty("toString");
 
-    ({ length: 12 }).should.have.own.property('length');
-    ({ length: 12 }).should.have.ownProperty('length');
-    ({ length: 12 }).should.haveOwnProperty('length');
-    ({ length: 12 }).should.not.have.own.property('iDontExist');
-    ({ length: 12 }).should.not.have.ownProperty('iDontExist');
-    ({ length: 12 }).should.not.haveOwnProperty('iDontExist');
+    ({ length: 12 }).should.have.own.property("length");
+    ({ length: 12 }).should.have.ownProperty("length");
+    ({ length: 12 }).should.haveOwnProperty("length");
+    ({ length: 12 }).should.not.have.own.property("iDontExist");
+    ({ length: 12 }).should.not.have.ownProperty("iDontExist");
+    ({ length: 12 }).should.not.haveOwnProperty("iDontExist");
     ({ 1: 1 }).should.have.ownProperty(1);
 
-    var objNoHasOwnProperty = {hasOwnProperty: null};
-    objNoHasOwnProperty.a = 'a';
-    objNoHasOwnProperty.should.have.own.property('a');
-    objNoHasOwnProperty.should.have.ownProperty('a');
-    objNoHasOwnProperty.should.haveOwnProperty('a');
+    var objNoHasOwnProperty = { hasOwnProperty: null };
+    objNoHasOwnProperty.a = "a";
+    objNoHasOwnProperty.should.have.own.property("a");
+    objNoHasOwnProperty.should.have.ownProperty("a");
+    objNoHasOwnProperty.should.haveOwnProperty("a");
 
     // Chaining property's value
-    'test'.should.have.own.property('length').that.is.a('number');
-    'test'.should.have.ownProperty('length').that.is.a('number');
-    'test'.should.haveOwnProperty('length').that.is.a('number');
+    "test".should.have.own.property("length").that.is.a("number");
+    "test".should.have.ownProperty("length").that.is.a("number");
+    "test".should.haveOwnProperty("length").that.is.a("number");
 
-    err(function(){
-      ({ length: 12 }).should.have.own.property('iDontExist');
+    err(function () {
+      ({ length: 12 }).should.have.own.property("iDontExist");
     }, "expected { length: 12 } to have own property 'iDontExist'");
 
-    err(function(){
-      ({ length: 12 }).should.not.have.own.property('length');
+    err(function () {
+      ({ length: 12 }).should.not.have.own.property("length");
     }, "expected { length: 12 } to not have own property 'length'");
 
-    err(function(){
-      ({ length: 12 }).should.have.ownProperty('iDontExist');
+    err(function () {
+      ({ length: 12 }).should.have.ownProperty("iDontExist");
     }, "expected { length: 12 } to have own property 'iDontExist'");
 
-    err(function(){
-      ({ length: 12 }).should.not.have.ownProperty('length');
+    err(function () {
+      ({ length: 12 }).should.not.have.ownProperty("length");
     }, "expected { length: 12 } to not have own property 'length'");
 
-    err(function(){
-      ({ length: 12 }).should.haveOwnProperty('iDontExist');
+    err(function () {
+      ({ length: 12 }).should.haveOwnProperty("iDontExist");
     }, "expected { length: 12 } to have own property 'iDontExist'");
 
-    err(function(){
-      ({ length: 12 }).should.not.haveOwnProperty('length');
+    err(function () {
+      ({ length: 12 }).should.not.haveOwnProperty("length");
     }, "expected { length: 12 } to not have own property 'length'");
   });
 
-  it('ownProperty(name, value)', function(){
-    'test'.should.have.own.property('length', 4);
-    'test'.should.have.ownProperty('length', 4);
-    'test'.should.haveOwnProperty('length', 4);
-    'test'.should.not.have.own.property('length', 1337);
-    'test'.should.not.have.ownProperty('length', 1337);
-    'test'.should.not.haveOwnProperty('length', 1337);
-    'test'.should.not.have.own.property('toString', Object.prototype.toString);
-    'test'.should.not.have.ownProperty('toString', Object.prototype.toString);
-    'test'.should.not.haveOwnProperty('toString', Object.prototype.toString);
-    ({a: {b: 1}}).should.not.have.own.property('a', {b: 1});
-    ({a: {b: 1}}).should.not.have.ownProperty('a', {b: 1});
-    ({a: {b: 1}}).should.not.haveOwnProperty('a', {b: 1});
+  it("ownProperty(name, value)", function () {
+    "test".should.have.own.property("length", 4);
+    "test".should.have.ownProperty("length", 4);
+    "test".should.haveOwnProperty("length", 4);
+    "test".should.not.have.own.property("length", 1337);
+    "test".should.not.have.ownProperty("length", 1337);
+    "test".should.not.haveOwnProperty("length", 1337);
+    "test".should.not.have.own.property("toString", Object.prototype.toString);
+    "test".should.not.have.ownProperty("toString", Object.prototype.toString);
+    "test".should.not.haveOwnProperty("toString", Object.prototype.toString);
+    ({ a: { b: 1 } }).should.not.have.own.property("a", { b: 1 });
+    ({ a: { b: 1 } }).should.not.have.ownProperty("a", { b: 1 });
+    ({ a: { b: 1 } }).should.not.haveOwnProperty("a", { b: 1 });
 
-    ({ length: 12 }).should.have.own.property('length', 12);
-    ({ length: 12 }).should.have.ownProperty('length', 12);
-    ({ length: 12 }).should.haveOwnProperty('length', 12);
-    ({ length: 12 }).should.not.have.own.property('length', 15);
-    ({ length: 12 }).should.not.have.ownProperty('length', 15);
-    ({ length: 12 }).should.not.haveOwnProperty('length', 15);
+    ({ length: 12 }).should.have.own.property("length", 12);
+    ({ length: 12 }).should.have.ownProperty("length", 12);
+    ({ length: 12 }).should.haveOwnProperty("length", 12);
+    ({ length: 12 }).should.not.have.own.property("length", 15);
+    ({ length: 12 }).should.not.have.ownProperty("length", 15);
+    ({ length: 12 }).should.not.haveOwnProperty("length", 15);
 
     // Chaining property's value
-    'test'.should.have.own.property('length', 4).that.is.a('number');
-    'test'.should.have.ownProperty('length', 4).that.is.a('number');
-    'test'.should.haveOwnProperty('length', 4).that.is.a('number');
+    "test".should.have.own.property("length", 4).that.is.a("number");
+    "test".should.have.ownProperty("length", 4).that.is.a("number");
+    "test".should.haveOwnProperty("length", 4).that.is.a("number");
 
-    err(function(){
-      ({ length: 12 }).should.have.own.property('iDontExist', 12, 'blah');
+    err(function () {
+      ({ length: 12 }).should.have.own.property("iDontExist", 12, "blah");
     }, "blah: expected { length: 12 } to have own property 'iDontExist'");
 
-    err(function() {
-      ({ length: 12 }).should.not.have.own.property('length', 12);
+    err(function () {
+      ({ length: 12 }).should.not.have.own.property("length", 12);
     }, "expected { length: 12 } to not have own property 'length' of 12");
 
-    err(function() {
-      ({ length: 12 }).should.have.own.property('length', 15);
+    err(function () {
+      ({ length: 12 }).should.have.own.property("length", 15);
     }, "expected { length: 12 } to have own property 'length' of 15, but got 12");
 
-    err(function(){
-      ({ length: 12 }).should.have.ownProperty('iDontExist', 12);
+    err(function () {
+      ({ length: 12 }).should.have.ownProperty("iDontExist", 12);
     }, "expected { length: 12 } to have own property 'iDontExist'");
 
-    err(function() {
-      ({ length: 12 }).should.not.have.ownProperty('length', 12);
+    err(function () {
+      ({ length: 12 }).should.not.have.ownProperty("length", 12);
     }, "expected { length: 12 } to not have own property 'length' of 12");
 
-    err(function() {
-      ({ length: 12 }).should.have.ownProperty('length', 15);
+    err(function () {
+      ({ length: 12 }).should.have.ownProperty("length", 15);
     }, "expected { length: 12 } to have own property 'length' of 15, but got 12");
 
-    err(function(){
-      ({ length: 12 }).should.haveOwnProperty('iDontExist', 12);
+    err(function () {
+      ({ length: 12 }).should.haveOwnProperty("iDontExist", 12);
     }, "expected { length: 12 } to have own property 'iDontExist'");
 
-    err(function() {
-      ({ length: 12 }).should.not.haveOwnProperty('length', 12);
+    err(function () {
+      ({ length: 12 }).should.not.haveOwnProperty("length", 12);
     }, "expected { length: 12 } to not have own property 'length' of 12");
 
-    err(function() {
-      ({ length: 12 }).should.haveOwnProperty('length', 15);
+    err(function () {
+      ({ length: 12 }).should.haveOwnProperty("length", 15);
     }, "expected { length: 12 } to have own property 'length' of 15, but got 12");
   });
 
-  it('deep.own.property(name, val)', function () {
-    var obj = {a: {b: 1}};
-    obj.should.have.deep.own.property('a', {b: 1});
-    obj.should.have.deep.ownProperty('a', {b: 1});
-    obj.should.deep.haveOwnProperty('a', {b: 1});
-    obj.should.not.have.deep.own.property('a', {z: 1});
-    obj.should.not.have.deep.ownProperty('a', {z: 1});
-    obj.should.not.deep.haveOwnProperty('a', {z: 1});
-    obj.should.not.have.deep.own.property('a', {b: 7});
-    obj.should.not.have.deep.ownProperty('a', {b: 7});
-    obj.should.not.deep.haveOwnProperty('a', {b: 7});
-    obj.should.not.have.deep.own.property('toString', Object.prototype.toString);
-    obj.should.not.have.deep.ownProperty('toString', Object.prototype.toString);
-    obj.should.not.deep.haveOwnProperty('toString', Object.prototype.toString);
+  it("deep.own.property(name, val)", function () {
+    var obj = { a: { b: 1 } };
+    obj.should.have.deep.own.property("a", { b: 1 });
+    obj.should.have.deep.ownProperty("a", { b: 1 });
+    obj.should.deep.haveOwnProperty("a", { b: 1 });
+    obj.should.not.have.deep.own.property("a", { z: 1 });
+    obj.should.not.have.deep.ownProperty("a", { z: 1 });
+    obj.should.not.deep.haveOwnProperty("a", { z: 1 });
+    obj.should.not.have.deep.own.property("a", { b: 7 });
+    obj.should.not.have.deep.ownProperty("a", { b: 7 });
+    obj.should.not.deep.haveOwnProperty("a", { b: 7 });
+    obj.should.not.have.deep.own.property(
+      "toString",
+      Object.prototype.toString,
+    );
+    obj.should.not.have.deep.ownProperty("toString", Object.prototype.toString);
+    obj.should.not.deep.haveOwnProperty("toString", Object.prototype.toString);
 
     err(function () {
-      obj.should.have.deep.own.property('a', {z: 7}, 'blah');
+      obj.should.have.deep.own.property("a", { z: 7 }, "blah");
     }, "blah: expected { a: { b: 1 } } to have deep own property 'a' of { z: 7 }, but got { b: 1 }");
 
     err(function () {
-      obj.should.have.deep.own.property('z', {b: 1}, 'blah');
+      obj.should.have.deep.own.property("z", { b: 1 }, "blah");
     }, "blah: expected { a: { b: 1 } } to have deep own property 'z'");
 
     err(function () {
-      obj.should.not.have.deep.own.property('a', {b: 1}, 'blah');
+      obj.should.not.have.deep.own.property("a", { b: 1 }, "blah");
     }, "blah: expected { a: { b: 1 } } to not have deep own property 'a' of { b: 1 }");
     err(function () {
-      obj.should.have.deep.ownProperty('a', {z: 7}, 'blah');
+      obj.should.have.deep.ownProperty("a", { z: 7 }, "blah");
     }, "blah: expected { a: { b: 1 } } to have deep own property 'a' of { z: 7 }, but got { b: 1 }");
 
     err(function () {
-      obj.should.have.deep.ownProperty('z', {b: 1}, 'blah');
+      obj.should.have.deep.ownProperty("z", { b: 1 }, "blah");
     }, "blah: expected { a: { b: 1 } } to have deep own property 'z'");
 
     err(function () {
-      obj.should.not.have.deep.ownProperty('a', {b: 1}, 'blah');
+      obj.should.not.have.deep.ownProperty("a", { b: 1 }, "blah");
     }, "blah: expected { a: { b: 1 } } to not have deep own property 'a' of { b: 1 }");
 
     err(function () {
-      obj.should.deep.haveOwnProperty('a', {z: 7}, 'blah');
+      obj.should.deep.haveOwnProperty("a", { z: 7 }, "blah");
     }, "blah: expected { a: { b: 1 } } to have deep own property 'a' of { z: 7 }, but got { b: 1 }");
 
     err(function () {
-      obj.should.deep.haveOwnProperty('z', {b: 1}, 'blah');
+      obj.should.deep.haveOwnProperty("z", { b: 1 }, "blah");
     }, "blah: expected { a: { b: 1 } } to have deep own property 'z'");
 
     err(function () {
-      obj.should.not.deep.haveOwnProperty('a', {b: 1}, 'blah');
+      obj.should.not.deep.haveOwnProperty("a", { b: 1 }, "blah");
     }, "blah: expected { a: { b: 1 } } to not have deep own property 'a' of { b: 1 }");
   });
 
-  it('nested.property(name)', function(){
-    ({ 'foo.bar': 'baz'}).should.not.have.nested.property('foo.bar');
-    ({ foo: { bar: 'baz' } }).should.have.nested.property('foo.bar');
+  it("nested.property(name)", function () {
+    ({ "foo.bar": "baz" }).should.not.have.nested.property("foo.bar");
+    ({ foo: { bar: "baz" } }).should.have.nested.property("foo.bar");
 
-    ({ 'foo': [1, 2, 3] }).should.have.nested.property('foo[1]');
+    ({ foo: [1, 2, 3] }).should.have.nested.property("foo[1]");
 
-    ({ 'foo.bar[]': 'baz'}).should.have.nested.property('foo\\.bar\\[\\]');
+    ({ "foo.bar[]": "baz" }).should.have.nested.property("foo\\.bar\\[\\]");
 
-    ({a:1}).should.have.nested.property('a');
+    ({ a: 1 }).should.have.nested.property("a");
 
-    err(function(){
-      ({a:1}).should.have.nested.property({'a':'1'});
+    err(function () {
+      ({ a: 1 }).should.have.nested.property({ a: "1" });
     }, "the argument to property must be a string when using nested syntax");
 
-    err(function(){
-      ({ 'foo.bar': 'baz' }).should.have.nested.property('foo.bar');
+    err(function () {
+      ({ "foo.bar": "baz" }).should.have.nested.property("foo.bar");
     }, "expected { 'foo.bar': 'baz' } to have nested property 'foo.bar'");
   });
 
-  it('nested.property(name, val)', function(){
-    ({ foo: { bar: 'baz' } }).should.have.nested.property('foo.bar', 'baz');
-    ({ foo: { bar: 'baz' } }).should.not.have.nested.property('foo.bar', 'quux');
-    ({ foo: { bar: 'baz' } }).should.not.have.nested.property('foo.quux', 'baz');
-    ({a: {b: {c: 1}}}).should.not.have.nested.property('a.b', {c: 1});
+  it("nested.property(name, val)", function () {
+    ({ foo: { bar: "baz" } }).should.have.nested.property("foo.bar", "baz");
+    ({ foo: { bar: "baz" } }).should.not.have.nested.property(
+      "foo.bar",
+      "quux",
+    );
+    ({ foo: { bar: "baz" } }).should.not.have.nested.property(
+      "foo.quux",
+      "baz",
+    );
+    ({ a: { b: { c: 1 } } }).should.not.have.nested.property("a.b", { c: 1 });
 
-    err(function(){
-      ({ foo: { bar: 'baz' } }).should.have.nested.property('foo.bar', 'quux', 'blah');
+    err(function () {
+      ({ foo: { bar: "baz" } }).should.have.nested.property(
+        "foo.bar",
+        "quux",
+        "blah",
+      );
     }, "blah: expected { foo: { bar: 'baz' } } to have nested property 'foo.bar' of 'quux', but got 'baz'");
-    err(function(){
-      ({ foo: { bar: 'baz' } }).should.not.have.nested.property('foo.bar', 'baz', 'blah');
+    err(function () {
+      ({ foo: { bar: "baz" } }).should.not.have.nested.property(
+        "foo.bar",
+        "baz",
+        "blah",
+      );
     }, "blah: expected { foo: { bar: 'baz' } } to not have nested property 'foo.bar' of 'baz'");
   });
 
-  it('deep.nested.property(name, val)', function () {
-    var obj = {a: {b: {c: 1}}};
-    obj.should.have.deep.nested.property('a.b', {c: 1});
-    obj.should.not.have.deep.nested.property('a.b', {c: 7});
-    obj.should.not.have.deep.nested.property('a.b', {z: 1});
-    obj.should.not.have.deep.nested.property('a.z', {c: 1});
+  it("deep.nested.property(name, val)", function () {
+    var obj = { a: { b: { c: 1 } } };
+    obj.should.have.deep.nested.property("a.b", { c: 1 });
+    obj.should.not.have.deep.nested.property("a.b", { c: 7 });
+    obj.should.not.have.deep.nested.property("a.b", { z: 1 });
+    obj.should.not.have.deep.nested.property("a.z", { c: 1 });
 
     err(function () {
-      obj.should.have.deep.nested.property('a.b', {c: 7}, 'blah');
+      obj.should.have.deep.nested.property("a.b", { c: 7 }, "blah");
     }, "blah: expected { a: { b: { c: 1 } } } to have deep nested property 'a.b' of { c: 7 }, but got { c: 1 }");
 
     err(function () {
-      obj.should.have.deep.nested.property('a.z', {c: 1}, 'blah');
+      obj.should.have.deep.nested.property("a.z", { c: 1 }, "blah");
     }, "blah: expected { a: { b: { c: 1 } } } to have deep nested property 'a.z'");
 
     err(function () {
-      obj.should.not.have.deep.nested.property('a.b', {c: 1}, 'blah');
+      obj.should.not.have.deep.nested.property("a.b", { c: 1 }, "blah");
     }, "blah: expected { a: { b: { c: 1 } } } to not have deep nested property 'a.b' of { c: 1 }");
   });
 
-  it('ownPropertyDescriptor(name)', function(){
-    'test'.should.haveOwnPropertyDescriptor('length');
-    'test'.should.have.ownPropertyDescriptor('length');
-    'test'.should.not.have.ownPropertyDescriptor('foo');
+  it("ownPropertyDescriptor(name)", function () {
+    "test".should.haveOwnPropertyDescriptor("length");
+    "test".should.have.ownPropertyDescriptor("length");
+    "test".should.not.have.ownPropertyDescriptor("foo");
 
     ({ 1: 1 }).should.have.ownPropertyDescriptor(1);
 
-    var obj = { },
-        obj2 = { };
+    var obj = {},
+      obj2 = {};
     var descriptor = {
       configurable: false,
       enumerable: true,
       writable: true,
-      value: NaN
+      value: NaN,
     };
-    Object.defineProperty(obj, 'test', descriptor);
-    obj.should.haveOwnPropertyDescriptor('test', descriptor);
+    Object.defineProperty(obj, "test", descriptor);
+    obj.should.haveOwnPropertyDescriptor("test", descriptor);
 
     Object.defineProperty(obj2, 1, descriptor);
     obj2.should.haveOwnPropertyDescriptor(1, descriptor);
 
-    err(function(){
-      obj.should.not.haveOwnPropertyDescriptor('test', descriptor, 'blah');
+    err(function () {
+      obj.should.not.haveOwnPropertyDescriptor("test", descriptor, "blah");
     }, /^blah: expected the own property descriptor for 'test' on \{ test: NaN \} to not match \{ [^\}]+ \}$/);
-    err(function(){
+    err(function () {
       var wrongDescriptor = {
         configurable: false,
         enumerable: true,
         writable: false,
-        value: NaN
+        value: NaN,
       };
-      obj.should.haveOwnPropertyDescriptor('test', wrongDescriptor, 'blah');
+      obj.should.haveOwnPropertyDescriptor("test", wrongDescriptor, "blah");
     }, /^blah: expected the own property descriptor for 'test' on \{ test: NaN \} to match \{ [^\}]+ \}, got \{ [^\}]+ \}$/);
 
-    err(function(){
-      obj.should.haveOwnPropertyDescriptor('test2', 'blah');
+    err(function () {
+      obj.should.haveOwnPropertyDescriptor("test2", "blah");
     }, "blah: expected { test: NaN } to have an own property descriptor for 'test2'");
 
-    obj.should.have.ownPropertyDescriptor('test').and.have.property('enumerable', true);
+    obj.should.have
+      .ownPropertyDescriptor("test")
+      .and.have.property("enumerable", true);
   });
 
-  it('string()', function(){
-    'foobar'.should.contain.string('bar');
-    'foobar'.should.contain.string('foo');
-    'foobar'.should.not.contain.string('baz');
+  it("string()", function () {
+    "foobar".should.contain.string("bar");
+    "foobar".should.contain.string("foo");
+    "foobar".should.not.contain.string("baz");
 
-    err(function(){
-      (3).should.contain.string('baz', 'blah');
+    err(function () {
+      (3).should.contain.string("baz", "blah");
     }, "blah: expected 3 to be a string");
 
-    err(function(){
-      'foobar'.should.contain.string('baz', 'blah');
+    err(function () {
+      "foobar".should.contain.string("baz", "blah");
     }, "blah: expected 'foobar' to contain 'baz'");
 
-    err(function(){
-      'foobar'.should.not.contain.string('bar', 'blah');
+    err(function () {
+      "foobar".should.not.contain.string("bar", "blah");
     }, "blah: expected 'foobar' to not contain 'bar'");
   });
 
-  it('oneOf()', function(){
-    'foo'.should.be.oneOf(['foo', 'bar']);
-    'bar'.should.be.oneOf(['foo', 'bar']);
-    'baz'.should.not.be.oneOf(['foo', 'bar']);
-    'baz'.should.not.be.oneOf([]);
+  it("oneOf()", function () {
+    "foo".should.be.oneOf(["foo", "bar"]);
+    "bar".should.be.oneOf(["foo", "bar"]);
+    "baz".should.not.be.oneOf(["foo", "bar"]);
+    "baz".should.not.be.oneOf([]);
 
     err(function () {
-      (1).should.be.oneOf([2, 3], 'blah');
+      (1).should.be.oneOf([2, 3], "blah");
     }, "blah: expected 1 to be one of [ 2, 3 ]");
 
     err(function () {
-      (1).should.not.be.oneOf([1, 2, 3], 'blah');
+      (1).should.not.be.oneOf([1, 2, 3], "blah");
     }, "blah: expected 1 to not be one of [ 1, 2, 3 ]");
 
     err(function () {
-      (1).should.be.oneOf({}, 'blah');
+      (1).should.be.oneOf({}, "blah");
     }, "blah: expected {} to be an array");
   });
 
-  it('include()', function(){
-    ['foo', 'bar'].should.include('foo');
-    ['foo', 'bar'].should.contain('foo');
-    ['foo', 'bar'].should.include('bar');
-    [1,2].should.include(1);
-    ['foo', 'bar'].should.not.include('baz');
-    ['foo', 'bar'].should.not.include(1);
+  it("include()", function () {
+    ["foo", "bar"].should.include("foo");
+    ["foo", "bar"].should.contain("foo");
+    ["foo", "bar"].should.include("bar");
+    [1, 2].should.include(1);
+    ["foo", "bar"].should.not.include("baz");
+    ["foo", "bar"].should.not.include(1);
 
     // .include should work with Error objects and objects with a custom
     // `@@toStringTag`.
-    (new Error('foo')).should.include({message: 'foo'});
-    if (typeof Symbol !== 'undefined'
-        && typeof Symbol.toStringTag !== 'undefined') {
-      var customObj = {a: 1};
-      customObj[Symbol.toStringTag] = 'foo';
+    new Error("foo").should.include({ message: "foo" });
+    if (
+      typeof Symbol !== "undefined" &&
+      typeof Symbol.toStringTag !== "undefined"
+    ) {
+      var customObj = { a: 1 };
+      customObj[Symbol.toStringTag] = "foo";
 
-      customObj.should.include({a: 1});
+      customObj.should.include({ a: 1 });
     }
 
-    ({a: 1}).should.include({'toString': Object.prototype.toString});
+    ({ a: 1 }).should.include({ toString: Object.prototype.toString });
 
-    var obj1 = {a: 1}
-      , obj2 = {b: 2};
+    var obj1 = { a: 1 },
+      obj2 = { b: 2 };
     [obj1, obj2].should.include(obj1);
-    [obj1, obj2].should.not.include({a: 1});
-    ({foo: obj1, bar: obj2}).should.include({foo: obj1});
-    ({foo: obj1, bar: obj2}).should.include({foo: obj1, bar: obj2});
-    ({foo: obj1, bar: obj2}).should.not.include({foo: {a: 1}});
-    ({foo: obj1, bar: obj2}).should.not.include({foo: obj1, bar: {b: 2}});
+    [obj1, obj2].should.not.include({ a: 1 });
+    ({ foo: obj1, bar: obj2 }).should.include({ foo: obj1 });
+    ({ foo: obj1, bar: obj2 }).should.include({ foo: obj1, bar: obj2 });
+    ({ foo: obj1, bar: obj2 }).should.not.include({ foo: { a: 1 } });
+    ({ foo: obj1, bar: obj2 }).should.not.include({ foo: obj1, bar: { b: 2 } });
 
     var map = new Map();
-    var val = [{a: 1}];
-    map.set('a', val);
-    map.set('b', 2);
-    map.set('c', -0);
-    map.set('d', NaN);
+    var val = [{ a: 1 }];
+    map.set("a", val);
+    map.set("b", 2);
+    map.set("c", -0);
+    map.set("d", NaN);
 
     map.should.include(val);
-    map.should.not.include([{a: 1}]);
+    map.should.not.include([{ a: 1 }]);
     map.should.include(2);
     map.should.not.include(3);
     map.should.include(0);
     map.should.include(NaN);
 
     var set = new Set();
-    var val = [{a: 1}];
+    var val = [{ a: 1 }];
     set.add(val);
     set.add(2);
     set.add(-0);
     set.add(NaN);
 
     set.should.include(val);
-    set.should.not.include([{a: 1}]);
+    set.should.not.include([{ a: 1 }]);
     set.should.include(2);
     set.should.not.include(3);
     if (set.has(0)) {
@@ -1852,499 +2072,587 @@ describe('should', function() {
     set.should.include(NaN);
 
     var ws = new WeakSet();
-    var val = [{a: 1}];
+    var val = [{ a: 1 }];
     ws.add(val);
 
     ws.should.include(val);
-    ws.should.not.include([{a: 1}]);
+    ws.should.not.include([{ a: 1 }]);
     ws.should.not.include({});
 
-    var sym1 = Symbol()
-    , sym2 = Symbol()
-    , sym3 = Symbol();
+    var sym1 = Symbol(),
+      sym2 = Symbol(),
+      sym3 = Symbol();
     [sym1, sym2].should.include(sym1);
     [sym1, sym2].should.not.include(sym3);
 
-    err(function(){
-      ['foo'].should.include('bar', 'blah');
+    err(function () {
+      ["foo"].should.include("bar", "blah");
     }, "blah: expected [ 'foo' ] to include 'bar'");
 
-    err(function(){
-      ['bar', 'foo'].should.not.include('foo', 'blah');
+    err(function () {
+      ["bar", "foo"].should.not.include("foo", "blah");
     }, "blah: expected [ 'bar', 'foo' ] to not include 'foo'");
 
-    err(function(){
-      ({a:1}).should.include({b:2}, 'blah');
+    err(function () {
+      ({ a: 1 }).should.include({ b: 2 }, "blah");
     }, "blah: expected { a: 1 } to have property 'b'");
 
     err(function () {
-      [{a: 1}, {b: 2}].should.include({a: 1});
+      [{ a: 1 }, { b: 2 }].should.include({ a: 1 });
     }, "expected [ { a: 1 }, { b: 2 } ] to include { a: 1 }");
 
     err(function () {
-      var obj1 = {a: 1}
-        , obj2 = {b: 2};
+      var obj1 = { a: 1 },
+        obj2 = { b: 2 };
       [obj1, obj2].should.not.include(obj1);
     }, "expected [ { a: 1 }, { b: 2 } ] to not include { a: 1 }");
 
     err(function () {
-      ({foo: {a: 1}, bar: {b: 2}}).should.include({foo: {a: 1}});
+      ({ foo: { a: 1 }, bar: { b: 2 } }).should.include({ foo: { a: 1 } });
     }, "expected { foo: { a: 1 }, bar: { b: 2 } } to have property 'foo' of { a: 1 }, but got { a: 1 }");
 
     err(function () {
-      var obj1 = {a: 1}
-        , obj2 = {b: 2};
-      ({foo: obj1, bar: obj2}).should.not.include({foo: obj1, bar: obj2});
+      var obj1 = { a: 1 },
+        obj2 = { b: 2 };
+      ({ foo: obj1, bar: obj2 }).should.not.include({ foo: obj1, bar: obj2 });
     }, "expected { foo: { a: 1 }, bar: { b: 2 } } to not have property 'foo' of { a: 1 }");
 
-    err(function(){
-      (true).should.include(true, 'blah');
-    },
-      "blah: the given combination of arguments (boolean and boolean) is invalid for this assertion. " +
-      "You can use an array, a map, an object, a set, a string, or a weakset instead of a boolean"
-    );
+    err(function () {
+      true.should.include(true, "blah");
+    }, "blah: the given combination of arguments (boolean and boolean) is invalid for this assertion. " + "You can use an array, a map, an object, a set, a string, or a weakset instead of a boolean");
 
-    err(function(){
+    err(function () {
       (42).should.include(4);
-    },
-      "the given combination of arguments (number and number) is invalid for this assertion. " +
-      "You can use an array, a map, an object, a set, a string, or a weakset instead of a number"
-    );
+    }, "the given combination of arguments (number and number) is invalid for this assertion. " + "You can use an array, a map, an object, a set, a string, or a weakset instead of a number");
 
-    err(function(){
-      (true).should.not.include(true);
-    },
-      "the given combination of arguments (boolean and boolean) is invalid for this assertion. " +
-      "You can use an array, a map, an object, a set, a string, or a weakset instead of a boolean"
-    );
+    err(function () {
+      true.should.not.include(true);
+    }, "the given combination of arguments (boolean and boolean) is invalid for this assertion. " + "You can use an array, a map, an object, a set, a string, or a weakset instead of a boolean");
 
-    err(function(){
+    err(function () {
       (42).should.not.include(4);
-    },
-      "the given combination of arguments (number and number) is invalid for this assertion. " +
-      "You can use an array, a map, an object, a set, a string, or a weakset instead of a number"
-    );
+    }, "the given combination of arguments (number and number) is invalid for this assertion. " + "You can use an array, a map, an object, a set, a string, or a weakset instead of a number");
   });
 
-  it('deep.include()', function () {
-    var obj1 = {a: 1}
-      , obj2 = {b: 2};
-    [obj1, obj2].should.deep.include({a: 1});
-    [obj1, obj2].should.not.deep.include({a: 9});
-    [obj1, obj2].should.not.deep.include({z: 1});
-    ({foo: obj1, bar: obj2}).should.deep.include({foo: {a: 1}});
-    ({foo: obj1, bar: obj2}).should.deep.include({foo: {a: 1}, bar: {b: 2}});
-    ({foo: obj1, bar: obj2}).should.not.deep.include({foo: {a: 9}});
-    ({foo: obj1, bar: obj2}).should.not.deep.include({foo: {z: 1}});
-    ({foo: obj1, bar: obj2}).should.not.deep.include({baz: {a: 1}});
-    ({foo: obj1, bar: obj2}).should.not.deep.include({foo: {a: 1}, bar: {b: 9}});
+  it("deep.include()", function () {
+    var obj1 = { a: 1 },
+      obj2 = { b: 2 };
+    [obj1, obj2].should.deep.include({ a: 1 });
+    [obj1, obj2].should.not.deep.include({ a: 9 });
+    [obj1, obj2].should.not.deep.include({ z: 1 });
+    ({ foo: obj1, bar: obj2 }).should.deep.include({ foo: { a: 1 } });
+    ({ foo: obj1, bar: obj2 }).should.deep.include({
+      foo: { a: 1 },
+      bar: { b: 2 },
+    });
+    ({ foo: obj1, bar: obj2 }).should.not.deep.include({ foo: { a: 9 } });
+    ({ foo: obj1, bar: obj2 }).should.not.deep.include({ foo: { z: 1 } });
+    ({ foo: obj1, bar: obj2 }).should.not.deep.include({ baz: { a: 1 } });
+    ({ foo: obj1, bar: obj2 }).should.not.deep.include({
+      foo: { a: 1 },
+      bar: { b: 9 },
+    });
 
     var map = new Map();
 
-    map.set(1, [{a: 1}]);
-    map.should.deep.include([{a: 1}]);
+    map.set(1, [{ a: 1 }]);
+    map.should.deep.include([{ a: 1 }]);
 
     var set = new Set();
 
-    set.add([{a: 1}]);
-    set.should.deep.include([{a: 1}]);
-
-    err(function() {
-      new WeakSet().should.deep.include({}, 'foo');
-    }, 'foo: unable to use .deep.include with WeakSet');
+    set.add([{ a: 1 }]);
+    set.should.deep.include([{ a: 1 }]);
 
     err(function () {
-      [obj1, obj2].should.deep.include({a: 9}, 'blah');
+      new WeakSet().should.deep.include({}, "foo");
+    }, "foo: unable to use .deep.include with WeakSet");
+
+    err(function () {
+      [obj1, obj2].should.deep.include({ a: 9 }, "blah");
     }, "blah: expected [ { a: 1 }, { b: 2 } ] to deep include { a: 9 }");
 
     err(function () {
-      [obj1, obj2].should.not.deep.include({a: 1});
+      [obj1, obj2].should.not.deep.include({ a: 1 });
     }, "expected [ { a: 1 }, { b: 2 } ] to not deep include { a: 1 }");
 
     err(function () {
-      ({foo: obj1, bar: obj2}).should.deep.include({foo: {a: 1}, bar: {b: 9}});
+      ({ foo: obj1, bar: obj2 }).should.deep.include({
+        foo: { a: 1 },
+        bar: { b: 9 },
+      });
     }, "expected { foo: { a: 1 }, bar: { b: 2 } } to have deep property 'bar' of { b: 9 }, but got { b: 2 }");
 
     err(function () {
-      ({foo: obj1, bar: obj2}).should.not.deep.include({foo: {a: 1}, bar: {b: 2}}, 'blah');
+      ({ foo: obj1, bar: obj2 }).should.not.deep.include(
+        { foo: { a: 1 }, bar: { b: 2 } },
+        "blah",
+      );
     }, "blah: expected { foo: { a: 1 }, bar: { b: 2 } } to not have deep property 'foo' of { a: 1 }");
   });
 
-  it('nested.include()', function () {
-    ({a: {b: ['x', 'y']}}).should.nested.include({'a.b[1]': 'y'});
-    ({a: {b: ['x', 'y']}}).should.not.nested.include({'a.b[1]': 'x'});
-    ({a: {b: ['x', 'y']}}).should.not.nested.include({'a.c': 'y'});
+  it("nested.include()", function () {
+    ({ a: { b: ["x", "y"] } }).should.nested.include({ "a.b[1]": "y" });
+    ({ a: { b: ["x", "y"] } }).should.not.nested.include({ "a.b[1]": "x" });
+    ({ a: { b: ["x", "y"] } }).should.not.nested.include({ "a.c": "y" });
 
-    ({a: {b: [{x: 1}]}}).should.not.nested.include({'a.b[0]': {x: 1}});
+    ({ a: { b: [{ x: 1 }] } }).should.not.nested.include({
+      "a.b[0]": { x: 1 },
+    });
 
-    ({'.a': {'[b]': 'x'}}).should.nested.include({'\\.a.\\[b\\]': 'x'});
-    ({'.a': {'[b]': 'x'}}).should.not.nested.include({'\\.a.\\[b\\]': 'y'});
+    ({ ".a": { "[b]": "x" } }).should.nested.include({ "\\.a.\\[b\\]": "x" });
+    ({ ".a": { "[b]": "x" } }).should.not.nested.include({
+      "\\.a.\\[b\\]": "y",
+    });
 
     err(function () {
-      ({a: {b: ['x', 'y']}}).should.nested.include({'a.b[1]': 'x'}, 'blah');
+      ({ a: { b: ["x", "y"] } }).should.nested.include(
+        { "a.b[1]": "x" },
+        "blah",
+      );
     }, "blah: expected { a: { b: [ 'x', 'y' ] } } to have nested property 'a.b[1]' of 'x', but got 'y'");
 
     err(function () {
-      ({a: {b: ['x', 'y']}}).should.nested.include({'a.c': 'y'});
+      ({ a: { b: ["x", "y"] } }).should.nested.include({ "a.c": "y" });
     }, "expected { a: { b: [ 'x', 'y' ] } } to have nested property 'a.c'");
 
     err(function () {
-      ({a: {b: ['x', 'y']}}).should.not.nested.include({'a.b[1]': 'y'}, 'blah');
+      ({ a: { b: ["x", "y"] } }).should.not.nested.include(
+        { "a.b[1]": "y" },
+        "blah",
+      );
     }, "blah: expected { a: { b: [ 'x', 'y' ] } } to not have nested property 'a.b[1]' of 'y'");
   });
 
-  it('deep.nested.include()', function () {
-    ({a: {b: [{x: 1}]}}).should.deep.nested.include({'a.b[0]': {x: 1}});
-    ({a: {b: [{x: 1}]}}).should.not.deep.nested.include({'a.b[0]': {y: 2}});
-    ({a: {b: [{x: 1}]}}).should.not.deep.nested.include({'a.c': {x: 1}});
+  it("deep.nested.include()", function () {
+    ({ a: { b: [{ x: 1 }] } }).should.deep.nested.include({
+      "a.b[0]": { x: 1 },
+    });
+    ({ a: { b: [{ x: 1 }] } }).should.not.deep.nested.include({
+      "a.b[0]": { y: 2 },
+    });
+    ({ a: { b: [{ x: 1 }] } }).should.not.deep.nested.include({
+      "a.c": { x: 1 },
+    });
 
-    ({'.a': {'[b]': {x: 1}}})
-      .should.deep.nested.include({'\\.a.\\[b\\]': {x: 1}});
-    ({'.a': {'[b]': {x: 1}}})
-      .should.not.deep.nested.include({'\\.a.\\[b\\]': {y: 2}});
+    ({ ".a": { "[b]": { x: 1 } } }).should.deep.nested.include({
+      "\\.a.\\[b\\]": { x: 1 },
+    });
+    ({ ".a": { "[b]": { x: 1 } } }).should.not.deep.nested.include({
+      "\\.a.\\[b\\]": { y: 2 },
+    });
 
     err(function () {
-      ({a: {b: [{x: 1}]}}).should.deep.nested.include({'a.b[0]': {y: 2}}, 'blah');
+      ({ a: { b: [{ x: 1 }] } }).should.deep.nested.include(
+        { "a.b[0]": { y: 2 } },
+        "blah",
+      );
     }, "blah: expected { a: { b: [ { x: 1 } ] } } to have deep nested property 'a.b[0]' of { y: 2 }, but got { x: 1 }");
 
     err(function () {
-      ({a: {b: [{x: 1}]}}).should.deep.nested.include({'a.c': {x: 1}});
+      ({ a: { b: [{ x: 1 }] } }).should.deep.nested.include({
+        "a.c": { x: 1 },
+      });
     }, "expected { a: { b: [ { x: 1 } ] } } to have deep nested property 'a.c'");
 
     err(function () {
-      ({a: {b: [{x: 1}]}}).should.not.deep.nested.include({'a.b[0]': {x: 1}}, 'blah');
+      ({ a: { b: [{ x: 1 }] } }).should.not.deep.nested.include(
+        { "a.b[0]": { x: 1 } },
+        "blah",
+      );
     }, "blah: expected { a: { b: [ { x: 1 } ] } } to not have deep nested property 'a.b[0]' of { x: 1 }");
   });
 
-  it('own.include()', function () {
-    ({a: 1}).should.own.include({a: 1});
-    ({a: 1}).should.not.own.include({a: 3});
-    ({a: 1}).should.not.own.include({'toString': Object.prototype.toString});
+  it("own.include()", function () {
+    ({ a: 1 }).should.own.include({ a: 1 });
+    ({ a: 1 }).should.not.own.include({ a: 3 });
+    ({ a: 1 }).should.not.own.include({ toString: Object.prototype.toString });
 
-    ({a: {b: 2}}).should.not.own.include({a: {b: 2}});
+    ({ a: { b: 2 } }).should.not.own.include({ a: { b: 2 } });
 
     err(function () {
-      ({a: 1}).should.own.include({a: 3}, 'blah');
+      ({ a: 1 }).should.own.include({ a: 3 }, "blah");
     }, "blah: expected { a: 1 } to have own property 'a' of 3, but got 1");
 
     err(function () {
-      ({a: 1}).should.own.include({'toString': Object.prototype.toString});
+      ({ a: 1 }).should.own.include({ toString: Object.prototype.toString });
     }, "expected { a: 1 } to have own property 'toString'");
 
     err(function () {
-      ({a: 1}).should.not.own.include({a: 1}, 'blah');
+      ({ a: 1 }).should.not.own.include({ a: 1 }, "blah");
     }, "blah: expected { a: 1 } to not have own property 'a' of 1");
   });
 
-  it('deep.own.include()', function () {
-    ({a: {b: 2}}).should.deep.own.include({a: {b: 2}});
-    ({a: {b: 2}}).should.not.deep.own.include({a: {c: 3}});
-    ({a: {b: 2}})
-      .should.not.deep.own.include({'toString': Object.prototype.toString});
+  it("deep.own.include()", function () {
+    ({ a: { b: 2 } }).should.deep.own.include({ a: { b: 2 } });
+    ({ a: { b: 2 } }).should.not.deep.own.include({ a: { c: 3 } });
+    ({ a: { b: 2 } }).should.not.deep.own.include({
+      toString: Object.prototype.toString,
+    });
 
     err(function () {
-      ({a: {b: 2}}).should.deep.own.include({a: {c: 3}}, 'blah');
+      ({ a: { b: 2 } }).should.deep.own.include({ a: { c: 3 } }, "blah");
     }, "blah: expected { a: { b: 2 } } to have deep own property 'a' of { c: 3 }, but got { b: 2 }");
 
     err(function () {
-      ({a: {b: 2}}).should.deep.own.include({'toString': Object.prototype.toString});
+      ({ a: { b: 2 } }).should.deep.own.include({
+        toString: Object.prototype.toString,
+      });
     }, "expected { a: { b: 2 } } to have deep own property 'toString'");
 
     err(function () {
-      ({a: {b: 2}}).should.not.deep.own.include({a: {b: 2}}, 'blah');
+      ({ a: { b: 2 } }).should.not.deep.own.include({ a: { b: 2 } }, "blah");
     }, "blah: expected { a: { b: 2 } } to not have deep own property 'a' of { b: 2 }");
   });
 
-  it('keys(array|Object|arguments)', function(){
-    ({ foo: 1 }).should.have.keys(['foo']);
-    ({ foo: 1 }).should.have.keys({ 'foo': 6 });
+  it("keys(array|Object|arguments)", function () {
+    ({ foo: 1 }).should.have.keys(["foo"]);
+    ({ foo: 1 }).should.have.keys({ foo: 6 });
 
-    ({ foo: 1, bar: 2 }).should.have.keys(['foo', 'bar']);
-    ({ foo: 1, bar: 2 }).should.have.keys('foo', 'bar');
-    ({ foo: 1, bar: 2 }).should.have.keys({ 'foo': 6, 'bar': 7 });
+    ({ foo: 1, bar: 2 }).should.have.keys(["foo", "bar"]);
+    ({ foo: 1, bar: 2 }).should.have.keys("foo", "bar");
+    ({ foo: 1, bar: 2 }).should.have.keys({ foo: 6, bar: 7 });
 
-    ({ foo: 1, bar: 2, baz: 3 }).should.include.keys('foo', 'bar');
-    ({ foo: 1, bar: 2, baz: 3 }).should.contain.keys('bar', 'foo');
-    ({ foo: 1, bar: 2, baz: 3 }).should.contain.keys('baz');
+    ({ foo: 1, bar: 2, baz: 3 }).should.include.keys("foo", "bar");
+    ({ foo: 1, bar: 2, baz: 3 }).should.contain.keys("bar", "foo");
+    ({ foo: 1, bar: 2, baz: 3 }).should.contain.keys("baz");
 
-    ({ foo: 1, bar: 2 }).should.contain.keys('foo');
-    ({ foo: 1, bar: 2 }).should.contain.keys('bar', 'foo');
-    ({ foo: 1, bar: 2 }).should.contain.keys(['foo']);
-    ({ foo: 1, bar: 2 }).should.contain.keys(['bar']);
-    ({ foo: 1, bar: 2 }).should.contain.keys(['bar', 'foo']);
-    ({ foo: 1, bar: 2 }).should.contain.keys({ 'foo': 6 });
-    ({ foo: 1, bar: 2 }).should.contain.keys({ 'bar': 7 });
-    ({ foo: 1, bar: 2 }).should.contain.keys({ 'foo': 6 });
+    ({ foo: 1, bar: 2 }).should.contain.keys("foo");
+    ({ foo: 1, bar: 2 }).should.contain.keys("bar", "foo");
+    ({ foo: 1, bar: 2 }).should.contain.keys(["foo"]);
+    ({ foo: 1, bar: 2 }).should.contain.keys(["bar"]);
+    ({ foo: 1, bar: 2 }).should.contain.keys(["bar", "foo"]);
+    ({ foo: 1, bar: 2 }).should.contain.keys({ foo: 6 });
+    ({ foo: 1, bar: 2 }).should.contain.keys({ bar: 7 });
+    ({ foo: 1, bar: 2 }).should.contain.keys({ foo: 6 });
 
-    ({ foo: 1, bar: 2 }).should.not.have.keys('baz');
-    ({ foo: 1, bar: 2 }).should.not.have.keys('foo');
-    ({ foo: 1, bar: 2 }).should.not.have.keys('foo', 'baz');
-    ({ foo: 1, bar: 2 }).should.not.contain.keys('baz');
-    ({ foo: 1, bar: 2 }).should.not.contain.keys('foo', 'baz');
-    ({ foo: 1, bar: 2 }).should.not.contain.keys('baz', 'foo');
+    ({ foo: 1, bar: 2 }).should.not.have.keys("baz");
+    ({ foo: 1, bar: 2 }).should.not.have.keys("foo");
+    ({ foo: 1, bar: 2 }).should.not.have.keys("foo", "baz");
+    ({ foo: 1, bar: 2 }).should.not.contain.keys("baz");
+    ({ foo: 1, bar: 2 }).should.not.contain.keys("foo", "baz");
+    ({ foo: 1, bar: 2 }).should.not.contain.keys("baz", "foo");
 
-    ({ foo: 1, bar: 2 }).should.have.any.keys('foo', 'baz');
-    ({ foo: 1, bar: 2 }).should.have.any.keys('foo');
-    ({ foo: 1, bar: 2 }).should.contain.any.keys('bar', 'baz');
-    ({ foo: 1, bar: 2 }).should.contain.any.keys(['foo']);
-    ({ foo: 1, bar: 2 }).should.have.all.keys(['bar', 'foo']);
-    ({ foo: 1, bar: 2 }).should.contain.all.keys(['bar', 'foo']);
-    ({ foo: 1, bar: 2 }).should.contain.any.keys({ 'foo': 6 });
-    ({ foo: 1, bar: 2 }).should.have.all.keys({ 'foo': 6, 'bar': 7 });
-    ({ foo: 1, bar: 2 }).should.contain.all.keys({ 'bar': 7, 'foo': 6 });
+    ({ foo: 1, bar: 2 }).should.have.any.keys("foo", "baz");
+    ({ foo: 1, bar: 2 }).should.have.any.keys("foo");
+    ({ foo: 1, bar: 2 }).should.contain.any.keys("bar", "baz");
+    ({ foo: 1, bar: 2 }).should.contain.any.keys(["foo"]);
+    ({ foo: 1, bar: 2 }).should.have.all.keys(["bar", "foo"]);
+    ({ foo: 1, bar: 2 }).should.contain.all.keys(["bar", "foo"]);
+    ({ foo: 1, bar: 2 }).should.contain.any.keys({ foo: 6 });
+    ({ foo: 1, bar: 2 }).should.have.all.keys({ foo: 6, bar: 7 });
+    ({ foo: 1, bar: 2 }).should.contain.all.keys({ bar: 7, foo: 6 });
 
-    ({ foo: 1, bar: 2 }).should.not.have.any.keys('baz', 'abc', 'def');
-    ({ foo: 1, bar: 2 }).should.not.have.any.keys('baz');
-    ({ foo: 1, bar: 2 }).should.not.contain.any.keys('baz');
-    ({ foo: 1, bar: 2 }).should.not.have.all.keys(['baz', 'foo']);
-    ({ foo: 1, bar: 2 }).should.not.contain.all.keys(['baz', 'foo']);
-    ({ foo: 1, bar: 2 }).should.not.have.all.keys({ 'baz': 8, 'foo': 7 });
+    ({ foo: 1, bar: 2 }).should.not.have.any.keys("baz", "abc", "def");
+    ({ foo: 1, bar: 2 }).should.not.have.any.keys("baz");
+    ({ foo: 1, bar: 2 }).should.not.contain.any.keys("baz");
+    ({ foo: 1, bar: 2 }).should.not.have.all.keys(["baz", "foo"]);
+    ({ foo: 1, bar: 2 }).should.not.contain.all.keys(["baz", "foo"]);
+    ({ foo: 1, bar: 2 }).should.not.have.all.keys({ baz: 8, foo: 7 });
 
-    ({ foo: 1, bar: 2 }).should.not.contain.all.keys({ 'baz': 8, 'foo': 7 });
+    ({ foo: 1, bar: 2 }).should.not.contain.all.keys({ baz: 8, foo: 7 });
 
     ({ 1: 1, 2: 2 }).should.have.keys(1, 2);
     ({ 1: 1, 2: 2 }).should.have.any.keys(1, 3);
     ({ 1: 1, 2: 2 }).should.contain.keys(1);
 
-    var enumProp1 = 'enumProp1'
-      , enumProp2 = 'enumProp2'
-      , nonEnumProp = 'nonEnumProp'
-      , obj = {};
+    var enumProp1 = "enumProp1",
+      enumProp2 = "enumProp2",
+      nonEnumProp = "nonEnumProp",
+      obj = {};
 
-    obj[enumProp1] = 'enumProp1';
-    obj[enumProp2] = 'enumProp2';
+    obj[enumProp1] = "enumProp1";
+    obj[enumProp2] = "enumProp2";
 
     Object.defineProperty(obj, nonEnumProp, {
-        enumerable: false,
-        value: 'nonEnumProp'
+      enumerable: false,
+      value: "nonEnumProp",
     });
 
     obj.should.have.all.keys([enumProp1, enumProp2]);
     obj.should.not.have.all.keys([enumProp1, enumProp2, nonEnumProp]);
 
-      var sym1 = Symbol('sym1')
-        , sym2 = Symbol('sym2')
-        , sym3 = Symbol('sym3')
-        , str = 'str'
-        , obj = {};
+    var sym1 = Symbol("sym1"),
+      sym2 = Symbol("sym2"),
+      sym3 = Symbol("sym3"),
+      str = "str",
+      obj = {};
 
-      obj[sym1] = 'sym1';
-      obj[sym2] = 'sym2';
-      obj[str] = 'str';
+    obj[sym1] = "sym1";
+    obj[sym2] = "sym2";
+    obj[str] = "str";
 
-      Object.defineProperty(obj, sym3, {
-        enumerable: false,
-        value: 'sym3'
-      });
+    Object.defineProperty(obj, sym3, {
+      enumerable: false,
+      value: "sym3",
+    });
 
-      obj.should.have.all.keys([sym1, sym2, str]);
-      obj.should.not.have.all.keys([sym1, sym2, sym3, str]);
+    obj.should.have.all.keys([sym1, sym2, str]);
+    obj.should.not.have.all.keys([sym1, sym2, sym3, str]);
 
-      // Not using Map constructor args because not supported in IE 11.
-      var aKey = {thisIs: 'anExampleObject'}
-        , anotherKey = {doingThisBecauseOf: 'referential equality'}
-        , testMap = new Map();
+    // Not using Map constructor args because not supported in IE 11.
+    var aKey = { thisIs: "anExampleObject" },
+      anotherKey = { doingThisBecauseOf: "referential equality" },
+      testMap = new Map();
 
-      testMap.set(aKey, 'aValue');
-      testMap.set(anotherKey, 'anotherValue');
+    testMap.set(aKey, "aValue");
+    testMap.set(anotherKey, "anotherValue");
 
-      testMap.should.have.any.keys(aKey);
-      testMap.should.have.any.keys('thisDoesNotExist', 'thisToo', aKey);
-      testMap.should.have.all.keys(aKey, anotherKey);
+    testMap.should.have.any.keys(aKey);
+    testMap.should.have.any.keys("thisDoesNotExist", "thisToo", aKey);
+    testMap.should.have.all.keys(aKey, anotherKey);
 
-      testMap.should.contain.all.keys(aKey);
-      testMap.should.not.contain.all.keys(aKey, 'thisDoesNotExist');
-      testMap.should.not.have.any.keys({iDoNot: 'exist'});
-      testMap.should.not.have.all.keys('thisDoesNotExist', 'thisToo', anotherKey);
+    testMap.should.contain.all.keys(aKey);
+    testMap.should.not.contain.all.keys(aKey, "thisDoesNotExist");
+    testMap.should.not.have.any.keys({ iDoNot: "exist" });
+    testMap.should.not.have.all.keys("thisDoesNotExist", "thisToo", anotherKey);
 
-      testMap.should.have.any.keys([aKey]);
-      testMap.should.have.any.keys([20, 1, aKey]);
-      testMap.should.have.all.keys([aKey, anotherKey]);
+    testMap.should.have.any.keys([aKey]);
+    testMap.should.have.any.keys([20, 1, aKey]);
+    testMap.should.have.all.keys([aKey, anotherKey]);
 
-      testMap.should.not.have.any.keys([{13: 37}, 'thisDoesNotExist', 'thisToo']);
-      testMap.should.not.have.any.keys([20, 1, {13: 37}]);
-      testMap.should.not.have.all.keys([aKey, {'iDoNot': 'exist'}]);
+    testMap.should.not.have.any.keys([
+      { 13: 37 },
+      "thisDoesNotExist",
+      "thisToo",
+    ]);
+    testMap.should.not.have.any.keys([20, 1, { 13: 37 }]);
+    testMap.should.not.have.all.keys([aKey, { iDoNot: "exist" }]);
 
-      // Ensure the assertions above use strict equality
-      err(function() {
-        testMap.should.have.any.keys({thisIs: 'anExampleObject'});
-      });
+    // Ensure the assertions above use strict equality
+    err(function () {
+      testMap.should.have.any.keys({ thisIs: "anExampleObject" });
+    });
 
-      err(function() {
-        testMap.should.have.all.keys({thisIs: 'anExampleObject'}, {doingThisBecauseOf: 'referential equality'});
-      });
+    err(function () {
+      testMap.should.have.all.keys(
+        { thisIs: "anExampleObject" },
+        { doingThisBecauseOf: "referential equality" },
+      );
+    });
 
-      err(function() {
-        testMap.should.contain.all.keys({thisIs: 'anExampleObject'});
-      });
+    err(function () {
+      testMap.should.contain.all.keys({ thisIs: "anExampleObject" });
+    });
 
-      err(function() {
-        testMap.should.have.any.keys([{thisIs: 'anExampleObject'}]);
-      });
+    err(function () {
+      testMap.should.have.any.keys([{ thisIs: "anExampleObject" }]);
+    });
 
-      err(function() {
-        testMap.should.have.all.keys([{thisIs: 'anExampleObject'}, {doingThisBecauseOf: 'referential equality'}]);
-      });
+    err(function () {
+      testMap.should.have.all.keys([
+        { thisIs: "anExampleObject" },
+        { doingThisBecauseOf: "referential equality" },
+      ]);
+    });
 
-      // Using the same assertions as above but with `.deep` flag instead of using referential equality
-      testMap.should.have.any.deep.keys({thisIs: 'anExampleObject'});
-      testMap.should.have.any.deep.keys('thisDoesNotExist', 'thisToo', {thisIs: 'anExampleObject'});
+    // Using the same assertions as above but with `.deep` flag instead of using referential equality
+    testMap.should.have.any.deep.keys({ thisIs: "anExampleObject" });
+    testMap.should.have.any.deep.keys("thisDoesNotExist", "thisToo", {
+      thisIs: "anExampleObject",
+    });
 
-      testMap.should.contain.all.deep.keys({thisIs: 'anExampleObject'});
-      testMap.should.not.contain.all.deep.keys({thisIs: 'anExampleObject'}, 'thisDoesNotExist');
-      testMap.should.not.have.any.deep.keys({iDoNot: 'exist'});
-      testMap.should.not.have.all.deep.keys('thisDoesNotExist', 'thisToo', {doingThisBecauseOf: 'referential equality'});
+    testMap.should.contain.all.deep.keys({ thisIs: "anExampleObject" });
+    testMap.should.not.contain.all.deep.keys(
+      { thisIs: "anExampleObject" },
+      "thisDoesNotExist",
+    );
+    testMap.should.not.have.any.deep.keys({ iDoNot: "exist" });
+    testMap.should.not.have.all.deep.keys("thisDoesNotExist", "thisToo", {
+      doingThisBecauseOf: "referential equality",
+    });
 
-      testMap.should.have.any.deep.keys([{thisIs: 'anExampleObject'}]);
-      testMap.should.have.any.deep.keys([20, 1, {thisIs: 'anExampleObject'}]);
+    testMap.should.have.any.deep.keys([{ thisIs: "anExampleObject" }]);
+    testMap.should.have.any.deep.keys([20, 1, { thisIs: "anExampleObject" }]);
 
-      testMap.should.have.all.deep.keys([{thisIs: 'anExampleObject'}, {doingThisBecauseOf: 'referential equality'}]);
+    testMap.should.have.all.deep.keys([
+      { thisIs: "anExampleObject" },
+      { doingThisBecauseOf: "referential equality" },
+    ]);
 
-      testMap.should.not.have.any.deep.keys([{13: 37}, 'thisDoesNotExist', 'thisToo']);
-      testMap.should.not.have.any.deep.keys([20, 1, {13: 37}]);
+    testMap.should.not.have.any.deep.keys([
+      { 13: 37 },
+      "thisDoesNotExist",
+      "thisToo",
+    ]);
+    testMap.should.not.have.any.deep.keys([20, 1, { 13: 37 }]);
 
-      var weirdMapKey1 = Object.create(null)
-        , weirdMapKey2 = {toString: NaN}
-        , weirdMapKey3 = []
-        , weirdMap = new Map();
+    var weirdMapKey1 = Object.create(null),
+      weirdMapKey2 = { toString: NaN },
+      weirdMapKey3 = [],
+      weirdMap = new Map();
 
-      weirdMap.set(weirdMapKey1, 'val1');
-      weirdMap.set(weirdMapKey2, 'val2');
+    weirdMap.set(weirdMapKey1, "val1");
+    weirdMap.set(weirdMapKey2, "val2");
 
-      weirdMap.should.have.all.keys([weirdMapKey1, weirdMapKey2]);
-      weirdMap.should.not.have.all.keys([weirdMapKey1, weirdMapKey3]);
+    weirdMap.should.have.all.keys([weirdMapKey1, weirdMapKey2]);
+    weirdMap.should.not.have.all.keys([weirdMapKey1, weirdMapKey3]);
 
-        var symMapKey1 = Symbol()
-          , symMapKey2 = Symbol()
-          , symMapKey3 = Symbol()
-          , symMap = new Map();
+    var symMapKey1 = Symbol(),
+      symMapKey2 = Symbol(),
+      symMapKey3 = Symbol(),
+      symMap = new Map();
 
-        symMap.set(symMapKey1, 'val1');
-        symMap.set(symMapKey2, 'val2');
+    symMap.set(symMapKey1, "val1");
+    symMap.set(symMapKey2, "val2");
 
-        symMap.should.have.all.keys(symMapKey1, symMapKey2);
-        symMap.should.have.any.keys(symMapKey1, symMapKey3);
-        symMap.should.contain.all.keys(symMapKey2, symMapKey1);
-        symMap.should.contain.any.keys(symMapKey3, symMapKey1);
+    symMap.should.have.all.keys(symMapKey1, symMapKey2);
+    symMap.should.have.any.keys(symMapKey1, symMapKey3);
+    symMap.should.contain.all.keys(symMapKey2, symMapKey1);
+    symMap.should.contain.any.keys(symMapKey3, symMapKey1);
 
-        symMap.should.not.have.all.keys(symMapKey1, symMapKey3);
-        symMap.should.not.have.any.keys(symMapKey3);
-        symMap.should.not.contain.all.keys(symMapKey3, symMapKey1);
-        symMap.should.not.contain.any.keys(symMapKey3);
+    symMap.should.not.have.all.keys(symMapKey1, symMapKey3);
+    symMap.should.not.have.any.keys(symMapKey3);
+    symMap.should.not.contain.all.keys(symMapKey3, symMapKey1);
+    symMap.should.not.contain.any.keys(symMapKey3);
 
-      var errMap = new Map();
+    var errMap = new Map();
 
-      errMap.set({ foo: 1 });
+    errMap.set({ foo: 1 });
 
-      err(function(){
-        errMap.should.have.keys();
-      }, "keys required");
+    err(function () {
+      errMap.should.have.keys();
+    }, "keys required");
 
-      err(function(){
-        errMap.should.have.keys([]);
-      }, "keys required");
+    err(function () {
+      errMap.should.have.keys([]);
+    }, "keys required");
 
-      err(function(){
-        errMap.should.contain.keys();
-      }, "keys required");
+    err(function () {
+      errMap.should.contain.keys();
+    }, "keys required");
 
-      err(function(){
-        errMap.should.contain.keys([]);
-      }, "keys required");
+    err(function () {
+      errMap.should.contain.keys([]);
+    }, "keys required");
 
-      // Uncomment these after solving https://github.com/chaijs/chai/issues/662
-      // This should fail because of referential equality (this is a strict comparison)
-      // err(function(){
-      //   new Map([[{foo: 1}, 'bar']]).should.contain.keys({ foo: 1 });
-      // }, 'expected [ [ { foo: 1 }, 'bar' ] ] to contain key { foo: 1 }');
+    // Uncomment these after solving https://github.com/chaijs/chai/issues/662
+    // This should fail because of referential equality (this is a strict comparison)
+    // err(function(){
+    //   new Map([[{foo: 1}, 'bar']]).should.contain.keys({ foo: 1 });
+    // }, 'expected [ [ { foo: 1 }, 'bar' ] ] to contain key { foo: 1 }');
 
-      // err(function(){
-      //   new Map([[{foo: 1}, 'bar']]).should.contain.deep.keys({ iDoNotExist: 0 });
-      // }, 'expected [ { foo: 1 } ] to deeply contain key { iDoNotExist: 0 }');
+    // err(function(){
+    //   new Map([[{foo: 1}, 'bar']]).should.contain.deep.keys({ iDoNotExist: 0 });
+    // }, 'expected [ { foo: 1 } ] to deeply contain key { iDoNotExist: 0 }');
 
-      // Not using Set constructor args because not supported in IE 11.
-      var aKey = {thisIs: 'anExampleObject'}
-        , anotherKey = {doingThisBecauseOf: 'referential equality'}
-        , testSet = new Set();
+    // Not using Set constructor args because not supported in IE 11.
+    var aKey = { thisIs: "anExampleObject" },
+      anotherKey = { doingThisBecauseOf: "referential equality" },
+      testSet = new Set();
 
-      testSet.add(aKey);
-      testSet.add(anotherKey);
+    testSet.add(aKey);
+    testSet.add(anotherKey);
 
-      testSet.should.have.any.keys(aKey);
-      testSet.should.have.any.keys('thisDoesNotExist', 'thisToo', aKey);
-      testSet.should.have.all.keys(aKey, anotherKey);
+    testSet.should.have.any.keys(aKey);
+    testSet.should.have.any.keys("thisDoesNotExist", "thisToo", aKey);
+    testSet.should.have.all.keys(aKey, anotherKey);
 
-      testSet.should.contain.all.keys(aKey);
-      testSet.should.not.contain.all.keys(aKey, 'thisDoesNotExist');
+    testSet.should.contain.all.keys(aKey);
+    testSet.should.not.contain.all.keys(aKey, "thisDoesNotExist");
 
-      testSet.should.not.have.any.keys({iDoNot: 'exist'});
-      testSet.should.not.have.any.keys('thisIsNotAkey', {iDoNot: 'exist'}, {33: 20});
-      testSet.should.not.have.all.keys('thisDoesNotExist', 'thisToo', anotherKey);
+    testSet.should.not.have.any.keys({ iDoNot: "exist" });
+    testSet.should.not.have.any.keys(
+      "thisIsNotAkey",
+      { iDoNot: "exist" },
+      { 33: 20 },
+    );
+    testSet.should.not.have.all.keys("thisDoesNotExist", "thisToo", anotherKey);
 
-      testSet.should.have.any.keys([aKey]);
-      testSet.should.have.any.keys([20, 1, aKey]);
-      testSet.should.have.all.keys([aKey, anotherKey]);
+    testSet.should.have.any.keys([aKey]);
+    testSet.should.have.any.keys([20, 1, aKey]);
+    testSet.should.have.all.keys([aKey, anotherKey]);
 
-      testSet.should.not.have.any.keys([{13: 37}, 'thisDoesNotExist', 'thisToo']);
-      testSet.should.not.have.any.keys([20, 1, {13: 37}]);
-      testSet.should.not.have.all.keys([aKey, {'iDoNot': 'exist'}]);
+    testSet.should.not.have.any.keys([
+      { 13: 37 },
+      "thisDoesNotExist",
+      "thisToo",
+    ]);
+    testSet.should.not.have.any.keys([20, 1, { 13: 37 }]);
+    testSet.should.not.have.all.keys([aKey, { iDoNot: "exist" }]);
 
-      // Ensure the assertions above use strict equality
-      err(function() {
-        testSet.should.have.any.keys({thisIs: 'anExampleObject'});
-      });
+    // Ensure the assertions above use strict equality
+    err(function () {
+      testSet.should.have.any.keys({ thisIs: "anExampleObject" });
+    });
 
-      err(function() {
-        testSet.should.have.all.keys({thisIs: 'anExampleObject'}, {doingThisBecauseOf: 'referential equality'});
-      });
+    err(function () {
+      testSet.should.have.all.keys(
+        { thisIs: "anExampleObject" },
+        { doingThisBecauseOf: "referential equality" },
+      );
+    });
 
-      err(function() {
-        testSet.should.contain.all.keys({thisIs: 'anExampleObject'});
-      });
+    err(function () {
+      testSet.should.contain.all.keys({ thisIs: "anExampleObject" });
+    });
 
-      err(function() {
-        testSet.should.have.any.keys([{thisIs: 'anExampleObject'}]);
-      });
+    err(function () {
+      testSet.should.have.any.keys([{ thisIs: "anExampleObject" }]);
+    });
 
-      err(function() {
-        testSet.should.have.all.keys([{thisIs: 'anExampleObject'}, {doingThisBecauseOf: 'referential equality'}]);
-      });
+    err(function () {
+      testSet.should.have.all.keys([
+        { thisIs: "anExampleObject" },
+        { doingThisBecauseOf: "referential equality" },
+      ]);
+    });
 
-      // Using the same assertions as above but with `.deep` flag instead of using referential equality
-      testSet.should.have.any.deep.keys({thisIs: 'anExampleObject'});
-      testSet.should.have.any.deep.keys('thisDoesNotExist', 'thisToo', {thisIs: 'anExampleObject'});
+    // Using the same assertions as above but with `.deep` flag instead of using referential equality
+    testSet.should.have.any.deep.keys({ thisIs: "anExampleObject" });
+    testSet.should.have.any.deep.keys("thisDoesNotExist", "thisToo", {
+      thisIs: "anExampleObject",
+    });
 
-      testSet.should.contain.all.deep.keys({thisIs: 'anExampleObject'});
-      testSet.should.not.contain.all.deep.keys({thisIs: 'anExampleObject'}, 'thisDoesNotExist');
+    testSet.should.contain.all.deep.keys({ thisIs: "anExampleObject" });
+    testSet.should.not.contain.all.deep.keys(
+      { thisIs: "anExampleObject" },
+      "thisDoesNotExist",
+    );
 
-      testSet.should.not.have.any.deep.keys({iDoNot: 'exist'});
-      testSet.should.not.have.any.deep.keys('thisIsNotAkey', {iDoNot: 'exist'}, {33: 20});
-      testSet.should.not.have.all.deep.keys('thisDoesNotExist', 'thisToo', {anotherObj: 'foo'});
+    testSet.should.not.have.any.deep.keys({ iDoNot: "exist" });
+    testSet.should.not.have.any.deep.keys(
+      "thisIsNotAkey",
+      { iDoNot: "exist" },
+      { 33: 20 },
+    );
+    testSet.should.not.have.all.deep.keys("thisDoesNotExist", "thisToo", {
+      anotherObj: "foo",
+    });
 
-      testSet.should.have.any.deep.keys([{thisIs: 'anExampleObject'}]);
-      testSet.should.have.any.deep.keys([20, 1, {thisIs: 'anExampleObject'}]);
+    testSet.should.have.any.deep.keys([{ thisIs: "anExampleObject" }]);
+    testSet.should.have.any.deep.keys([20, 1, { thisIs: "anExampleObject" }]);
 
-      testSet.should.have.all.deep.keys({thisIs: 'anExampleObject'}, {doingThisBecauseOf: 'referential equality'});
+    testSet.should.have.all.deep.keys(
+      { thisIs: "anExampleObject" },
+      { doingThisBecauseOf: "referential equality" },
+    );
 
-      testSet.should.not.have.any.deep.keys([{13: 37}, 'thisDoesNotExist', 'thisToo']);
-      testSet.should.not.have.any.deep.keys([20, 1, {13: 37}]);
-      testSet.should.not.have.all.deep.keys([{thisIs: 'anExampleObject'}, {'iDoNot': 'exist'}])
+    testSet.should.not.have.any.deep.keys([
+      { 13: 37 },
+      "thisDoesNotExist",
+      "thisToo",
+    ]);
+    testSet.should.not.have.any.deep.keys([20, 1, { 13: 37 }]);
+    testSet.should.not.have.all.deep.keys([
+      { thisIs: "anExampleObject" },
+      { iDoNot: "exist" },
+    ]);
 
-      var weirdSetKey1 = Object.create(null)
-        , weirdSetKey2 = {toString: NaN}
-        , weirdSetKey3 = []
-        , weirdSet = new Set();
+    var weirdSetKey1 = Object.create(null),
+      weirdSetKey2 = { toString: NaN },
+      weirdSetKey3 = [],
+      weirdSet = new Set();
 
-      weirdSet.add(weirdSetKey1);
-      weirdSet.add(weirdSetKey2);
+    weirdSet.add(weirdSetKey1);
+    weirdSet.add(weirdSetKey2);
 
-      weirdSet.should.have.all.keys([weirdSetKey1, weirdSetKey2]);
-      weirdSet.should.not.have.all.keys([weirdSetKey1, weirdSetKey3]);
+    weirdSet.should.have.all.keys([weirdSetKey1, weirdSetKey2]);
+    weirdSet.should.not.have.all.keys([weirdSetKey1, weirdSetKey3]);
 
-    var symSetKey1 = Symbol()
-    , symSetKey2 = Symbol()
-    , symSetKey3 = Symbol()
-    , symSet = new Set();
+    var symSetKey1 = Symbol(),
+      symSetKey2 = Symbol(),
+      symSetKey3 = Symbol(),
+      symSet = new Set();
 
     symSet.add(symSetKey1);
     symSet.add(symSetKey2);
@@ -2363,222 +2671,240 @@ describe('should', function() {
 
     errSet.add({ foo: 1 });
 
-    err(function(){
+    err(function () {
       errSet.should.have.keys();
     }, "keys required");
 
-    err(function(){
+    err(function () {
       errSet.should.have.keys([]);
     }, "keys required");
 
-    err(function(){
+    err(function () {
       errSet.should.contain.keys();
     }, "keys required");
 
-    err(function(){
+    err(function () {
       errSet.should.contain.keys([]);
     }, "keys required");
 
-    err(function(){
-      new Set([{foo: 1}]).should.contain.keys({ foo: 1 });
-    }, 'expected Set{ { foo: 1 } } to contain key { foo: 1 }');
+    err(function () {
+      new Set([{ foo: 1 }]).should.contain.keys({ foo: 1 });
+    }, "expected Set{ { foo: 1 } } to contain key { foo: 1 }");
 
-    err(function(){
-      new Set([{foo: 1}]).should.contain.deep.keys({ iDoNotExist: 0 });
-    }, 'expected Set{ { foo: 1 } } to deeply contain key { iDoNotExist: +0 }');
+    err(function () {
+      new Set([{ foo: 1 }]).should.contain.deep.keys({ iDoNotExist: 0 });
+    }, "expected Set{ { foo: 1 } } to deeply contain key { iDoNotExist: +0 }");
 
-    err(function(){
+    err(function () {
       ({ foo: 1 }).should.have.keys();
     }, "keys required");
 
-    err(function(){
+    err(function () {
       ({ foo: 1 }).should.have.keys([]);
     }, "keys required");
 
-    err(function(){
+    err(function () {
       ({ foo: 1 }).should.not.have.keys([]);
     }, "keys required");
 
-    err(function(){
+    err(function () {
       ({ foo: 1 }).should.contain.keys([]);
     }, "keys required");
 
-    var mixedArgsMsg = 'when testing keys against an object or an array you must give a single Array|Object|String argument or multiple String arguments'
+    var mixedArgsMsg =
+      "when testing keys against an object or an array you must give a single Array|Object|String argument or multiple String arguments";
 
-    err(function(){
-      ({}).should.contain.keys(['a'], "b");
+    err(function () {
+      ({}).should.contain.keys(["a"], "b");
     }, mixedArgsMsg);
 
-    err(function(){
-      ({}).should.contain.keys({ 'a': 1 }, "b");
+    err(function () {
+      ({}).should.contain.keys({ a: 1 }, "b");
     }, mixedArgsMsg);
 
-    err(function(){
-      ({ foo: 1 }).should.have.keys(['bar']);
+    err(function () {
+      ({ foo: 1 }).should.have.keys(["bar"]);
     }, "expected { foo: 1 } to have key 'bar'");
 
-    err(function(){
-      ({ foo: 1 }).should.have.keys(['bar', 'baz']);
+    err(function () {
+      ({ foo: 1 }).should.have.keys(["bar", "baz"]);
     }, "expected { foo: 1 } to have keys 'bar', and 'baz'");
 
-    err(function(){
-      ({ foo: 1 }).should.have.keys(['foo', 'bar', 'baz']);
+    err(function () {
+      ({ foo: 1 }).should.have.keys(["foo", "bar", "baz"]);
     }, "expected { foo: 1 } to have keys 'foo', 'bar', and 'baz'");
 
-    err(function(){
-      ({ foo: 1 }).should.not.have.keys(['foo']);
+    err(function () {
+      ({ foo: 1 }).should.not.have.keys(["foo"]);
     }, "expected { foo: 1 } to not have key 'foo'");
 
-    err(function(){
-      ({ foo: 1 }).should.not.have.keys(['foo']);
+    err(function () {
+      ({ foo: 1 }).should.not.have.keys(["foo"]);
     }, "expected { foo: 1 } to not have key 'foo'");
 
-    err(function(){
-      ({ foo: 1, bar: 2 }).should.not.have.keys(['foo', 'bar']);
+    err(function () {
+      ({ foo: 1, bar: 2 }).should.not.have.keys(["foo", "bar"]);
     }, "expected { foo: 1, bar: 2 } to not have keys 'foo', and 'bar'");
 
-    err(function(){
-      ({ foo: 1 }).should.not.contain.keys(['foo']);
+    err(function () {
+      ({ foo: 1 }).should.not.contain.keys(["foo"]);
     }, "expected { foo: 1 } to not contain key 'foo'");
 
-    err(function(){
-      ({ foo: 1 }).should.contain.keys('foo', 'bar');
+    err(function () {
+      ({ foo: 1 }).should.contain.keys("foo", "bar");
     }, "expected { foo: 1 } to contain keys 'foo', and 'bar'");
 
-    err(function() {
-      ({ foo: 1 }).should.have.any.keys('baz');
+    err(function () {
+      ({ foo: 1 }).should.have.any.keys("baz");
     }, "expected { foo: 1 } to have key 'baz'");
 
-    err(function(){
-      ({ foo: 1, bar: 2 }).should.not.have.all.keys(['foo', 'bar']);
+    err(function () {
+      ({ foo: 1, bar: 2 }).should.not.have.all.keys(["foo", "bar"]);
     }, "expected { foo: 1, bar: 2 } to not have keys 'foo', and 'bar'");
 
-    err(function(){
-      ({ foo: 1, bar: 2 }).should.not.have.any.keys(['foo', 'baz']);
+    err(function () {
+      ({ foo: 1, bar: 2 }).should.not.have.any.keys(["foo", "baz"]);
     }, "expected { foo: 1, bar: 2 } to not have keys 'foo', or 'baz'");
 
     // repeat previous tests with Object as arg.
-    err(function(){
-      ({ foo: 1 }).should.have.keys({ 'bar': 1 });
+    err(function () {
+      ({ foo: 1 }).should.have.keys({ bar: 1 });
     }, "expected { foo: 1 } to have key 'bar'");
 
-    err(function(){
-      ({ foo: 1 }).should.have.keys({ 'bar': 1, 'baz': 1});
+    err(function () {
+      ({ foo: 1 }).should.have.keys({ bar: 1, baz: 1 });
     }, "expected { foo: 1 } to have keys 'bar', and 'baz'");
 
-    err(function(){
-      ({ foo: 1 }).should.have.keys({ 'foo': 1, 'bar': 1, 'baz': 1});
+    err(function () {
+      ({ foo: 1 }).should.have.keys({ foo: 1, bar: 1, baz: 1 });
     }, "expected { foo: 1 } to have keys 'foo', 'bar', and 'baz'");
 
-    err(function(){
-      ({ foo: 1 }).should.not.have.keys({ 'foo': 1 });
+    err(function () {
+      ({ foo: 1 }).should.not.have.keys({ foo: 1 });
     }, "expected { foo: 1 } to not have key 'foo'");
 
-    err(function(){
-      ({ foo: 1 }).should.not.have.keys({ 'foo': 1 });
+    err(function () {
+      ({ foo: 1 }).should.not.have.keys({ foo: 1 });
     }, "expected { foo: 1 } to not have key 'foo'");
 
-    err(function(){
-      ({ foo: 1, bar: 2 }).should.not.have.keys({ 'foo': 1, 'bar': 1});
+    err(function () {
+      ({ foo: 1, bar: 2 }).should.not.have.keys({ foo: 1, bar: 1 });
     }, "expected { foo: 1, bar: 2 } to not have keys 'foo', and 'bar'");
 
-    err(function(){
-      ({ foo: 1 }).should.not.contain.keys({ 'foo': 1 });
+    err(function () {
+      ({ foo: 1 }).should.not.contain.keys({ foo: 1 });
     }, "expected { foo: 1 } to not contain key 'foo'");
 
-    err(function(){
-      ({ foo: 1 }).should.contain.keys('foo', 'bar');
+    err(function () {
+      ({ foo: 1 }).should.contain.keys("foo", "bar");
     }, "expected { foo: 1 } to contain keys 'foo', and 'bar'");
 
-    err(function() {
-      ({ foo: 1 }).should.have.any.keys('baz');
+    err(function () {
+      ({ foo: 1 }).should.have.any.keys("baz");
     }, "expected { foo: 1 } to have key 'baz'");
 
-    err(function(){
-      ({ foo: 1, bar: 2 }).should.not.have.all.keys({ 'foo': 1, 'bar': 1});
+    err(function () {
+      ({ foo: 1, bar: 2 }).should.not.have.all.keys({ foo: 1, bar: 1 });
     }, "expected { foo: 1, bar: 2 } to not have keys 'foo', and 'bar'");
 
-    err(function(){
-      ({ foo: 1, bar: 2 }).should.not.have.any.keys({ 'foo': 1, 'baz': 1});
+    err(function () {
+      ({ foo: 1, bar: 2 }).should.not.have.any.keys({ foo: 1, baz: 1 });
     }, "expected { foo: 1, bar: 2 } to not have keys 'foo', or 'baz'");
-
   });
 
-  it('keys(array) will not mutate array (#359)', function () {
-      var expected = [ 'b', 'a' ];
-      var original_order = [ 'b', 'a' ];
-      var obj = { "b": 1, "a": 1 };
-      expected.should.deep.equal(original_order);
-      obj.should.keys(original_order);
-      expected.should.deep.equal(original_order);
+  it("keys(array) will not mutate array (#359)", function () {
+    var expected = ["b", "a"];
+    var original_order = ["b", "a"];
+    var obj = { b: 1, a: 1 };
+    expected.should.deep.equal(original_order);
+    obj.should.keys(original_order);
+    expected.should.deep.equal(original_order);
   });
 
-  it('throw', function () {
+  it("throw", function () {
     // See GH-45: some poorly-constructed custom errors don't have useful names
     // on either their constructor or their constructor prototype, but instead
     // only set the name inside the constructor itself.
     var PoorlyConstructedError = function () {
-      this.name = 'PoorlyConstructedError';
+      this.name = "PoorlyConstructedError";
     };
     PoorlyConstructedError.prototype = Object.create(Error.prototype);
 
     function CustomError(message) {
-        this.name = 'CustomError';
-        this.message = message;
+      this.name = "CustomError";
+      this.message = message;
     }
     CustomError.prototype = Error.prototype;
 
-    var specificError = new RangeError('boo');
+    var specificError = new RangeError("boo");
 
-    var goodFn = function () { 1==1; }
-      , badFn = function () { throw new Error('testing'); }
-      , stringErrFn = function () { throw 'testing'; }
-      , refErrFn = function () { throw new ReferenceError('hello'); }
-      , ickyErrFn = function () { throw new PoorlyConstructedError(); }
-      , specificErrFn = function () { throw specificError; }
-      , customErrFn = function () { throw new CustomError('foo'); }
-      , emptyErrFn = function () { throw new Error(); }
-      , emptyStringErrFn = function () { throw new Error(''); };
+    var goodFn = function () {
+        1 == 1;
+      },
+      badFn = function () {
+        throw new Error("testing");
+      },
+      stringErrFn = function () {
+        throw "testing";
+      },
+      refErrFn = function () {
+        throw new ReferenceError("hello");
+      },
+      ickyErrFn = function () {
+        throw new PoorlyConstructedError();
+      },
+      specificErrFn = function () {
+        throw specificError;
+      },
+      customErrFn = function () {
+        throw new CustomError("foo");
+      },
+      emptyErrFn = function () {
+        throw new Error();
+      },
+      emptyStringErrFn = function () {
+        throw new Error("");
+      };
 
-    (goodFn).should.not.throw();
-    (goodFn).should.not.throw(Error);
-    (goodFn).should.not.throw(specificError);
-    (badFn).should.throw();
-    (badFn).should.throw(Error);
-    (badFn).should.not.throw(ReferenceError);
-    (badFn).should.not.throw(specificError);
-    (stringErrFn).should.throw();
-    (stringErrFn).should.not.throw(ReferenceError);
-    (stringErrFn).should.not.throw(specificError);
-    (refErrFn).should.throw();
-    (refErrFn).should.throw(ReferenceError);
-    (refErrFn).should.throw(Error);
-    (refErrFn).should.not.throw(TypeError);
-    (refErrFn).should.not.throw(specificError);
-    (ickyErrFn).should.throw();
-    (ickyErrFn).should.throw(PoorlyConstructedError);
-    (ickyErrFn).should.throw(Error);
-    (ickyErrFn).should.not.throw(specificError);
-    (specificErrFn).should.throw(specificError);
+    goodFn.should.not.throw();
+    goodFn.should.not.throw(Error);
+    goodFn.should.not.throw(specificError);
+    badFn.should.throw();
+    badFn.should.throw(Error);
+    badFn.should.not.throw(ReferenceError);
+    badFn.should.not.throw(specificError);
+    stringErrFn.should.throw();
+    stringErrFn.should.not.throw(ReferenceError);
+    stringErrFn.should.not.throw(specificError);
+    refErrFn.should.throw();
+    refErrFn.should.throw(ReferenceError);
+    refErrFn.should.throw(Error);
+    refErrFn.should.not.throw(TypeError);
+    refErrFn.should.not.throw(specificError);
+    ickyErrFn.should.throw();
+    ickyErrFn.should.throw(PoorlyConstructedError);
+    ickyErrFn.should.throw(Error);
+    ickyErrFn.should.not.throw(specificError);
+    specificErrFn.should.throw(specificError);
 
-    (goodFn).should.not.throw('testing');
-    (goodFn).should.not.throw(/testing/);
-    (badFn).should.throw(/testing/);
-    (badFn).should.throw('testing');
-    (badFn).should.not.throw(/hello/);
-    (badFn).should.not.throw('hello');
-    (emptyStringErrFn).should.throw('');
-    (emptyStringErrFn).should.not.throw('testing');
-    (badFn).should.throw('');
+    goodFn.should.not.throw("testing");
+    goodFn.should.not.throw(/testing/);
+    badFn.should.throw(/testing/);
+    badFn.should.throw("testing");
+    badFn.should.not.throw(/hello/);
+    badFn.should.not.throw("hello");
+    emptyStringErrFn.should.throw("");
+    emptyStringErrFn.should.not.throw("testing");
+    badFn.should.throw("");
 
-    (badFn).should.throw(Error, /testing/);
-    (badFn).should.throw(Error, 'testing');
-    (emptyErrFn).should.not.throw(Error, 'testing');
+    badFn.should.throw(Error, /testing/);
+    badFn.should.throw(Error, "testing");
+    emptyErrFn.should.not.throw(Error, "testing");
 
-    (stringErrFn).should.throw(/testing/);
-    (stringErrFn).should.throw('testing');
-    (stringErrFn).should.not.throw(/hello/);
-    (stringErrFn).should.not.throw('hello');
+    stringErrFn.should.throw(/testing/);
+    stringErrFn.should.throw("testing");
+    stringErrFn.should.not.throw(/hello/);
+    stringErrFn.should.not.throw("hello");
 
     should.throw(badFn);
     should.throw(refErrFn, ReferenceError);
@@ -2590,109 +2916,109 @@ describe('should', function() {
     should.not.throw(badFn, specificError);
 
     should.throw(badFn, Error, /testing/);
-    should.throw(badFn, Error, 'testing');
+    should.throw(badFn, Error, "testing");
 
-    (badFn).should.not.throw(Error, 'I am the wrong error message');
-    (badFn).should.not.throw(TypeError, 'testing');
+    badFn.should.not.throw(Error, "I am the wrong error message");
+    badFn.should.not.throw(TypeError, "testing");
 
-    err(function(){
-      (goodFn).should.throw();
+    err(function () {
+      goodFn.should.throw();
     }, /^expected \[Function( goodFn)*\] to throw an error$/);
 
-    err(function(){
-      (goodFn).should.throw(ReferenceError);
+    err(function () {
+      goodFn.should.throw(ReferenceError);
     }, /^expected \[Function( goodFn)*\] to throw ReferenceError$/);
 
-    err(function(){
-      (goodFn).should.throw(specificError);
+    err(function () {
+      goodFn.should.throw(specificError);
     }, /^expected \[Function( goodFn)*\] to throw 'RangeError: boo'$/);
 
-    err(function(){
-      (badFn).should.not.throw();
+    err(function () {
+      badFn.should.not.throw();
     }, /^expected \[Function( badFn)*\] to not throw an error but 'Error: testing' was thrown$/);
 
-    err(function(){
-      (badFn).should.throw(ReferenceError);
+    err(function () {
+      badFn.should.throw(ReferenceError);
     }, /^expected \[Function( badFn)*\] to throw 'ReferenceError' but 'Error: testing' was thrown$/);
 
-    err(function(){
-      (badFn).should.throw(specificError);
+    err(function () {
+      badFn.should.throw(specificError);
     }, /^expected \[Function( badFn)*\] to throw 'RangeError: boo' but 'Error: testing' was thrown$/);
 
-    err(function(){
-      (badFn).should.not.throw(Error);
+    err(function () {
+      badFn.should.not.throw(Error);
     }, /^expected \[Function( badFn)*\] to not throw 'Error' but 'Error: testing' was thrown$/);
 
-    err(function(){
-      (stringErrFn).should.not.throw();
+    err(function () {
+      stringErrFn.should.not.throw();
     }, /^expected \[Function( stringErrFn)*\] to not throw an error but 'testing' was thrown$/);
 
-    err(function(){
-      (stringErrFn).should.throw(ReferenceError);
+    err(function () {
+      stringErrFn.should.throw(ReferenceError);
     }, /^expected \[Function( stringErrFn)*\] to throw 'ReferenceError' but 'testing' was thrown$/);
 
-    err(function(){
-      (stringErrFn).should.throw(specificError);
+    err(function () {
+      stringErrFn.should.throw(specificError);
     }, /^expected \[Function( stringErrFn)*\] to throw 'RangeError: boo' but 'testing' was thrown$/);
 
-    err(function(){
-      (stringErrFn).should.not.throw('testing');
+    err(function () {
+      stringErrFn.should.not.throw("testing");
     }, /^expected \[Function( stringErrFn)*\] to throw error not including 'testing'$/);
 
-    err(function(){
-      (refErrFn).should.not.throw(ReferenceError);
+    err(function () {
+      refErrFn.should.not.throw(ReferenceError);
     }, /^expected \[Function( refErrFn)*\] to not throw 'ReferenceError' but 'ReferenceError: hello' was thrown$/);
 
-    err(function(){
-      (badFn).should.throw(PoorlyConstructedError);
+    err(function () {
+      badFn.should.throw(PoorlyConstructedError);
     }, /^expected \[Function( badFn)*\] to throw 'PoorlyConstructedError' but 'Error: testing' was thrown$/);
 
-    err(function(){
-      (ickyErrFn).should.not.throw(PoorlyConstructedError);
+    err(function () {
+      ickyErrFn.should.not.throw(PoorlyConstructedError);
     }, /^(expected \[Function( ickyErrFn)*\] to not throw 'PoorlyConstructedError' but)(.*)(PoorlyConstructedError|\{ Object \()(.*)(was thrown)$/);
 
-    err(function(){
-      (ickyErrFn).should.throw(ReferenceError);
+    err(function () {
+      ickyErrFn.should.throw(ReferenceError);
     }, /^(expected \[Function( ickyErrFn)*\] to throw 'ReferenceError' but)(.*)(PoorlyConstructedError|\{ Object \()(.*)(was thrown)$/);
 
-    err(function(){
-      (specificErrFn).should.throw(new ReferenceError('eek'));
+    err(function () {
+      specificErrFn.should.throw(new ReferenceError("eek"));
     }, /^expected \[Function( specificErrFn)*\] to throw 'ReferenceError: eek' but 'RangeError: boo' was thrown$/);
 
-    err(function(){
-      (specificErrFn).should.not.throw(specificError);
+    err(function () {
+      specificErrFn.should.not.throw(specificError);
     }, /^expected \[Function( specificErrFn)*\] to not throw 'RangeError: boo'$/);
 
-    err(function (){
-      (badFn).should.not.throw(/testing/);
+    err(function () {
+      badFn.should.not.throw(/testing/);
     }, /^expected \[Function( badFn)*\] to throw error not matching \/testing\/$/);
 
     err(function () {
-      (badFn).should.throw(/hello/);
+      badFn.should.throw(/hello/);
     }, /^expected \[Function( badFn)*\] to throw error matching \/hello\/ but got \'testing\'$/);
 
     err(function () {
-      (badFn).should.throw(Error, /hello/, 'blah');
+      badFn.should.throw(Error, /hello/, "blah");
     }, /^blah: expected \[Function( badFn)*\] to throw error matching \/hello\/ but got 'testing'$/);
 
     err(function () {
-      (badFn).should.throw(Error, 'hello', 'blah');
+      badFn.should.throw(Error, "hello", "blah");
     }, /^blah: expected \[Function( badFn)*\] to throw error including 'hello' but got 'testing'$/);
 
     err(function () {
-      (customErrFn).should.not.throw();
+      customErrFn.should.not.throw();
     }, /^expected \[Function( customErrFn)*\] to not throw an error but 'CustomError: foo' was thrown$/);
 
-    err(function(){
-      (badFn).should.not.throw(Error, 'testing');
+    err(function () {
+      badFn.should.not.throw(Error, "testing");
     }, /^expected \[Function( badFn)*\] to not throw 'Error' but 'Error: testing' was thrown$/);
 
-    err(function(){
-      (emptyStringErrFn).should.not.throw(Error, '');
+    err(function () {
+      emptyStringErrFn.should.not.throw(Error, "");
     }, /^expected \[Function( emptyStringErrFn)*\] to not throw 'Error' but 'Error' was thrown$/);
 
-    err(function(){
-      (emptyStringErrFn).should.not.throw('');
+    err(function () {
+      emptyStringErrFn.should.not.throw("");
     }, /^expected \[Function( emptyStringErrFn)*\] to throw error not including ''$/);
 
     err(function () {
@@ -2700,95 +3026,95 @@ describe('should', function() {
     }, "expected {} to be a function");
 
     err(function () {
-      ({}).should.throw(Error, 'testing', 'blah');
+      ({}).should.throw(Error, "testing", "blah");
     }, "blah: expected {} to be a function");
   });
 
-  it('respondTo', function(){
-    function Foo(){};
-    Foo.prototype.bar = function(){};
-    Foo.func = function(){};
+  it("respondTo", function () {
+    function Foo() {}
+    Foo.prototype.bar = function () {};
+    Foo.func = function () {};
 
     var bar = {};
-    bar.foo = function(){};
+    bar.foo = function () {};
 
-    Foo.should.respondTo('bar');
-    Foo.should.not.respondTo('foo');
-    Foo.should.itself.respondTo('func');
-    Foo.should.itself.not.respondTo('bar');
+    Foo.should.respondTo("bar");
+    Foo.should.not.respondTo("foo");
+    Foo.should.itself.respondTo("func");
+    Foo.should.itself.not.respondTo("bar");
 
-    bar.should.respondTo('foo');
+    bar.should.respondTo("foo");
 
-    err(function(){
-      Foo.should.respondTo('baz', 'constructor');
+    err(function () {
+      Foo.should.respondTo("baz", "constructor");
     }, /^(constructor: expected)(.*)(\[Function Foo\])(.*)(to respond to \'baz\')$/);
 
-    err(function(){
-      bar.should.respondTo('baz', 'object');
+    err(function () {
+      bar.should.respondTo("baz", "object");
     }, /^(object: expected)(.*)(\{ foo: \[Function\] \}|\{ Object \()(.*)(to respond to \'baz\')$/);
   });
 
-  it('satisfy', function(){
-    var matcher = function (num){
+  it("satisfy", function () {
+    var matcher = function (num) {
       return num === 1;
     };
 
     (1).should.satisfy(matcher);
 
-    err(function(){
-      (2).should.satisfy(matcher, 'blah');
+    err(function () {
+      (2).should.satisfy(matcher, "blah");
     }, /^blah: expected 2 to satisfy \[Function( matcher)*\]$/);
   });
 
-  it('closeTo', function(){
+  it("closeTo", function () {
     (1.5).should.be.closeTo(1.0, 0.5);
 
-    err(function(){
-      (2).should.be.closeTo(1.0, 0.5, 'blah');
+    err(function () {
+      (2).should.be.closeTo(1.0, 0.5, "blah");
     }, "blah: expected 2 to be close to 1 +/- 0.5");
 
-    err(function() {
-      [1.5].should.be.closeTo(1.0, 0.5, 'blah');
+    err(function () {
+      [1.5].should.be.closeTo(1.0, 0.5, "blah");
     }, "blah: expected [ 1.5 ] to be a number");
 
-    err(function() {
-      (1.5).should.be.closeTo("1.0", 0.5, 'blah');
+    err(function () {
+      (1.5).should.be.closeTo("1.0", 0.5, "blah");
     }, "blah: the arguments to closeTo or approximately must be numbers");
 
-    err(function() {
-      (1.5).should.be.closeTo(1.0, true, 'blah');
+    err(function () {
+      (1.5).should.be.closeTo(1.0, true, "blah");
     }, "blah: the arguments to closeTo or approximately must be numbers");
 
-    err(function() {
-      (1.5).should.be.closeTo(1.0, undefined, 'blah');
+    err(function () {
+      (1.5).should.be.closeTo(1.0, undefined, "blah");
     }, "blah: the arguments to closeTo or approximately must be numbers, and a delta is required");
   });
 
-  it('approximately', function(){
+  it("approximately", function () {
     (1.5).should.be.approximately(1.0, 0.5);
 
-    err(function(){
-      (2).should.be.approximately(1.0, 0.5, 'blah');
+    err(function () {
+      (2).should.be.approximately(1.0, 0.5, "blah");
     }, "blah: expected 2 to be close to 1 +/- 0.5");
 
-    err(function() {
+    err(function () {
       [1.5].should.be.approximately(1.0, 0.5);
     }, "expected [ 1.5 ] to be a number");
 
-    err(function() {
+    err(function () {
       (1.5).should.be.approximately("1.0", 0.5);
     }, "the arguments to closeTo or approximately must be numbers");
 
-    err(function() {
+    err(function () {
       (1.5).should.be.approximately(1.0, true);
     }, "the arguments to closeTo or approximately must be numbers");
 
-    err(function() {
+    err(function () {
       (1.5).should.be.approximately(1.0);
     }, "the arguments to closeTo or approximately must be numbers, and a delta is required");
   });
 
-  it('include.members', function() {
+  it("include.members", function () {
     [1, 2, 3].should.include.members([3]);
     [1, 2, 3].should.include.members([]);
     [1, 2, 3].should.include.members([2, 1]);
@@ -2796,26 +3122,26 @@ describe('should', function() {
 
     [1, 2, 3].should.not.include.members([999]);
     [].should.not.include.members([23]);
-    [{a: 1}].should.not.include.members([{a: 1}]);
+    [{ a: 1 }].should.not.include.members([{ a: 1 }]);
 
-    err(function() {
-      [].should.include.members([43], 'blah');
-    }, 'blah: expected [] to be a superset of [ 43 ]');
+    err(function () {
+      [].should.include.members([43], "blah");
+    }, "blah: expected [] to be a superset of [ 43 ]");
 
-    err(function() {
+    err(function () {
       [5, 2, 1].should.not.include.members([2]);
-    }, 'expected [ 5, 2, 1 ] to not be a superset of [ 2 ]');
+    }, "expected [ 5, 2, 1 ] to not be a superset of [ 2 ]");
 
-    err(function() {
-      'foo'.should.include.members([12], 'blah');
+    err(function () {
+      "foo".should.include.members([12], "blah");
     }, "blah: expected 'foo' to be an array");
 
-    err(function() {
-      [1, 2, 3].should.include.members('o', 'blah');
+    err(function () {
+      [1, 2, 3].should.include.members("o", "blah");
     }, "blah: expected 'o' to be an array");
   });
 
-  it('memberEquals', function() {
+  it("memberEquals", function () {
     [1, 2, 3].should.have.same.members([3, 2, 1]);
     [5, 4].should.have.same.members([5, 4]);
     [5, 4, 4].should.have.same.members([5, 4, 4]);
@@ -2825,43 +3151,76 @@ describe('should', function() {
     [5, 4, 4].should.not.have.same.members([5, 4]);
     [5, 4, 4].should.not.have.same.members([5, 4, 3]);
     [5, 4, 3].should.not.have.same.members([5, 4, 4]);
-    [{a: 1}].should.not.have.same.members([{a: 1}]);
+    [{ a: 1 }].should.not.have.same.members([{ a: 1 }]);
 
-    err(function() {
-      [1, 2, 3].should.have.same.members([], 'blah');
-    }, 'blah: expected [ 1, 2, 3 ] to have the same members as []');
+    err(function () {
+      [1, 2, 3].should.have.same.members([], "blah");
+    }, "blah: expected [ 1, 2, 3 ] to have the same members as []");
 
-    err(function() {
-      [1, 2, 3].should.have.same.members(4, 'blah');
-    }, 'blah: expected 4 to be an array');
+    err(function () {
+      [1, 2, 3].should.have.same.members(4, "blah");
+    }, "blah: expected 4 to be an array");
   });
 
-  it('deep.members', function() {
+  it("deep.members", function () {
     [{ id: 1 }].should.have.deep.members([{ id: 1 }]);
-    [{a: 1}, {b: 2}, {b: 2}].should.have.deep.members([{a: 1}, {b: 2}, {b: 2}]);
+    [{ a: 1 }, { b: 2 }, { b: 2 }].should.have.deep.members([
+      { a: 1 },
+      { b: 2 },
+      { b: 2 },
+    ]);
 
     [{ id: 2 }].should.not.have.deep.members([{ id: 1 }]);
-    [{a: 1}, {b: 2}].should.not.have.deep.members([{a: 1}, {b: 2}, {b: 2}]);
-    [{a: 1}, {b: 2}, {b: 2}].should.not.have.deep.members([{a: 1}, {b: 2}]);
-    [{a: 1}, {b: 2}, {b: 2}].should.not.have.deep.members([{a: 1}, {b: 2}, {c: 3}]);
-    [{a: 1}, {b: 2}, {c: 3}].should.not.have.deep.members([{a: 1}, {b: 2}, {b: 2}]);
+    [{ a: 1 }, { b: 2 }].should.not.have.deep.members([
+      { a: 1 },
+      { b: 2 },
+      { b: 2 },
+    ]);
+    [{ a: 1 }, { b: 2 }, { b: 2 }].should.not.have.deep.members([
+      { a: 1 },
+      { b: 2 },
+    ]);
+    [{ a: 1 }, { b: 2 }, { b: 2 }].should.not.have.deep.members([
+      { a: 1 },
+      { b: 2 },
+      { c: 3 },
+    ]);
+    [{ a: 1 }, { b: 2 }, { c: 3 }].should.not.have.deep.members([
+      { a: 1 },
+      { b: 2 },
+      { b: 2 },
+    ]);
 
-    err(function(){
-      [{ id: 1 }].should.have.deep.members([{ id: 2 }], 'blah')
-    }, 'blah: expected [ { id: 1 } ] to have the same members as [ { id: 2 } ]');
+    err(function () {
+      [{ id: 1 }].should.have.deep.members([{ id: 2 }], "blah");
+    }, "blah: expected [ { id: 1 } ] to have the same members as [ { id: 2 } ]");
   });
 
-  it('include.deep.members', function() {
-    [{a: 1}, {b: 2}, {c: 3}].should.include.deep.members([{b: 2}, {a: 1}]);
-    [{a: 1}, {b: 2}, {c: 3}].should.include.deep.members([{b: 2}, {a: 1}, {a: 1}]);
-    [{a: 1}, {b: 2}, {c: 3}].should.not.include.deep.members([{b: 2}, {a: 1}, {f: 5}]);
+  it("include.deep.members", function () {
+    [{ a: 1 }, { b: 2 }, { c: 3 }].should.include.deep.members([
+      { b: 2 },
+      { a: 1 },
+    ]);
+    [{ a: 1 }, { b: 2 }, { c: 3 }].should.include.deep.members([
+      { b: 2 },
+      { a: 1 },
+      { a: 1 },
+    ]);
+    [{ a: 1 }, { b: 2 }, { c: 3 }].should.not.include.deep.members([
+      { b: 2 },
+      { a: 1 },
+      { f: 5 },
+    ]);
 
-    err(function() {
-      [{a: 1}, {b: 2}, {c: 3}].should.include.deep.members([{b: 2}, {a: 1}, {f: 5}], 'blah');
-    }, 'blah: expected [ { a: 1 }, { b: 2 }, { c: 3 } ] to be a superset of [ { b: 2 }, { a: 1 }, { f: 5 } ]');
+    err(function () {
+      [{ a: 1 }, { b: 2 }, { c: 3 }].should.include.deep.members(
+        [{ b: 2 }, { a: 1 }, { f: 5 }],
+        "blah",
+      );
+    }, "blah: expected [ { a: 1 }, { b: 2 }, { c: 3 } ] to be a superset of [ { b: 2 }, { a: 1 }, { f: 5 } ]");
   });
 
-  it('ordered.members', function() {
+  it("ordered.members", function () {
     [1, 2, 3].should.ordered.members([1, 2, 3]);
     [1, 2, 2].should.ordered.members([1, 2, 2]);
 
@@ -2872,88 +3231,155 @@ describe('should', function() {
     [1, 2, 2].should.not.ordered.members([1, 2, 3]);
     [1, 2, 3].should.not.ordered.members([1, 2, 2]);
 
-    err(function() {
-      [1, 2, 3].should.ordered.members([2, 1, 3], 'blah');
-    }, 'blah: expected [ 1, 2, 3 ] to have the same ordered members as [ 2, 1, 3 ]');
+    err(function () {
+      [1, 2, 3].should.ordered.members([2, 1, 3], "blah");
+    }, "blah: expected [ 1, 2, 3 ] to have the same ordered members as [ 2, 1, 3 ]");
 
-    err(function() {
+    err(function () {
       [1, 2, 3].should.not.ordered.members([1, 2, 3]);
-    }, 'expected [ 1, 2, 3 ] to not have the same ordered members as [ 1, 2, 3 ]');
+    }, "expected [ 1, 2, 3 ] to not have the same ordered members as [ 1, 2, 3 ]");
   });
 
-  it('include.ordered.members', function() {
+  it("include.ordered.members", function () {
     [1, 2, 3].should.include.ordered.members([1, 2]);
     [1, 2, 3].should.not.include.ordered.members([2, 1]);
     [1, 2, 3].should.not.include.ordered.members([2, 3]);
     [1, 2, 3].should.not.include.ordered.members([1, 2, 2]);
 
-    err(function() {
-      [1, 2, 3].should.include.ordered.members([2, 1], 'blah');
-    }, 'blah: expected [ 1, 2, 3 ] to be an ordered superset of [ 2, 1 ]');
+    err(function () {
+      [1, 2, 3].should.include.ordered.members([2, 1], "blah");
+    }, "blah: expected [ 1, 2, 3 ] to be an ordered superset of [ 2, 1 ]");
 
-    err(function() {
+    err(function () {
       [1, 2, 3].should.not.include.ordered.members([1, 2]);
-    }, 'expected [ 1, 2, 3 ] to not be an ordered superset of [ 1, 2 ]');
+    }, "expected [ 1, 2, 3 ] to not be an ordered superset of [ 1, 2 ]");
   });
 
-  it('deep.ordered.members', function() {
-    [{a: 1}, {b: 2}, {c: 3}].should.deep.ordered.members([{a: 1}, {b: 2}, {c: 3}]);
-    [{a: 1}, {b: 2}, {b: 2}].should.deep.ordered.members([{a: 1}, {b: 2}, {b: 2}]);
+  it("deep.ordered.members", function () {
+    [{ a: 1 }, { b: 2 }, { c: 3 }].should.deep.ordered.members([
+      { a: 1 },
+      { b: 2 },
+      { c: 3 },
+    ]);
+    [{ a: 1 }, { b: 2 }, { b: 2 }].should.deep.ordered.members([
+      { a: 1 },
+      { b: 2 },
+      { b: 2 },
+    ]);
 
-    [{a: 1}, {b: 2}, {c: 3}].should.not.deep.ordered.members([{b: 2}, {a: 1}, {c: 3}]);
-    [{a: 1}, {b: 2}].should.not.deep.ordered.members([{a: 1}, {b: 2}, {b: 2}]);
-    [{a: 1}, {b: 2}, {b: 2}].should.not.deep.ordered.members([{a: 1}, {b: 2}]);
-    [{a: 1}, {b: 2}, {b: 2}].should.not.deep.ordered.members([{a: 1}, {b: 2}, {c: 3}]);
-    [{a: 1}, {b: 2}, {c: 3}].should.not.deep.ordered.members([{a: 1}, {b: 2}, {b: 2}]);
+    [{ a: 1 }, { b: 2 }, { c: 3 }].should.not.deep.ordered.members([
+      { b: 2 },
+      { a: 1 },
+      { c: 3 },
+    ]);
+    [{ a: 1 }, { b: 2 }].should.not.deep.ordered.members([
+      { a: 1 },
+      { b: 2 },
+      { b: 2 },
+    ]);
+    [{ a: 1 }, { b: 2 }, { b: 2 }].should.not.deep.ordered.members([
+      { a: 1 },
+      { b: 2 },
+    ]);
+    [{ a: 1 }, { b: 2 }, { b: 2 }].should.not.deep.ordered.members([
+      { a: 1 },
+      { b: 2 },
+      { c: 3 },
+    ]);
+    [{ a: 1 }, { b: 2 }, { c: 3 }].should.not.deep.ordered.members([
+      { a: 1 },
+      { b: 2 },
+      { b: 2 },
+    ]);
 
-    err(function() {
-      [{a: 1}, {b: 2}, {c: 3}].should.deep.ordered.members([{b: 2}, {a: 1}, {c: 3}], 'blah');
-    }, 'blah: expected [ { a: 1 }, { b: 2 }, { c: 3 } ] to have the same ordered members as [ { b: 2 }, { a: 1 }, { c: 3 } ]');
+    err(function () {
+      [{ a: 1 }, { b: 2 }, { c: 3 }].should.deep.ordered.members(
+        [{ b: 2 }, { a: 1 }, { c: 3 }],
+        "blah",
+      );
+    }, "blah: expected [ { a: 1 }, { b: 2 }, { c: 3 } ] to have the same ordered members as [ { b: 2 }, { a: 1 }, { c: 3 } ]");
 
-    err(function() {
-      [{a: 1}, {b: 2}, {c: 3}].should.not.deep.ordered.members([{a: 1}, {b: 2}, {c: 3}]);
-    }, 'expected [ { a: 1 }, { b: 2 }, { c: 3 } ] to not have the same ordered members as [ { a: 1 }, { b: 2 }, { c: 3 } ]');
+    err(function () {
+      [{ a: 1 }, { b: 2 }, { c: 3 }].should.not.deep.ordered.members([
+        { a: 1 },
+        { b: 2 },
+        { c: 3 },
+      ]);
+    }, "expected [ { a: 1 }, { b: 2 }, { c: 3 } ] to not have the same ordered members as [ { a: 1 }, { b: 2 }, { c: 3 } ]");
   });
 
-  it('include.deep.ordered.members', function() {
-    [{a: 1}, {b: 2}, {c: 3}].should.include.deep.ordered.members([{a: 1}, {b: 2}]);
-    [{a: 1}, {b: 2}, {c: 3}].should.not.include.deep.ordered.members([{b: 2}, {a: 1}]);
-    [{a: 1}, {b: 2}, {c: 3}].should.not.include.deep.ordered.members([{b: 2}, {c: 3}]);
-    [{a: 1}, {b: 2}, {c: 3}].should.not.include.deep.ordered.members([{a: 1}, {b: 2}, {b: 2}]);
+  it("include.deep.ordered.members", function () {
+    [{ a: 1 }, { b: 2 }, { c: 3 }].should.include.deep.ordered.members([
+      { a: 1 },
+      { b: 2 },
+    ]);
+    [{ a: 1 }, { b: 2 }, { c: 3 }].should.not.include.deep.ordered.members([
+      { b: 2 },
+      { a: 1 },
+    ]);
+    [{ a: 1 }, { b: 2 }, { c: 3 }].should.not.include.deep.ordered.members([
+      { b: 2 },
+      { c: 3 },
+    ]);
+    [{ a: 1 }, { b: 2 }, { c: 3 }].should.not.include.deep.ordered.members([
+      { a: 1 },
+      { b: 2 },
+      { b: 2 },
+    ]);
 
-    err(function() {
-      [{a: 1}, {b: 2}, {c: 3}].should.include.deep.ordered.members([{b: 2}, {a: 1}], 'blah');
-    }, 'blah: expected [ { a: 1 }, { b: 2 }, { c: 3 } ] to be an ordered superset of [ { b: 2 }, { a: 1 } ]');
+    err(function () {
+      [{ a: 1 }, { b: 2 }, { c: 3 }].should.include.deep.ordered.members(
+        [{ b: 2 }, { a: 1 }],
+        "blah",
+      );
+    }, "blah: expected [ { a: 1 }, { b: 2 }, { c: 3 } ] to be an ordered superset of [ { b: 2 }, { a: 1 } ]");
 
-    err(function() {
-      [{a: 1}, {b: 2}, {c: 3}].should.not.include.deep.ordered.members([{a: 1}, {b: 2}]);
-    }, 'expected [ { a: 1 }, { b: 2 }, { c: 3 } ] to not be an ordered superset of [ { a: 1 }, { b: 2 } ]');
+    err(function () {
+      [{ a: 1 }, { b: 2 }, { c: 3 }].should.not.include.deep.ordered.members([
+        { a: 1 },
+        { b: 2 },
+      ]);
+    }, "expected [ { a: 1 }, { b: 2 }, { c: 3 } ] to not be an ordered superset of [ { a: 1 }, { b: 2 } ]");
   });
 
-  it('change', function() {
-    var obj = { value: 10, str: 'foo' },
-        heroes = ['spiderman', 'superman'],
-        fn     = function() { obj.value += 5 },
-        sameFn = function() { obj.value += 0 },
-        decFn  = function() { obj.value -= 20 },
-        bangFn = function() { obj.str += '!' },
-        batFn  = function() { heroes.push('batman') },
-        lenFn  = function() { return heroes.length },
-        noFn   = function() { return null };
+  it("change", function () {
+    var obj = { value: 10, str: "foo" },
+      heroes = ["spiderman", "superman"],
+      fn = function () {
+        obj.value += 5;
+      },
+      sameFn = function () {
+        obj.value += 0;
+      },
+      decFn = function () {
+        obj.value -= 20;
+      },
+      bangFn = function () {
+        obj.str += "!";
+      },
+      batFn = function () {
+        heroes.push("batman");
+      },
+      lenFn = function () {
+        return heroes.length;
+      },
+      noFn = function () {
+        return null;
+      };
 
-    fn.should.change(obj, 'value');
-    fn.should.change(obj, 'value').by(5);
-    fn.should.change(obj, 'value').by(-5);
-    fn.should.change(obj, 'value').but.not.by(10);
+    fn.should.change(obj, "value");
+    fn.should.change(obj, "value").by(5);
+    fn.should.change(obj, "value").by(-5);
+    fn.should.change(obj, "value").but.not.by(10);
 
-    decFn.should.change(obj, 'value');
-    decFn.should.change(obj, 'value').by(20);
-    decFn.should.change(obj, 'value').but.not.by(19);
+    decFn.should.change(obj, "value");
+    decFn.should.change(obj, "value").by(20);
+    decFn.should.change(obj, "value").but.not.by(19);
 
-    sameFn.should.not.change(obj, 'value');
+    sameFn.should.not.change(obj, "value");
 
-    sameFn.should.not.change(obj, 'str');
-    bangFn.should.change(obj, 'str');
+    sameFn.should.not.change(obj, "str");
+    bangFn.should.change(obj, "str");
 
     batFn.should.change(lenFn);
     batFn.should.change(lenFn).by(1);
@@ -2961,52 +3387,66 @@ describe('should', function() {
     noFn.should.not.change(lenFn);
 
     err(function () {
-      (sameFn).should.change(obj, 'value', 'blah');
+      sameFn.should.change(obj, "value", "blah");
     }, "blah: expected .value to change");
 
     err(function () {
-      (fn).should.not.change(obj, 'value', 'blah');
+      fn.should.not.change(obj, "value", "blah");
     }, "blah: expected .value to not change");
 
     err(function () {
-      ({}).should.change(obj, 'value', 'blah');
+      ({}).should.change(obj, "value", "blah");
     }, "blah: expected {} to be a function");
 
     err(function () {
-      (fn).should.change({}, 'badprop', 'blah');
+      fn.should.change({}, "badprop", "blah");
     }, "blah: expected {} to have property 'badprop'");
 
     err(function () {
-      (fn).should.change(obj, 'value').by(10, 'blah');
+      fn.should.change(obj, "value").by(10, "blah");
     }, "blah: expected .value to change by 10");
 
     err(function () {
-      (fn).should.change(obj, 'value').but.not.by(5, 'blah');
+      fn.should.change(obj, "value").but.not.by(5, "blah");
     }, "blah: expected .value to not change by 5");
   });
 
-  it('increase, decrease', function() {
+  it("increase, decrease", function () {
     var obj = { value: 10, noop: null },
-        arr = ['one', 'two'],
-        pFn   = function() { arr.push('three') },
-        popFn = function() { arr.pop() },
-        lenFn = function() { return arr.length },
-        nFn   = function() { return null },
-        incFn = function() { obj.value += 2 },
-        decFn = function() { obj.value -= 3 },
-        smFn  = function() { obj.value += 0 };
+      arr = ["one", "two"],
+      pFn = function () {
+        arr.push("three");
+      },
+      popFn = function () {
+        arr.pop();
+      },
+      lenFn = function () {
+        return arr.length;
+      },
+      nFn = function () {
+        return null;
+      },
+      incFn = function () {
+        obj.value += 2;
+      },
+      decFn = function () {
+        obj.value -= 3;
+      },
+      smFn = function () {
+        obj.value += 0;
+      };
 
-    smFn.should.not.increase(obj, 'value');
-    decFn.should.not.increase(obj, 'value');
-    incFn.should.increase(obj, 'value');
-    incFn.should.increase(obj, 'value').by(2);
-    incFn.should.increase(obj, 'value').but.not.by(1);
+    smFn.should.not.increase(obj, "value");
+    decFn.should.not.increase(obj, "value");
+    incFn.should.increase(obj, "value");
+    incFn.should.increase(obj, "value").by(2);
+    incFn.should.increase(obj, "value").but.not.by(1);
 
-    smFn.should.not.decrease(obj, 'value');
-    incFn.should.not.decrease(obj, 'value');
-    decFn.should.decrease(obj, 'value');
-    decFn.should.decrease(obj, 'value').by(3);
-    decFn.should.decrease(obj, 'value').but.not.by(2);
+    smFn.should.not.decrease(obj, "value");
+    incFn.should.not.decrease(obj, "value");
+    decFn.should.decrease(obj, "value");
+    decFn.should.decrease(obj, "value").by(3);
+    decFn.should.decrease(obj, "value").but.not.by(2);
 
     nFn.should.not.increase(lenFn);
     nFn.should.not.decrease(lenFn);
@@ -3024,203 +3464,221 @@ describe('should', function() {
     popFn.should.decrease(lenFn).but.not.by(2);
 
     err(function () {
-      (smFn).should.increase(obj, 'value', 'blah');
+      smFn.should.increase(obj, "value", "blah");
     }, "blah: expected .value to increase");
 
     err(function () {
-      (incFn).should.not.increase(obj, 'value', 'blah');
+      incFn.should.not.increase(obj, "value", "blah");
     }, "blah: expected .value to not increase");
 
     err(function () {
-      ({}).should.increase(obj, 'value', 'blah');
+      ({}).should.increase(obj, "value", "blah");
     }, "blah: expected {} to be a function");
 
     err(function () {
-      (incFn).should.increase({}, 'badprop', 'blah');
+      incFn.should.increase({}, "badprop", "blah");
     }, "blah: expected {} to have property 'badprop'");
 
-    err(function() {
-      (incFn).should.increase(obj, 'noop', 'blah');
-    }, 'blah: expected null to be a number');
+    err(function () {
+      incFn.should.increase(obj, "noop", "blah");
+    }, "blah: expected null to be a number");
 
     err(function () {
-      (incFn).should.increase(obj, 'value').by(10, 'blah');
+      incFn.should.increase(obj, "value").by(10, "blah");
     }, "blah: expected .value to increase by 10");
 
     err(function () {
-      (incFn).should.increase(obj, 'value').but.not.by(2, 'blah');
+      incFn.should.increase(obj, "value").but.not.by(2, "blah");
     }, "blah: expected .value to not increase by 2");
 
     err(function () {
-      (smFn).should.decrease(obj, 'value', 'blah');
+      smFn.should.decrease(obj, "value", "blah");
     }, "blah: expected .value to decrease");
 
     err(function () {
-      (decFn).should.not.decrease(obj, 'value', 'blah');
+      decFn.should.not.decrease(obj, "value", "blah");
     }, "blah: expected .value to not decrease");
 
     err(function () {
-      ({}).should.decrease(obj, 'value', 'blah');
+      ({}).should.decrease(obj, "value", "blah");
     }, "blah: expected {} to be a function");
 
     err(function () {
-      (decFn).should.decrease({}, 'badprop', 'blah');
+      decFn.should.decrease({}, "badprop", "blah");
     }, "blah: expected {} to have property 'badprop'");
 
-    err(function() {
-      (decFn).should.decrease(obj, 'noop', 'blah');
-    }, 'blah: expected null to be a number');
+    err(function () {
+      decFn.should.decrease(obj, "noop", "blah");
+    }, "blah: expected null to be a number");
 
     err(function () {
-      (decFn).should.decrease(obj, 'value').by(10, 'blah');
+      decFn.should.decrease(obj, "value").by(10, "blah");
     }, "blah: expected .value to decrease by 10");
 
     err(function () {
-      (decFn).should.decrease(obj, 'value').but.not.by(3, 'blah');
+      decFn.should.decrease(obj, "value").but.not.by(3, "blah");
     }, "blah: expected .value to not decrease by 3");
   });
 
-  it('extensible', function() {
-     var nonExtensibleObject = Object.preventExtensions({});
+  it("extensible", function () {
+    var nonExtensibleObject = Object.preventExtensions({});
 
-     ({}).should.be.extensible;
-     nonExtensibleObject.should.not.be.extensible;
+    ({}).should.be.extensible;
+    nonExtensibleObject.should.not.be.extensible;
 
-     err(function() {
-       nonExtensibleObject.should.be.extensible;
-     }, 'expected {} to be extensible');
+    err(function () {
+      nonExtensibleObject.should.be.extensible;
+    }, "expected {} to be extensible");
 
-     err(function() {
-       ({}).should.not.be.extensible;
-     }, 'expected {} to not be extensible');
+    err(function () {
+      ({}).should.not.be.extensible;
+    }, "expected {} to not be extensible");
 
-     // Making sure ES6-like Object.isExtensible response is respected for all primitive types
+    // Making sure ES6-like Object.isExtensible response is respected for all primitive types
 
-     (42).should.not.be.extensible;
-     'foo'.should.not.be.extensible;
-     false.should.not.be.extensible;
+    (42).should.not.be.extensible;
+    "foo".should.not.be.extensible;
+    false.should.not.be.extensible;
 
-     Symbol().should.not.be.extensible;
+    Symbol().should.not.be.extensible;
 
-     err(function() {
-       (42).should.be.extensible;
-     }, 'expected 42 to be extensible');
+    err(function () {
+      (42).should.be.extensible;
+    }, "expected 42 to be extensible");
 
-     err(function() {
-       'foo'.should.be.extensible;
-     }, 'expected \'foo\' to be extensible');
+    err(function () {
+      "foo".should.be.extensible;
+    }, "expected 'foo' to be extensible");
 
-     err(function() {
-       false.should.be.extensible;
-     }, 'expected false to be extensible');
+    err(function () {
+      false.should.be.extensible;
+    }, "expected false to be extensible");
 
-    var proxy = new Proxy({}, {
-      isExtensible: function() {
-        throw new TypeError();
-      }
-    });
+    var proxy = new Proxy(
+      {},
+      {
+        isExtensible: function () {
+          throw new TypeError();
+        },
+      },
+    );
 
-    err(function() {
-      // .extensible should not suppress errors, thrown in proxy traps
-      proxy.should.be.extensible;
-    }, { name: 'TypeError' });
+    err(
+      function () {
+        // .extensible should not suppress errors, thrown in proxy traps
+        proxy.should.be.extensible;
+      },
+      { name: "TypeError" },
+    );
   });
 
-  it('sealed', function() {
+  it("sealed", function () {
     var sealedObject = Object.seal({});
 
     sealedObject.should.be.sealed;
     ({}).should.not.be.sealed;
 
-    err(function() {
+    err(function () {
       ({}).should.be.sealed;
-    }, 'expected {} to be sealed');
+    }, "expected {} to be sealed");
 
-    err(function() {
+    err(function () {
       sealedObject.should.not.be.sealed;
-    }, 'expected {} to not be sealed');
+    }, "expected {} to not be sealed");
 
     // Making sure ES6-like Object.isSealed response is respected for all primitive types
 
     (42).should.be.sealed;
-    'foo'.should.be.sealed;
+    "foo".should.be.sealed;
     false.should.be.sealed;
 
     Symbol().should.be.sealed;
 
-    err(function() {
+    err(function () {
       (42).should.not.be.sealed;
-    }, 'expected 42 to not be sealed');
+    }, "expected 42 to not be sealed");
 
-    err(function() {
-      'foo'.should.not.be.sealed;
-    }, 'expected \'foo\' to not be sealed');
+    err(function () {
+      "foo".should.not.be.sealed;
+    }, "expected 'foo' to not be sealed");
 
-    err(function() {
+    err(function () {
       false.should.not.be.sealed;
-    }, 'expected false to not be sealed');
+    }, "expected false to not be sealed");
 
-    var proxy = new Proxy({}, {
-      ownKeys: function() {
-        throw new TypeError();
-      }
-    });
+    var proxy = new Proxy(
+      {},
+      {
+        ownKeys: function () {
+          throw new TypeError();
+        },
+      },
+    );
 
     // Object.isSealed will call ownKeys trap only if object is not extensible
     Object.preventExtensions(proxy);
 
-    err(function() {
-      // .sealed should not suppress errors, thrown in proxy traps
-      proxy.should.be.sealed;
-    }, { name: 'TypeError' });
+    err(
+      function () {
+        // .sealed should not suppress errors, thrown in proxy traps
+        proxy.should.be.sealed;
+      },
+      { name: "TypeError" },
+    );
   });
 
-  it('frozen', function() {
+  it("frozen", function () {
     var frozenObject = Object.freeze({});
 
     frozenObject.should.be.frozen;
     ({}).should.not.be.frozen;
 
-    err(function() {
-        ({}).should.be.frozen;
-    }, 'expected {} to be frozen');
+    err(function () {
+      ({}).should.be.frozen;
+    }, "expected {} to be frozen");
 
-    err(function() {
-        frozenObject.should.not.be.frozen;
-    }, 'expected {} to not be frozen');
+    err(function () {
+      frozenObject.should.not.be.frozen;
+    }, "expected {} to not be frozen");
 
     // Making sure ES6-like Object.isFrozen response is respected for all primitive types
 
     (42).should.be.frozen;
-    'foo'.should.be.frozen;
+    "foo".should.be.frozen;
     false.should.be.frozen;
 
     Symbol().should.be.frozen;
 
-    err(function() {
+    err(function () {
       (42).should.not.be.frozen;
-    }, 'expected 42 to not be frozen');
+    }, "expected 42 to not be frozen");
 
-    err(function() {
-      'foo'.should.not.be.frozen;
-    }, 'expected \'foo\' to not be frozen');
+    err(function () {
+      "foo".should.not.be.frozen;
+    }, "expected 'foo' to not be frozen");
 
-    err(function() {
+    err(function () {
       false.should.not.be.frozen;
-    }, 'expected false to not be frozen');
+    }, "expected false to not be frozen");
 
-    var proxy = new Proxy({}, {
-      ownKeys: function() {
-        throw new TypeError();
-      }
-    });
+    var proxy = new Proxy(
+      {},
+      {
+        ownKeys: function () {
+          throw new TypeError();
+        },
+      },
+    );
 
     // Object.isFrozen will call ownKeys trap only if object is not extensible
     Object.preventExtensions(proxy);
 
-    err(function() {
-      // .frozen should not suppress errors, thrown in proxy traps
-      proxy.should.be.frozen;
-    }, { name: 'TypeError' });
+    err(
+      function () {
+        // .frozen should not suppress errors, thrown in proxy traps
+        proxy.should.be.frozen;
+      },
+      { name: "TypeError" },
+    );
   });
 });

--- a/test/should.js
+++ b/test/should.js
@@ -337,6 +337,18 @@ describe('should', function() {
     }, "expected '' to be false")
   });
 
+  it("callable", function () {
+    (function () {}).should.be.callable;
+    (async function () {}).should.be.callable;
+    (function* () {}).should.be.callable;
+    (async function* () {}).should.be.callable;
+    true.should.not.be.callable;
+
+    err(function () {
+      "".should.be.callable;
+    }, "expected '' to be a callable function");
+  });
+
   it('null', function(){
     (0).should.not.be.null;
 


### PR DESCRIPTION
Fix #1564 by introducing new `isAsyncFunction` and `isNotAsyncFunction` assertions. 

The thinking is that even though async functions are functions this change will allow for more granular assertions.

I'm still not sure if this is what we'd like though. Async functions are still functions so I could see a argument being made for `isFunction` asserting that a async function is indeed a function. Maybe we should add a `isSynchronousFunction` to specifically check if a function is not async and then leave `isFunction` to assert for both sync and async functions?

Interested in hearing thoughts.

@43081j @keithamus @ReDemoNBR 
  