### PR TITLE
fix: removes `??` for node compat (5.x)

### DIFF
--- a/lib/chai/assertion.js
+++ b/lib/chai/assertion.js
@@ -54,7 +54,7 @@ export function Assertion (obj, msg, ssfi, lockSsfi) {
   util.flag(this, 'lockSsfi', lockSsfi);
   util.flag(this, 'object', obj);
   util.flag(this, 'message', msg);
-  util.flag(this, 'eql', config.deepEqual ?? util.eql);
+  util.flag(this, 'eql', config.deepEqual || util.eql);
 
   return util.proxify(this);
 }


### PR DESCRIPTION
same as #1574 for 5.x/main