### PR TITLE
fix: removes `??` for node compat

### DIFF
--- a/lib/chai/assertion.js
+++ b/lib/chai/assertion.js
@@ -66,7 +66,7 @@ module.exports = function (_chai, util) {
     flag(this, 'lockSsfi', lockSsfi);
     flag(this, 'object', obj);
     flag(this, 'message', msg);
-    flag(this, 'eql', config.deepEqual ?? util.eql);
+    flag(this, 'eql', config.deepEqual || util.eql);
 
     return util.proxify(this);
   }


### PR DESCRIPTION
We shipped syntax which is beyond our `engine` constraint. `??` is available in node 14 but 4.x is node 4 and above, while 5.x is node 12 and above.

This just dumbs it back down to `||` for now at least.

Fixes #1573

@koddsson @keithamus can we just catch 5.x up from 4.x when this lands? how do we deal with keeping them in sync, as 5 needs this too