### PR TITLE
Set support in same members

### DIFF
--- a/lib/chai/core/assertions.js
+++ b/lib/chai/core/assertions.js
@@ -319,6 +319,12 @@ function an (type, msg) {
       , 'expected #{this} to be ' + article + type
       , 'expected #{this} not to be ' + article + type
     );
+  } else if (type === 'iterable') {
+    this.assert(
+        typeof obj !== 'string' && obj != undefined && obj[Symbol.iterator]
+      , 'expected #{this} to be ' + article + type
+      , 'expected #{this} not to be ' + article + type
+    );
   } else {
     this.assert(
       type === detectedType
@@ -3037,7 +3043,9 @@ Assertion.addMethod('closeTo', closeTo);
 Assertion.addMethod('approximately', closeTo);
 
 // Note: Duplicates are ignored if testing for inclusion instead of sameness.
-function isSubsetOf(subset, superset, cmp, contains, ordered) {
+function isSubsetOf(_subset, _superset, cmp, contains, ordered) {
+  let superset = Array.from(_superset);
+  let subset = Array.from(_subset);
   if (!contains) {
     if (subset.length !== superset.length) return false;
     superset = superset.slice();
@@ -3175,6 +3183,7 @@ Assertion.addMethod('members', function (subset, msg) {
  * Asserts that the target is an iterable, which means that it has a iterator.
  *
  *     expect([1, 2]).to.be.iterable;
+ *     expect("foobar").to.be.iterable;
  *
  * Add `.not` earlier in the chain to negate `.iterable`.
  *

--- a/lib/chai/core/assertions.js
+++ b/lib/chai/core/assertions.js
@@ -3147,8 +3147,20 @@ Assertion.addMethod('members', function (subset, msg) {
     , flagMsg = flag(this, 'message')
     , ssfi = flag(this, 'ssfi');
 
-  new Assertion(obj, flagMsg, ssfi, true).to.be.an('array');
-  new Assertion(subset, flagMsg, ssfi, true).to.be.an('array');
+  if (!['Array', 'Set'].includes(_.type(obj))) {
+    throw new AssertionError(
+      `${flagMsg}: expected ${_.inspect(obj)} to be an iterator`,
+      undefined,
+      ssfi
+    );
+  }
+  if (!['Array', 'Set'].includes(_.type(subset))) {
+    throw new AssertionError(
+      `${flagMsg}: expected ${_.inspect(subset)} to be an iterator`,
+      undefined,
+      ssfi
+    );
+  }
 
   var contains = flag(this, 'contains');
   var ordered = flag(this, 'ordered');

--- a/lib/chai/core/assertions.js
+++ b/lib/chai/core/assertions.js
@@ -3141,26 +3141,30 @@ function isSubsetOf(_subset, _superset, cmp, contains, ordered) {
  * @namespace BDD
  * @api public
  */
+
+Assertion.addMethod('iterable', function(msg) {
+  if (msg) flag(this, 'message', msg);
+  var obj = flag(this, 'object')
+    , flagMsg = flag(this, 'message')
+    , ssfi = flag(this, 'ssfi');
+
+  if (typeof obj === 'string' || !obj[Symbol.iterator]) {
+    throw new AssertionError(
+      `${flagMsg}: expected ${_.inspect(obj)} to be an iterable`,
+      undefined,
+      ssfi
+    );
+  }
+});
+
 Assertion.addMethod('members', function (subset, msg) {
   if (msg) flag(this, 'message', msg);
   var obj = flag(this, 'object')
     , flagMsg = flag(this, 'message')
     , ssfi = flag(this, 'ssfi');
 
-  if (!['Array', 'Set'].includes(_.type(obj))) {
-    throw new AssertionError(
-      `${flagMsg}: expected ${_.inspect(obj)} to be an iterator`,
-      undefined,
-      ssfi
-    );
-  }
-  if (!['Array', 'Set'].includes(_.type(subset))) {
-    throw new AssertionError(
-      `${flagMsg}: expected ${_.inspect(subset)} to be an iterator`,
-      undefined,
-      ssfi
-    );
-  }
+  new Assertion(obj, flagMsg, ssfi, true).to.be.an('iterable');
+  new Assertion(subset, flagMsg, ssfi, true).to.be.an('iterable');
 
   var contains = flag(this, 'contains');
   var ordered = flag(this, 'ordered');

--- a/lib/chai/core/assertions.js
+++ b/lib/chai/core/assertions.js
@@ -319,12 +319,6 @@ function an (type, msg) {
       , 'expected #{this} to be ' + article + type
       , 'expected #{this} not to be ' + article + type
     );
-  } else if (type === 'iterable') {
-    this.assert(
-        typeof obj !== 'string' && obj != undefined && obj[Symbol.iterator]
-      , 'expected #{this} to be ' + article + type
-      , 'expected #{this} not to be ' + article + type
-    );
   } else {
     this.assert(
       type === detectedType
@@ -336,14 +330,6 @@ function an (type, msg) {
 
 Assertion.addChainableMethod('an', an);
 Assertion.addChainableMethod('a', an);
-
-function SameValueZero(a, b) {
-  return (_.isNaN(a) && _.isNaN(b)) || a === b;
-}
-
-function includeChainingBehavior () {
-  flag(this, 'contains', true);
-}
 
 /**
  * ### .include(val[, msg])
@@ -491,6 +477,14 @@ function includeChainingBehavior () {
  * @namespace BDD
  * @api public
  */
+
+function SameValueZero(a, b) {
+  return (_.isNaN(a) && _.isNaN(b)) || a === b;
+}
+
+function includeChainingBehavior () {
+  flag(this, 'contains', true);
+}
 
 function include (val, msg) {
   if (msg) flag(this, 'message', msg);
@@ -3147,8 +3141,8 @@ Assertion.addMethod('members', function (subset, msg) {
     , flagMsg = flag(this, 'message')
     , ssfi = flag(this, 'ssfi');
 
-  new Assertion(obj, flagMsg, ssfi, true).to.be.an('iterable');
-  new Assertion(subset, flagMsg, ssfi, true).to.be.an('iterable');
+  new Assertion(obj, flagMsg, ssfi, true).to.be.iterable;
+  new Assertion(subset, flagMsg, ssfi, true).to.be.iterable;
 
   var contains = flag(this, 'contains');
   var ordered = flag(this, 'ordered');

--- a/lib/chai/core/assertions.js
+++ b/lib/chai/core/assertions.js
@@ -337,6 +337,14 @@ function an (type, msg) {
 Assertion.addChainableMethod('an', an);
 Assertion.addChainableMethod('a', an);
 
+function SameValueZero(a, b) {
+  return (_.isNaN(a) && _.isNaN(b)) || a === b;
+}
+
+function includeChainingBehavior () {
+  flag(this, 'contains', true);
+}
+
 /**
  * ### .include(val[, msg])
  *
@@ -483,14 +491,6 @@ Assertion.addChainableMethod('a', an);
  * @namespace BDD
  * @api public
  */
-
-function SameValueZero(a, b) {
-  return (_.isNaN(a) && _.isNaN(b)) || a === b;
-}
-
-function includeChainingBehavior () {
-  flag(this, 'contains', true);
-}
 
 function include (val, msg) {
   if (msg) flag(this, 'message', msg);

--- a/lib/chai/core/assertions.js
+++ b/lib/chai/core/assertions.js
@@ -3141,22 +3141,6 @@ function isSubsetOf(_subset, _superset, cmp, contains, ordered) {
  * @namespace BDD
  * @api public
  */
-
-Assertion.addMethod('iterable', function(msg) {
-  if (msg) flag(this, 'message', msg);
-  var obj = flag(this, 'object')
-    , flagMsg = flag(this, 'message')
-    , ssfi = flag(this, 'ssfi');
-
-  if (typeof obj === 'string' || !obj[Symbol.iterator]) {
-    throw new AssertionError(
-      `${flagMsg}: expected ${_.inspect(obj)} to be an iterable`,
-      undefined,
-      ssfi
-    );
-  }
-});
-
 Assertion.addMethod('members', function (subset, msg) {
   if (msg) flag(this, 'message', msg);
   var obj = flag(this, 'object')

--- a/test/assert.js
+++ b/test/assert.js
@@ -1921,11 +1921,11 @@ describe('assert', function () {
 
     err(function () {
       assert.sameMembers({}, [], 'blah');
-    }, 'blah: expected {} to be an iterator');
+    }, 'blah: expected {} to be an iterable');
 
     err(function () {
       assert.sameMembers([], {}, 'blah');
-    }, 'blah: expected {} to be an iterator');
+    }, 'blah: expected {} to be an iterable');
   });
 
   it('notSameMembers', function() {

--- a/test/assert.js
+++ b/test/assert.js
@@ -1921,11 +1921,11 @@ describe('assert', function () {
 
     err(function () {
       assert.sameMembers({}, [], 'blah');
-    }, 'blah: expected {} to be an array');
+    }, 'blah: expected {} to be an iterator');
 
     err(function () {
       assert.sameMembers([], {}, 'blah');
-    }, 'blah: expected {} to be an array');
+    }, 'blah: expected {} to be an iterator');
   });
 
   it('notSameMembers', function() {

--- a/test/assert.js
+++ b/test/assert.js
@@ -1909,6 +1909,8 @@ describe('assert', function () {
     assert.sameMembers([4, 2], [4, 2]);
     assert.sameMembers([4, 2, 2], [4, 2, 2]);
 
+    assert.sameMembers(new Set([1,2,3]), new Set([3,2,1]));
+
     err(function() {
       assert.sameMembers([], [1, 2], 'blah');
     }, 'blah: expected [] to have the same members as [ 1, 2 ]');

--- a/test/expect.js
+++ b/test/expect.js
@@ -3436,19 +3436,19 @@ describe('expect', function () {
 
     err(function () {
       expect({}).members([], 'blah');
-    }, 'blah: expected {} to be an iterator');
+    }, 'blah: expected {} to be an iterable');
 
     err(function () {
       expect({}, 'blah').members([]);
-    }, 'blah: expected {} to be an iterator');
+    }, 'blah: expected {} to be an iterable');
 
     err(function () {
       expect([]).members({}, 'blah');
-    }, 'blah: expected {} to be an iterator');
+    }, 'blah: expected {} to be an iterable');
 
     err(function () {
       expect([], 'blah').members({});
-    }, 'blah: expected {} to be an iterator');
+    }, 'blah: expected {} to be an iterable');
   });
 
   it('deep.members', function() {

--- a/test/expect.js
+++ b/test/expect.js
@@ -3397,9 +3397,11 @@ describe('expect', function () {
   });
 
   it('same.members', function() {
-    expect([5, 4]).to.have.same.members([4, 5]);
     expect([5, 4]).to.have.same.members([5, 4]);
+    expect([5, 4]).to.have.same.members([4, 5]);
     expect([5, 4, 4]).to.have.same.members([5, 4, 4]);
+    expect(new Set([5, 4])).to.have.same.members([4, 5]);
+
     expect([5, 4]).to.not.have.same.members([]);
     expect([5, 4]).to.not.have.same.members([6, 3]);
     expect([5, 4]).to.not.have.same.members([5, 4, 2]);
@@ -3407,6 +3409,7 @@ describe('expect', function () {
     expect([5, 4, 4]).to.not.have.same.members([5, 4]);
     expect([5, 4, 4]).to.not.have.same.members([5, 4, 3]);
     expect([5, 4, 3]).to.not.have.same.members([5, 4, 4]);
+    expect(new Set([5, 4])).to.not.have.same.members([4]);
   });
 
   it('members', function() {

--- a/test/expect.js
+++ b/test/expect.js
@@ -3436,19 +3436,19 @@ describe('expect', function () {
 
     err(function () {
       expect({}).members([], 'blah');
-    }, 'blah: expected {} to be an array');
+    }, 'blah: expected {} to be an iterator');
 
     err(function () {
       expect({}, 'blah').members([]);
-    }, 'blah: expected {} to be an array');
+    }, 'blah: expected {} to be an iterator');
 
     err(function () {
       expect([]).members({}, 'blah');
-    }, 'blah: expected {} to be an array');
+    }, 'blah: expected {} to be an iterator');
 
     err(function () {
       expect([], 'blah').members({});
-    }, 'blah: expected {} to be an array');
+    }, 'blah: expected {} to be an iterator');
   });
 
   it('deep.members', function() {

--- a/test/should.js
+++ b/test/should.js
@@ -2815,11 +2815,11 @@ describe('should', function() {
 
     err(function() {
       'foo'.should.include.members([12], 'blah');
-    }, "blah: expected 'foo' to be an iterator");
+    }, "blah: expected 'foo' to be an iterable");
 
     err(function() {
       [1, 2, 3].should.include.members('o', 'blah');
-    }, "blah: expected 'o' to be an iterator");
+    }, "blah: expected 'o' to be an iterable");
   });
 
   it('memberEquals', function() {
@@ -2840,7 +2840,7 @@ describe('should', function() {
 
     err(function() {
       [1, 2, 3].should.have.same.members(4, 'blah');
-    }, 'blah: expected 4 to be an iterator');
+    }, 'blah: expected 4 to be an iterable');
   });
 
   it('deep.members', function() {

--- a/test/should.js
+++ b/test/should.js
@@ -2815,11 +2815,11 @@ describe('should', function() {
 
     err(function() {
       'foo'.should.include.members([12], 'blah');
-    }, "blah: expected 'foo' to be an array");
+    }, "blah: expected 'foo' to be an iterator");
 
     err(function() {
       [1, 2, 3].should.include.members('o', 'blah');
-    }, "blah: expected 'o' to be an array");
+    }, "blah: expected 'o' to be an iterator");
   });
 
   it('memberEquals', function() {
@@ -2840,7 +2840,7 @@ describe('should', function() {
 
     err(function() {
       [1, 2, 3].should.have.same.members(4, 'blah');
-    }, 'blah: expected 4 to be an array');
+    }, 'blah: expected 4 to be an iterator');
   });
 
   it('deep.members', function() {

--- a/test/should.js
+++ b/test/should.js
@@ -2827,12 +2827,15 @@ describe('should', function() {
     [5, 4].should.have.same.members([5, 4]);
     [5, 4, 4].should.have.same.members([5, 4, 4]);
     [].should.have.same.members([]);
+    (new Set([])).should.have.same.members(new Set([]));
+    (new Set([1,2,3])).should.have.same.members(new Set([3,2,1]));
 
     [5, 4].should.not.have.same.members([5, 4, 4]);
     [5, 4, 4].should.not.have.same.members([5, 4]);
     [5, 4, 4].should.not.have.same.members([5, 4, 3]);
     [5, 4, 3].should.not.have.same.members([5, 4, 4]);
     [{a: 1}].should.not.have.same.members([{a: 1}]);
+    (new Set([1,2,3])).should.not.have.same.members(new Set([2,1]));
 
     err(function() {
       [1, 2, 3].should.have.same.members([], 'blah');

--- a/test/should.js
+++ b/test/should.js
@@ -2815,11 +2815,11 @@ describe('should', function() {
 
     err(function() {
       'foo'.should.include.members([12], 'blah');
-    }, "blah: expected 'foo' to be an iterable");
+    }, "blah: expected 'foo' to be a superset of [ 12 ]");
 
     err(function() {
       [1, 2, 3].should.include.members('o', 'blah');
-    }, "blah: expected 'o' to be an iterable");
+    }, "blah: expected [ 1, 2, 3 ] to be a superset of 'o'");
   });
 
   it('memberEquals', function() {


### PR DESCRIPTION
Fixes https://github.com/chaijs/chai/issues/1468

Add `Set` support to `members`/`sameMembers`. While doing that I want to introduce a `iterable` assertion that I think could be useful.