### PR TITLE
Implement `iterable` assertion

### DIFF
--- a/lib/chai/core/assertions.js
+++ b/lib/chai/core/assertions.js
@@ -319,12 +319,6 @@ function an (type, msg) {
       , 'expected #{this} to be ' + article + type
       , 'expected #{this} not to be ' + article + type
     );
-  } else if (type === 'iterable') {
-    this.assert(
-        obj != undefined && obj[Symbol.iterator]
-      , 'expected #{this} to be ' + article + type
-      , 'expected #{this} not to be ' + article + type
-    );
   } else {
     this.assert(
       type === detectedType
@@ -3197,11 +3191,14 @@ Assertion.addMethod('members', function (subset, msg) {
  */
 Assertion.addProperty('iterable', function(msg) {
   if (msg) flag(this, 'message', msg);
-  var obj = flag(this, 'object')
-    , flagMsg = flag(this, 'message')
-    , ssfi = flag(this, 'ssfi');
-  
-  new Assertion(obj, flagMsg, ssfi, true).to.be.an('iterable');
+  var obj = flag(this, 'object');
+
+  this.assert(
+    obj != undefined && obj[Symbol.iterator]
+    , 'expected #{this} to be an iterable'
+    , 'expected #{this} to not be an iterable'
+    , obj
+  );
 });
 
 /**

--- a/lib/chai/core/assertions.js
+++ b/lib/chai/core/assertions.js
@@ -321,7 +321,7 @@ function an (type, msg) {
     );
   } else if (type === 'iterable') {
     this.assert(
-        typeof obj !== 'string' && obj != undefined && obj[Symbol.iterator]
+        obj != undefined && obj[Symbol.iterator]
       , 'expected #{this} to be ' + article + type
       , 'expected #{this} not to be ' + article + type
     );
@@ -3180,15 +3180,14 @@ Assertion.addMethod('members', function (subset, msg) {
 /**
  * ### .iterable
  *
- * Asserts that the target is an iterable, which means that it has a iterator
- * with the exception of `String.`
+ * Asserts that the target is an iterable, which means that it has a iterator.
  *
  *     expect([1, 2]).to.be.iterable;
  *
  * Add `.not` earlier in the chain to negate `.iterable`.
  *
  *     expect(1).to.not.be.iterable;
- *     expect("foobar").to.not.be.iterable;
+ *     expect(true).to.not.be.iterable;
  *
  * A custom error message can be given as the second argument to `expect`.
  *

--- a/lib/chai/core/assertions.js
+++ b/lib/chai/core/assertions.js
@@ -319,6 +319,12 @@ function an (type, msg) {
       , 'expected #{this} to be ' + article + type
       , 'expected #{this} not to be ' + article + type
     );
+  } else if (type === 'iterable') {
+    this.assert(
+        typeof obj !== 'string' && obj != undefined && obj[Symbol.iterator]
+      , 'expected #{this} to be ' + article + type
+      , 'expected #{this} not to be ' + article + type
+    );
   } else {
     this.assert(
       type === detectedType
@@ -3037,7 +3043,9 @@ Assertion.addMethod('closeTo', closeTo);
 Assertion.addMethod('approximately', closeTo);
 
 // Note: Duplicates are ignored if testing for inclusion instead of sameness.
-function isSubsetOf(subset, superset, cmp, contains, ordered) {
+function isSubsetOf(_subset, _superset, cmp, contains, ordered) {
+  let superset = Array.from(_superset);
+  let subset = Array.from(_subset);
   if (!contains) {
     if (subset.length !== superset.length) return false;
     superset = superset.slice();
@@ -3133,7 +3141,6 @@ function isSubsetOf(subset, superset, cmp, contains, ordered) {
  * @namespace BDD
  * @api public
  */
-
 Assertion.addMethod('members', function (subset, msg) {
   if (msg) flag(this, 'message', msg);
   var obj = flag(this, 'object')
@@ -3168,6 +3175,36 @@ Assertion.addMethod('members', function (subset, msg) {
     , obj
     , true
   );
+});
+
+/**
+ * ### .iterable
+ *
+ * Asserts that the target is an iterable, which means that it has a iterator
+ * with the exception of `String.`
+ *
+ *     expect([1, 2]).to.be.iterable;
+ *
+ * Add `.not` earlier in the chain to negate `.iterable`.
+ *
+ *     expect(1).to.not.be.iterable;
+ *     expect("foobar").to.not.be.iterable;
+ *
+ * A custom error message can be given as the second argument to `expect`.
+ *
+ *     expect(1, 'nooo why fail??').to.be.iterable;
+ *
+ * @name iterable
+ * @namespace BDD
+ * @api public
+ */
+Assertion.addProperty('iterable', function(msg) {
+  if (msg) flag(this, 'message', msg);
+  var obj = flag(this, 'object')
+    , flagMsg = flag(this, 'message')
+    , ssfi = flag(this, 'ssfi');
+  
+  new Assertion(obj, flagMsg, ssfi, true).to.be.an('iterable');
 });
 
 /**

--- a/lib/chai/core/assertions.js
+++ b/lib/chai/core/assertions.js
@@ -3043,9 +3043,7 @@ Assertion.addMethod('closeTo', closeTo);
 Assertion.addMethod('approximately', closeTo);
 
 // Note: Duplicates are ignored if testing for inclusion instead of sameness.
-function isSubsetOf(_subset, _superset, cmp, contains, ordered) {
-  let superset = Array.from(_superset);
-  let subset = Array.from(_subset);
+function isSubsetOf(subset, superset, cmp, contains, ordered) {
   if (!contains) {
     if (subset.length !== superset.length) return false;
     superset = superset.slice();

--- a/lib/chai/interface/assert.js
+++ b/lib/chai/interface/assert.js
@@ -2498,7 +2498,17 @@ assert.oneOf = function (inList, list, msg) {
  * @api public
  */
 assert.isIterable = function(obj, msg) {
-  new Assertion(obj, msg, assert.isIterable, true).to.be.an('iterable');
+  if (obj == undefined || !obj[Symbol.iterator]) {
+    msg = msg ?
+      `${msg} expected ${inspect(obj)} to be an iterable` :
+      `expected ${inspect(obj)} to be an iterable`;
+
+    throw new AssertionError(
+      msg,
+      undefined,
+      assert.isIterable
+    );
+  }
 }
 
 /**

--- a/lib/chai/interface/assert.js
+++ b/lib/chai/interface/assert.js
@@ -8,7 +8,6 @@ import * as chai from '../../../index.js';
 import {Assertion} from '../assertion.js';
 import {flag, inspect} from '../utils/index.js';
 import {AssertionError} from 'assertion-error';
-import {type} from '../utils/type-detect.js';
 
 /**
  * ### assert(expression, message)
@@ -2483,6 +2482,23 @@ assert.notIncludeDeepOrderedMembers = function (superset, subset, msg) {
 
 assert.oneOf = function (inList, list, msg) {
   new Assertion(inList, msg, assert.oneOf, true).to.be.oneOf(list);
+}
+
+/**
+ * ### isIterable(obj, [message])
+ *
+ * Asserts that the target is an iterable, which means that it has a iterator
+ * with the exception of `String.`
+ *
+ *     assert.isIterable([1, 2]);
+ *
+ * @param {unknown} obj
+ * @param {string} [msg]
+ * @namespace Assert
+ * @api public
+ */
+assert.isIterable = function(obj, msg) {
+  new Assertion(obj, msg, assert.isIterable, true).to.be.an('iterable');
 }
 
 /**

--- a/test/assert.js
+++ b/test/assert.js
@@ -2375,6 +2375,36 @@ describe('assert', function () {
     }, 'blah: the argument to most must be a number');
   });
 
+  it('iterable', function() {
+    assert.isIterable([1, 2, 3]);
+    assert.isIterable(new Map([[1, 'one'], [2, 'two'], [3, 'three']]));
+    assert.isIterable(new Set([1, 2, 3]));
+
+    err(function() {
+      assert.isIterable(42);
+    }, 'expected 42 to be an iterable');
+
+    err(function() {
+      assert.isIterable('hello');
+    }, "expected 'hello' to be an iterable");
+
+    err(function() {
+      assert.isIterable(undefined);
+    }, 'expected undefined to be an iterable'); 
+
+    err(function() {
+      assert.isIterable(null);
+    }, 'expected null to be an iterable');
+
+    err(function() {
+      assert.isIterable(true);
+    }, 'expected true to be an iterable');
+
+    err(function() {
+      assert.isIterable({ key: 'value' });
+    }, 'expected { key: \'value\' } to be an iterable');
+  });
+
   it('change', function() {
     var obj = { value: 10, str: 'foo' },
         heroes = ['spiderman', 'superman'],

--- a/test/assert.js
+++ b/test/assert.js
@@ -2379,14 +2379,11 @@ describe('assert', function () {
     assert.isIterable([1, 2, 3]);
     assert.isIterable(new Map([[1, 'one'], [2, 'two'], [3, 'three']]));
     assert.isIterable(new Set([1, 2, 3]));
+    assert.isIterable('hello');
 
     err(function() {
       assert.isIterable(42);
     }, 'expected 42 to be an iterable');
-
-    err(function() {
-      assert.isIterable('hello');
-    }, "expected 'hello' to be an iterable");
 
     err(function() {
       assert.isIterable(undefined);

--- a/test/expect.js
+++ b/test/expect.js
@@ -3645,14 +3645,11 @@ describe('expect', function () {
     expect([1, 2, 3]).to.be.iterable;
     expect(new Map([[1, 'one'], [2, 'two'], [3, 'three']])).to.be.iterable;
     expect(new Set([1, 2, 3])).to.be.iterable;
+    expect('hello').to.be.iterable;
 
     err(function() {
       expect(42).to.be.iterable;
     }, 'expected 42 to be an iterable');
-
-    err(function() {
-      expect('hello').to.be.iterable;
-    }, "expected 'hello' to be an iterable");
 
     err(function() {
       expect(undefined).to.be.iterable;

--- a/test/expect.js
+++ b/test/expect.js
@@ -3641,6 +3641,36 @@ describe('expect', function () {
     }, 'expected [ { a: 1 }, { b: 2 }, { c: 3 } ] to not be an ordered superset of [ { a: 1 }, { b: 2 } ]');
   });
 
+  it('iterable', function() {
+    expect([1, 2, 3]).to.be.iterable;
+    expect(new Map([[1, 'one'], [2, 'two'], [3, 'three']])).to.be.iterable;
+    expect(new Set([1, 2, 3])).to.be.iterable;
+
+    err(function() {
+      expect(42).to.be.iterable;
+    }, 'expected 42 to be an iterable');
+
+    err(function() {
+      expect('hello').to.be.iterable;
+    }, "expected 'hello' to be an iterable");
+
+    err(function() {
+      expect(undefined).to.be.iterable;
+    }, 'expected undefined to be an iterable');
+
+    err(function() {
+      expect(null).to.be.iterable;
+    }, 'expected null to be an iterable');
+
+    err(function() {
+      expect(true).to.be.iterable;
+    }, 'expected true to be an iterable');
+
+    err(function() {
+      expect({ key: 'value' }).to.be.iterable;
+    }, 'expected { key: \'value\' } to be an iterable');
+  })
+
   it('change', function() {
     var obj = { value: 10, str: 'foo' },
         heroes = ['spiderman', 'superman'],

--- a/test/should.js
+++ b/test/should.js
@@ -2946,14 +2946,11 @@ describe('should', function() {
     ([1, 2, 3]).should.be.iterable;
     (new Map([[1, 'one'], [2, 'two'], [3, 'three']])).should.be.iterable;
     (new Set([1, 2, 3])).should.be.iterable;
+    ('hello').should.be.iterable;
 
     err(function() {
       (42).should.be.iterable;
     }, 'expected 42 to be an iterable');
-
-    err(function() {
-      ('hello').should.be.iterable;
-    }, "expected 'hello' to be an iterable");
 
     err(function() {
       (true).should.be.iterable;

--- a/test/should.js
+++ b/test/should.js
@@ -2942,6 +2942,28 @@ describe('should', function() {
     }, 'expected [ { a: 1 }, { b: 2 }, { c: 3 } ] to not be an ordered superset of [ { a: 1 }, { b: 2 } ]');
   });
 
+  it ('iterable', function() {
+    ([1, 2, 3]).should.be.iterable;
+    (new Map([[1, 'one'], [2, 'two'], [3, 'three']])).should.be.iterable;
+    (new Set([1, 2, 3])).should.be.iterable;
+
+    err(function() {
+      (42).should.be.iterable;
+    }, 'expected 42 to be an iterable');
+
+    err(function() {
+      ('hello').should.be.iterable;
+    }, "expected 'hello' to be an iterable");
+
+    err(function() {
+      (true).should.be.iterable;
+    }, 'expected true to be an iterable');
+
+    err(function() {
+      ({ key: 'value' }).should.be.iterable;
+    }, 'expected { key: \'value\' } to be an iterable');
+  })
+
   it('change', function() {
     var obj = { value: 10, str: 'foo' },
         heroes = ['spiderman', 'superman'],


### PR DESCRIPTION
Pulled this out of #1583 so that these PRs make more logical sense.

This PR implemensts a `iterable`/`isIterable` assertion that checks a given object for `Symbol.iterator` but notably excludes `string` which does have `Symbol.iterator` but we don't consider to be "iterable".