### PR TITLE
Remove useless guards and add parentheses to constuctors

### DIFF
--- a/test/assert.js
+++ b/test/assert.js
@@ -577,7 +577,7 @@ describe('assert', function () {
 
   it('isArray', function() {
     assert.isArray([]);
-    assert.isArray(new Array);
+    assert.isArray(new Array());
 
     err(function () {
       assert.isArray({}, 'blah');
@@ -592,7 +592,7 @@ describe('assert', function () {
     }, "blah: expected [] not to be an array");
 
     err(function () {
-      assert.isNotArray(new Array);
+      assert.isNotArray(new Array());
     }, "expected [] not to be an array");
   });
 
@@ -1412,9 +1412,9 @@ describe('assert', function () {
       assert.lengthOf(1, 5);
      }, "expected 1 to have property \'length\'");
 
-    assert.lengthOf(new Map, 0);
+    assert.lengthOf(new Map(), 0);
 
-    var map = new Map;
+    var map = new Map();
     map.set('a', 1);
     map.set('b', 2);
 
@@ -1424,9 +1424,9 @@ describe('assert', function () {
       assert.lengthOf(map, 3, 'blah');
     }, "blah: expected Map{ 'a' => 1, 'b' => 2 } to have a size of 3 but got 2");
 
-    assert.lengthOf(new Set, 0);
+    assert.lengthOf(new Set(), 0);
 
-    var set = new Set;
+    var set = new Set();
     set.add(1);
     set.add(2);
 
@@ -2714,25 +2714,25 @@ describe('assert', function () {
 
       assert[isEmpty]('');
       assert[isEmpty]([]);
-      assert[isEmpty](new FakeArgs);
+      assert[isEmpty](new FakeArgs());
       assert[isEmpty]({});
 
       err(function(){
-        assert[isEmpty](new WeakMap, 'blah');
+        assert[isEmpty](new WeakMap(), 'blah');
       }, "blah: .empty was passed a weak collection");
 
       err(function(){
-        assert[isEmpty](new WeakSet, 'blah');
+        assert[isEmpty](new WeakSet(), 'blah');
       }, "blah: .empty was passed a weak collection");
 
-      assert[isEmpty](new Map);
+      assert[isEmpty](new Map());
 
-      var map = new Map;
+      var map = new Map();
       map.key = 'val';
       assert[isEmpty](map);
-      assert[isEmpty](new Set);
+      assert[isEmpty](new Set());
 
-      var set = new Set;
+      var set = new Set();
       set.key = 'val';
       assert[isEmpty](set);
 
@@ -2811,11 +2811,11 @@ describe('assert', function () {
       assert[isNotEmpty]({foo: 'bar'});
 
       err(function(){
-        assert[isNotEmpty](new WeakMap, 'blah');
+        assert[isNotEmpty](new WeakMap(), 'blah');
       }, "blah: .empty was passed a weak collection");
 
       err(function(){
-        assert[isNotEmpty](new WeakSet, 'blah');
+        assert[isNotEmpty](new WeakSet(), 'blah');
       }, "blah: .empty was passed a weak collection");
 
       var map = new Map();
@@ -2823,7 +2823,7 @@ describe('assert', function () {
       assert[isNotEmpty](map);
 
       err(function(){
-        assert[isNotEmpty](new Map);
+        assert[isNotEmpty](new Map());
       }, "expected Map{} not to be empty");
 
       var set = new Set();
@@ -2831,7 +2831,7 @@ describe('assert', function () {
       assert[isNotEmpty](set);
 
       err(function(){
-        assert[isNotEmpty](new Set);
+        assert[isNotEmpty](new Set());
       }, "expected Set{} not to be empty");
 
       err(function(){
@@ -2843,7 +2843,7 @@ describe('assert', function () {
       }, "expected [] not to be empty");
 
       err(function(){
-        assert[isNotEmpty](new FakeArgs);
+        assert[isNotEmpty](new FakeArgs());
       }, "expected FakeArgs{} not to be empty");
 
       err(function(){

--- a/test/assert.js
+++ b/test/assert.js
@@ -125,10 +125,8 @@ describe('assert', function () {
     var foo;
     assert.equal(foo, undefined);
 
-    if (typeof Symbol === 'function') {
-      var sym = Symbol();
-      assert.equal(sym, sym);
-    }
+    var sym = Symbol();
+    assert.equal(sym, sym);
 
     err(function () {
       assert.equal(1, 2, 'blah');
@@ -145,6 +143,7 @@ describe('assert', function () {
     assert.typeOf(async function() {}, 'asyncfunction');
     assert.typeOf(function*() {}, 'generatorfunction');
     assert.typeOf(async function*() {}, 'asyncgeneratorfunction');
+    assert.typeOf(Symbol(), 'symbol');
     
     err(function () {
       assert.typeOf(5, 'function', 'blah');
@@ -153,10 +152,6 @@ describe('assert', function () {
     err(function () {
       assert.typeOf(function() {}, 'asyncfunction', 'blah');
     }, "blah: expected [Function] to be an asyncfunction");
-
-    if (typeof Symbol === 'function') {
-      assert.typeOf(Symbol(), 'symbol');
-    }
 
     err(function () {
       assert.typeOf(5, 'string', 'blah');
@@ -227,21 +222,19 @@ describe('assert', function () {
       assert.instanceOf(t, Thing);
     }, 'The instanceof assertion needs a constructor but Function was given.', true);
 
-    if (typeof Symbol !== 'undefined' && typeof Symbol.hasInstance !== 'undefined') {
-        err(function(){
-          assert.instanceOf(new Foo(), Symbol());
-        }, "The instanceof assertion needs a constructor but Symbol was given.");
+    err(function(){
+      assert.instanceOf(new Foo(), Symbol());
+    }, "The instanceof assertion needs a constructor but Symbol was given.");
 
-        err(function() {
-            var FakeConstructor = {};
-            var fakeInstanceB = 4;
-            FakeConstructor[Symbol.hasInstance] = function (val) {
-                return val === 3;
-            };
+    err(function() {
+        var FakeConstructor = {};
+        var fakeInstanceB = 4;
+        FakeConstructor[Symbol.hasInstance] = function (val) {
+            return val === 3;
+        };
 
-            assert.instanceOf(fakeInstanceB, FakeConstructor);
-        }, 'expected 4 to be an instance of an unnamed constructor')
-    }
+        assert.instanceOf(fakeInstanceB, FakeConstructor);
+    }, 'expected 4 to be an instance of an unnamed constructor')
 
     err(function () {
       assert.instanceOf(5, Foo, 'blah');
@@ -282,21 +275,19 @@ describe('assert', function () {
       assert.notInstanceOf(new Foo(), undefined);
     }, "The instanceof assertion needs a constructor but undefined was given.");
 
-    if (typeof Symbol !== 'undefined' && typeof Symbol.hasInstance !== 'undefined') {
-        err(function(){
-          assert.notInstanceOf(new Foo(), Symbol());
-        }, "The instanceof assertion needs a constructor but Symbol was given.");
+    err(function(){
+      assert.notInstanceOf(new Foo(), Symbol());
+    }, "The instanceof assertion needs a constructor but Symbol was given.");
 
-        err(function() {
-            var FakeConstructor = {};
-            var fakeInstanceB = 4;
-            FakeConstructor[Symbol.hasInstance] = function (val) {
-                return val === 4;
-            };
+    err(function() {
+        var FakeConstructor = {};
+        var fakeInstanceB = 4;
+        FakeConstructor[Symbol.hasInstance] = function (val) {
+            return val === 4;
+        };
 
-            assert.notInstanceOf(fakeInstanceB, FakeConstructor);
-        }, 'expected 4 to not be an instance of an unnamed constructor');
-    }
+        assert.notInstanceOf(fakeInstanceB, FakeConstructor);
+    }, 'expected 4 to not be an instance of an unnamed constructor');
 
     err(function () {
       assert.notInstanceOf(new Foo(), Foo, 'blah');
@@ -333,11 +324,9 @@ describe('assert', function () {
   it('notEqual', function() {
     assert.notEqual(3, 4);
 
-    if (typeof Symbol === 'function') {
-      var sym1 = Symbol()
-        , sym2 = Symbol();
-      assert.notEqual(sym1, sym2);
-    }
+    var sym1 = Symbol()
+      , sym2 = Symbol();
+    assert.notEqual(sym1, sym2);
 
     err(function () {
       assert.notEqual(5, 5, 'blah');
@@ -347,10 +336,8 @@ describe('assert', function () {
   it('strictEqual', function() {
     assert.strictEqual('foo', 'foo');
 
-    if (typeof Symbol === 'function') {
-      var sym = Symbol();
-      assert.strictEqual(sym, sym);
-    }
+    var sym = Symbol();
+    assert.strictEqual(sym, sym);
 
     err(function () {
       assert.strictEqual('5', 5, 'blah');
@@ -360,11 +347,9 @@ describe('assert', function () {
   it('notStrictEqual', function() {
     assert.notStrictEqual(5, '5');
 
-    if (typeof Symbol === 'function') {
-      var sym1 = Symbol()
-        , sym2 = Symbol();
-      assert.notStrictEqual(sym1, sym2);
-    }
+    var sym1 = Symbol()
+      , sym2 = Symbol();
+    assert.notStrictEqual(sym1, sym2);
 
     err(function () {
       assert.notStrictEqual(5, 5, 'blah');
@@ -701,13 +686,10 @@ describe('assert', function () {
     // .include should work with Error objects and objects with a custom
     // `@@toStringTag`.
     assert.include(new Error('foo'), {message: 'foo'});
-    if (typeof Symbol !== 'undefined'
-        && typeof Symbol.toStringTag !== 'undefined') {
-      var customObj = {a: 1};
-      customObj[Symbol.toStringTag] = 'foo';
+    var customObj = {a: 1};
+    customObj[Symbol.toStringTag] = 'foo';
 
-      assert.include(customObj, {a: 1});
-    }
+    assert.include(customObj, {a: 1});
 
     var obj1 = {a: 1}
       , obj2 = {b: 2};
@@ -715,51 +697,39 @@ describe('assert', function () {
     assert.include({foo: obj1, bar: obj2}, {foo: obj1});
     assert.include({foo: obj1, bar: obj2}, {foo: obj1, bar: obj2});
 
-    if (typeof Map === 'function') {
-      var map = new Map();
-      var val = [{a: 1}];
-      map.set('a', val);
-      map.set('b', 2);
-      map.set('c', -0);
-      map.set('d', NaN);
+    var map = new Map();
+    var val = [{a: 1}];
+    map.set('a', val);
+    map.set('b', 2);
+    map.set('c', -0);
+    map.set('d', NaN);
 
-      assert.include(map, val);
-      assert.include(map, 2);
-      assert.include(map, 0);
-      assert.include(map, NaN);
-    }
+    assert.include(map, val);
+    assert.include(map, 2);
+    assert.include(map, 0);
+    assert.include(map, NaN);
 
-    if (typeof Set === 'function') {
-      var set = new Set();
-      var val = [{a: 1}];
-      set.add(val);
-      set.add(2);
-      set.add(-0);
-      set.add(NaN);
+    var val = [{a: 1}];
+    var set = new Set();
+    set.add(val);
+    set.add(2);
+    set.add(-0);
+    set.add(NaN);
 
-      assert.include(set, val);
-      assert.include(set, 2);
-      if (set.has(0)) {
-        // This test is skipped in IE11 because (contrary to spec) IE11 uses
-        // SameValue instead of SameValueZero equality for sets.
-        assert.include(set, 0);
-      }
-      assert.include(set, NaN);
-    }
+    assert.include(set, val);
+    assert.include(set, 2);
+    assert.include(set, 0);
+    assert.include(set, NaN);
 
-    if (typeof WeakSet === 'function') {
-      var ws = new WeakSet();
-      var val = [{a: 1}];
-      ws.add(val);
+    var ws = new WeakSet();
+    var val = [{a: 1}];
+    ws.add(val);
 
-      assert.include(ws, val);
-    }
+    assert.include(ws, val);
 
-    if (typeof Symbol === 'function') {
-      var sym1 = Symbol()
-        , sym2 = Symbol();
-      assert.include([sym1, sym2], sym1);
-    }
+    var sym1 = Symbol()
+      , sym2 = Symbol();
+    assert.include([sym1, sym2], sym1);
 
     err(function () {
       assert.include('foobar', 'baz', 'blah');
@@ -812,44 +782,36 @@ describe('assert', function () {
     assert.notInclude({foo: obj1, bar: obj2}, {foo: {a: 1}});
     assert.notInclude({foo: obj1, bar: obj2}, {foo: obj1, bar: {b: 2}});
 
-    if (typeof Map === 'function') {
-      var map = new Map();
-      var val = [{a: 1}];
-      map.set('a', val);
-      map.set('b', 2);
+    var map = new Map();
+    var val = [{a: 1}];
+    map.set('a', val);
+    map.set('b', 2);
 
-      assert.notInclude(map, [{a: 1}]);
-      assert.notInclude(map, 3);
-    }
+    assert.notInclude(map, [{a: 1}]);
+    assert.notInclude(map, 3);
 
-    if (typeof Set === 'function') {
-      var set = new Set();
-      var val = [{a: 1}];
-      set.add(val);
-      set.add(2);
+    var set = new Set();
+    var val = [{a: 1}];
+    set.add(val);
+    set.add(2);
 
-      assert.include(set, val);
-      assert.include(set, 2);
+    assert.include(set, val);
+    assert.include(set, 2);
 
-      assert.notInclude(set, [{a: 1}]);
-      assert.notInclude(set, 3);
-    }
+    assert.notInclude(set, [{a: 1}]);
+    assert.notInclude(set, 3);
 
-    if (typeof WeakSet === 'function') {
-      var ws = new WeakSet();
-      var val = [{a: 1}];
-      ws.add(val);
+    var ws = new WeakSet();
+    var val = [{a: 1}];
+    ws.add(val);
 
-      assert.notInclude(ws, [{a: 1}]);
-      assert.notInclude(ws, {});
-    }
+    assert.notInclude(ws, [{a: 1}]);
+    assert.notInclude(ws, {});
 
-    if (typeof Symbol === 'function') {
-      var sym1 = Symbol()
-        , sym2 = Symbol()
-        , sym3 = Symbol();
-      assert.notInclude([sym1, sym2], sym3);
-    }
+    var sym1 = Symbol()
+      , sym2 = Symbol()
+      , sym3 = Symbol();
+    assert.notInclude([sym1, sym2], sym3);
 
     err(function () {
       var obj1 = {a: 1}
@@ -909,25 +871,19 @@ describe('assert', function () {
     assert.notDeepInclude({foo: obj1, bar: obj2}, {baz: {a: 1}});
     assert.notDeepInclude({foo: obj1, bar: obj2}, {foo: {a: 1}, bar: {b: 9}});
 
-    if (typeof Map === 'function') {
-      var map = new Map();
-      map.set(1, [{a: 1}]);
+    var map = new Map();
+    map.set(1, [{a: 1}]);
 
-      assert.deepInclude(map, [{a: 1}]);
-    }
+    assert.deepInclude(map, [{a: 1}]);
 
-    if (typeof Set === 'function') {
-      var set = new Set();
-      set.add([{a: 1}]);
+    var set = new Set();
+    set.add([{a: 1}]);
 
-      assert.deepInclude(set, [{a: 1}]);
-    }
+    assert.deepInclude(set, [{a: 1}]);
 
-    if (typeof WeakSet === 'function') {
-      err(function() {
-        assert.deepInclude(new WeakSet(), {}, 'foo');
-      }, 'foo: unable to use .deep.include with WeakSet');
-    }
+    err(function() {
+      assert.deepInclude(new WeakSet(), {}, 'foo');
+    }, 'foo: unable to use .deep.include with WeakSet');
 
     err(function () {
       assert.deepInclude([obj1, obj2], {a: 9}, 'blah');
@@ -1099,264 +1055,252 @@ describe('assert', function () {
     assert.hasAllKeys(obj, [enumProp1, enumProp2]);
     assert.doesNotHaveAllKeys(obj, [enumProp1, enumProp2, nonEnumProp]);
 
-    if (typeof Symbol === 'function') {
-      var sym1 = Symbol('sym1')
-        , sym2 = Symbol('sym2')
-        , sym3 = Symbol('sym3')
-        , str = 'str'
-        , obj = {};
+    var sym1 = Symbol('sym1')
+      , sym2 = Symbol('sym2')
+      , sym3 = Symbol('sym3')
+      , str = 'str'
+      , obj = {};
 
-      obj[sym1] = 'sym1';
-      obj[sym2] = 'sym2';
-      obj[str] = 'str';
+    obj[sym1] = 'sym1';
+    obj[sym2] = 'sym2';
+    obj[str] = 'str';
 
-      Object.defineProperty(obj, sym3, {
-        enumerable: false,
-        value: 'sym3'
-      });
+    Object.defineProperty(obj, sym3, {
+      enumerable: false,
+      value: 'sym3'
+    });
 
-      assert.hasAllKeys(obj, [sym1, sym2, str]);
-      assert.doesNotHaveAllKeys(obj, [sym1, sym2, sym3, str]);
-    }
+    assert.hasAllKeys(obj, [sym1, sym2, str]);
+    assert.doesNotHaveAllKeys(obj, [sym1, sym2, sym3, str]);
 
-    if (typeof Map !== 'undefined') {
-      // Not using Map constructor args because not supported in IE 11.
-      var aKey = {thisIs: 'anExampleObject'}
-        , anotherKey = {doingThisBecauseOf: 'referential equality'}
-        , testMap = new Map();
+    var aKey = {thisIs: 'anExampleObject'}
+      , anotherKey = {doingThisBecauseOf: 'referential equality'}
+      , testMap = new Map();
 
-      testMap.set(aKey, 'aValue');
-      testMap.set(anotherKey, 'anotherValue');
+    testMap.set(aKey, 'aValue');
+    testMap.set(anotherKey, 'anotherValue');
 
-      assert.hasAnyKeys(testMap, [ aKey ]);
-      assert.hasAnyKeys(testMap, [ 'thisDoesNotExist', 'thisToo', aKey ]);
-      assert.hasAllKeys(testMap, [ aKey, anotherKey ]);
+    assert.hasAnyKeys(testMap, [ aKey ]);
+    assert.hasAnyKeys(testMap, [ 'thisDoesNotExist', 'thisToo', aKey ]);
+    assert.hasAllKeys(testMap, [ aKey, anotherKey ]);
 
-      assert.containsAllKeys(testMap, [ aKey ]);
-      assert.doesNotHaveAllKeys(testMap, [ aKey, {iDoNot: 'exist'} ]);
+    assert.containsAllKeys(testMap, [ aKey ]);
+    assert.doesNotHaveAllKeys(testMap, [ aKey, {iDoNot: 'exist'} ]);
 
-      assert.doesNotHaveAnyKeys(testMap, [ {iDoNot: 'exist'} ]);
-      assert.doesNotHaveAnyKeys(testMap, [ 'thisDoesNotExist', 'thisToo', {iDoNot: 'exist'} ]);
-      assert.doesNotHaveAllKeys(testMap, [ 'thisDoesNotExist', 'thisToo', anotherKey ]);
+    assert.doesNotHaveAnyKeys(testMap, [ {iDoNot: 'exist'} ]);
+    assert.doesNotHaveAnyKeys(testMap, [ 'thisDoesNotExist', 'thisToo', {iDoNot: 'exist'} ]);
+    assert.doesNotHaveAllKeys(testMap, [ 'thisDoesNotExist', 'thisToo', anotherKey ]);
 
-      assert.doesNotHaveAnyKeys(testMap, [ {iDoNot: 'exist'}, 'thisDoesNotExist' ]);
-      assert.doesNotHaveAnyKeys(testMap, [ 'thisDoesNotExist', 'thisToo', {iDoNot: 'exist'} ]);
-      assert.doesNotHaveAllKeys(testMap, [ aKey, {iDoNot: 'exist'} ]);
-
-      // Ensure the assertions above use strict equality
-      assert.doesNotHaveAnyKeys(testMap, {thisIs: 'anExampleObject'});
-      assert.doesNotHaveAllKeys(testMap, [ {thisIs: 'anExampleObject'}, {doingThisBecauseOf: 'referential equality'} ]);
-
-      err(function(){
-        assert.hasAnyKeys(testMap, [ {thisIs: 'anExampleObject'} ]);
-      });
-
-      err(function(){
-        assert.hasAllKeys(testMap, [ {thisIs: 'anExampleObject'}, {doingThisBecauseOf: 'referential equality'} ]);
-      });
+    assert.doesNotHaveAnyKeys(testMap, [ {iDoNot: 'exist'}, 'thisDoesNotExist' ]);
+    assert.doesNotHaveAnyKeys(testMap, [ 'thisDoesNotExist', 'thisToo', {iDoNot: 'exist'} ]);
+    assert.doesNotHaveAllKeys(testMap, [ aKey, {iDoNot: 'exist'} ]);
 
-      err(function(){
-        assert.containsAllKeys(testMap, [ {thisIs: 'anExampleObject'} ]);
-      });
+    // Ensure the assertions above use strict equality
+    assert.doesNotHaveAnyKeys(testMap, {thisIs: 'anExampleObject'});
+    assert.doesNotHaveAllKeys(testMap, [ {thisIs: 'anExampleObject'}, {doingThisBecauseOf: 'referential equality'} ]);
 
-      // Tests for the deep variations of the keys assertion
-      assert.hasAnyDeepKeys(testMap, {thisIs: 'anExampleObject'});
-      assert.hasAnyDeepKeys(testMap, [{thisIs: 'anExampleObject'}, {three: 'three'}]);
-      assert.hasAnyDeepKeys(testMap, [{thisIs: 'anExampleObject'}, {doingThisBecauseOf: 'referential equality'}]);
+    err(function(){
+      assert.hasAnyKeys(testMap, [ {thisIs: 'anExampleObject'} ]);
+    });
 
-      assert.hasAllDeepKeys(testMap, [{thisIs: 'anExampleObject'}, {doingThisBecauseOf: 'referential equality'}]);
-
-      assert.containsAllDeepKeys(testMap, {thisIs: 'anExampleObject'});
-      assert.containsAllDeepKeys(testMap, [{thisIs: 'anExampleObject'}, {doingThisBecauseOf: 'referential equality'}]);
-
-      assert.doesNotHaveAnyDeepKeys(testMap, {thisDoesNot: 'exist'});
-      assert.doesNotHaveAnyDeepKeys(testMap, [{twenty: 'twenty'}, {fifty: 'fifty'}]);
+    err(function(){
+      assert.hasAllKeys(testMap, [ {thisIs: 'anExampleObject'}, {doingThisBecauseOf: 'referential equality'} ]);
+    });
 
-      assert.doesNotHaveAllDeepKeys(testMap, {thisDoesNot: 'exist'});
-      assert.doesNotHaveAllDeepKeys(testMap, [{twenty: 'twenty'}, {thisIs: 'anExampleObject'}]);
+    err(function(){
+      assert.containsAllKeys(testMap, [ {thisIs: 'anExampleObject'} ]);
+    });
 
-      var weirdMapKey1 = Object.create(null)
-        , weirdMapKey2 = {toString: NaN}
-        , weirdMapKey3 = []
-        , weirdMap = new Map();
+    // Tests for the deep variations of the keys assertion
+    assert.hasAnyDeepKeys(testMap, {thisIs: 'anExampleObject'});
+    assert.hasAnyDeepKeys(testMap, [{thisIs: 'anExampleObject'}, {three: 'three'}]);
+    assert.hasAnyDeepKeys(testMap, [{thisIs: 'anExampleObject'}, {doingThisBecauseOf: 'referential equality'}]);
 
-      weirdMap.set(weirdMapKey1, 'val1');
-      weirdMap.set(weirdMapKey2, 'val2');
-
-      assert.hasAllKeys(weirdMap, [weirdMapKey1, weirdMapKey2]);
-      assert.doesNotHaveAllKeys(weirdMap, [weirdMapKey1, weirdMapKey3]);
+    assert.hasAllDeepKeys(testMap, [{thisIs: 'anExampleObject'}, {doingThisBecauseOf: 'referential equality'}]);
 
-      if (typeof Symbol === 'function') {
-        var symMapKey1 = Symbol()
-          , symMapKey2 = Symbol()
-          , symMapKey3 = Symbol()
-          , symMap = new Map();
+    assert.containsAllDeepKeys(testMap, {thisIs: 'anExampleObject'});
+    assert.containsAllDeepKeys(testMap, [{thisIs: 'anExampleObject'}, {doingThisBecauseOf: 'referential equality'}]);
 
-        symMap.set(symMapKey1, 'val1');
-        symMap.set(symMapKey2, 'val2');
+    assert.doesNotHaveAnyDeepKeys(testMap, {thisDoesNot: 'exist'});
+    assert.doesNotHaveAnyDeepKeys(testMap, [{twenty: 'twenty'}, {fifty: 'fifty'}]);
 
-        assert.hasAllKeys(symMap, [symMapKey1, symMapKey2]);
-        assert.hasAnyKeys(symMap, [symMapKey1, symMapKey3]);
-        assert.containsAllKeys(symMap, [symMapKey2, symMapKey1]);
+    assert.doesNotHaveAllDeepKeys(testMap, {thisDoesNot: 'exist'});
+    assert.doesNotHaveAllDeepKeys(testMap, [{twenty: 'twenty'}, {thisIs: 'anExampleObject'}]);
 
-        assert.doesNotHaveAllKeys(symMap, [symMapKey1, symMapKey3]);
-        assert.doesNotHaveAnyKeys(symMap, [symMapKey3]);
-      }
+    var weirdMapKey1 = Object.create(null)
+      , weirdMapKey2 = {toString: NaN}
+      , weirdMapKey3 = []
+      , weirdMap = new Map();
 
-      var errMap = new Map();
+    weirdMap.set(weirdMapKey1, 'val1');
+    weirdMap.set(weirdMapKey2, 'val2');
 
-      errMap.set({1: 20}, 'number');
+    assert.hasAllKeys(weirdMap, [weirdMapKey1, weirdMapKey2]);
+    assert.doesNotHaveAllKeys(weirdMap, [weirdMapKey1, weirdMapKey3]);
 
-      err(function(){
-        assert.hasAllKeys(errMap, [], 'blah');
-      }, "blah: keys required");
+    var symMapKey1 = Symbol()
+      , symMapKey2 = Symbol()
+      , symMapKey3 = Symbol()
+      , symMap = new Map();
 
-      err(function(){
-        assert.containsAllKeys(errMap, [], 'blah');
-      }, "blah: keys required");
+    symMap.set(symMapKey1, 'val1');
+    symMap.set(symMapKey2, 'val2');
 
-      err(function(){
-        assert.doesNotHaveAllKeys(errMap, [], 'blah');
-      }, "blah: keys required");
+    assert.hasAllKeys(symMap, [symMapKey1, symMapKey2]);
+    assert.hasAnyKeys(symMap, [symMapKey1, symMapKey3]);
+    assert.containsAllKeys(symMap, [symMapKey2, symMapKey1]);
 
-      err(function(){
-        assert.hasAnyKeys(errMap, [], 'blah');
-      }, "blah: keys required");
+    assert.doesNotHaveAllKeys(symMap, [symMapKey1, symMapKey3]);
+    assert.doesNotHaveAnyKeys(symMap, [symMapKey3]);
 
-      err(function(){
-        assert.doesNotHaveAnyKeys(errMap, [], 'blah');
-      }, "blah: keys required");
+    var errMap = new Map();
 
-      // Uncomment this after solving https://github.com/chaijs/chai/issues/662
-      // This should fail because of referential equality (this is a strict comparison)
-      // err(function(){
-      //   assert.containsAllKeys(new Map([[{foo: 1}, 'bar']]), { foo: 1 });
-      // }, 'expected [ [ { foo: 1 }, 'bar' ] ] to contain key { foo: 1 }');
+    errMap.set({1: 20}, 'number');
 
-      // err(function(){
-      //   assert.containsAllDeepKeys(new Map([[{foo: 1}, 'bar']]), { iDoNotExist: 0 })
-      // }, 'expected [ { foo: 1 } ] to deeply contain key { iDoNotExist: 0 }');
-    }
+    err(function(){
+      assert.hasAllKeys(errMap, [], 'blah');
+    }, "blah: keys required");
 
-    if (typeof Set !== 'undefined') {
-      // Not using Set constructor args because not supported in IE 11.
-      var aKey = {thisIs: 'anExampleObject'}
-        , anotherKey = {doingThisBecauseOf: 'referential equality'}
-        , testSet = new Set();
+    err(function(){
+      assert.containsAllKeys(errMap, [], 'blah');
+    }, "blah: keys required");
 
-      testSet.add(aKey);
-      testSet.add(anotherKey);
+    err(function(){
+      assert.doesNotHaveAllKeys(errMap, [], 'blah');
+    }, "blah: keys required");
 
-      assert.hasAnyKeys(testSet, [ aKey ]);
-      assert.hasAnyKeys(testSet, [ 20, 1, aKey ]);
-      assert.hasAllKeys(testSet, [ aKey, anotherKey ]);
+    err(function(){
+      assert.hasAnyKeys(errMap, [], 'blah');
+    }, "blah: keys required");
 
-      assert.containsAllKeys(testSet, [ aKey ]);
-      assert.doesNotHaveAllKeys(testSet, [ aKey, {iDoNot: 'exist'} ]);
+    err(function(){
+      assert.doesNotHaveAnyKeys(errMap, [], 'blah');
+    }, "blah: keys required");
 
-      assert.doesNotHaveAnyKeys(testSet, [ {iDoNot: 'exist'} ]);
-      assert.doesNotHaveAnyKeys(testSet, [ 'thisDoesNotExist', 'thisToo', {iDoNot: 'exist'} ]);
-      assert.doesNotHaveAllKeys(testSet, [ 'thisDoesNotExist', 'thisToo', anotherKey ]);
+    // Uncomment this after solving https://github.com/chaijs/chai/issues/662
+    // This should fail because of referential equality (this is a strict comparison)
+    // err(function(){
+    //   assert.containsAllKeys(new Map([[{foo: 1}, 'bar']]), { foo: 1 });
+    // }, 'expected [ [ { foo: 1 }, 'bar' ] ] to contain key { foo: 1 }');
 
-      assert.doesNotHaveAnyKeys(testSet, [ {iDoNot: 'exist'}, 'thisDoesNotExist' ]);
-      assert.doesNotHaveAnyKeys(testSet, [ 20, 1, {iDoNot: 'exist'} ]);
-      assert.doesNotHaveAllKeys(testSet, [ 'thisDoesNotExist', 'thisToo', {iDoNot: 'exist'} ]);
+    // err(function(){
+    //   assert.containsAllDeepKeys(new Map([[{foo: 1}, 'bar']]), { iDoNotExist: 0 })
+    // }, 'expected [ { foo: 1 } ] to deeply contain key { iDoNotExist: 0 }');
 
-      // Ensure the assertions above use strict equality
-      assert.doesNotHaveAnyKeys(testSet, {thisIs: 'anExampleObject'});
-      assert.doesNotHaveAllKeys(testSet, [ {thisIs: 'anExampleObject'}, {doingThisBecauseOf: 'referential equality'} ]);
+    var aKey = {thisIs: 'anExampleObject'}
+      , anotherKey = {doingThisBecauseOf: 'referential equality'}
+      , testSet = new Set();
 
-      err(function(){
-        assert.hasAnyKeys(testSet, [ {thisIs: 'anExampleObject'} ]);
-      });
+    testSet.add(aKey);
+    testSet.add(anotherKey);
 
-      err(function(){
-        assert.hasAllKeys(testSet, [ {thisIs: 'anExampleObject'}, {doingThisBecauseOf: 'referential equality'} ]);
-      });
+    assert.hasAnyKeys(testSet, [ aKey ]);
+    assert.hasAnyKeys(testSet, [ 20, 1, aKey ]);
+    assert.hasAllKeys(testSet, [ aKey, anotherKey ]);
 
-      err(function(){
-        assert.containsAllKeys(testSet, [ {thisIs: 'anExampleObject'} ]);
-      });
+    assert.containsAllKeys(testSet, [ aKey ]);
+    assert.doesNotHaveAllKeys(testSet, [ aKey, {iDoNot: 'exist'} ]);
 
-      // Tests for the deep variations of the keys assertion
-      assert.hasAnyDeepKeys(testSet, {thisIs: 'anExampleObject'});
-      assert.hasAnyDeepKeys(testSet, [{thisIs: 'anExampleObject'}, {three: 'three'}]);
-      assert.hasAnyDeepKeys(testSet, [{thisIs: 'anExampleObject'}, {doingThisBecauseOf: 'referential equality'}]);
+    assert.doesNotHaveAnyKeys(testSet, [ {iDoNot: 'exist'} ]);
+    assert.doesNotHaveAnyKeys(testSet, [ 'thisDoesNotExist', 'thisToo', {iDoNot: 'exist'} ]);
+    assert.doesNotHaveAllKeys(testSet, [ 'thisDoesNotExist', 'thisToo', anotherKey ]);
 
-      assert.hasAllDeepKeys(testSet, [{thisIs: 'anExampleObject'}, {doingThisBecauseOf: 'referential equality'}]);
+    assert.doesNotHaveAnyKeys(testSet, [ {iDoNot: 'exist'}, 'thisDoesNotExist' ]);
+    assert.doesNotHaveAnyKeys(testSet, [ 20, 1, {iDoNot: 'exist'} ]);
+    assert.doesNotHaveAllKeys(testSet, [ 'thisDoesNotExist', 'thisToo', {iDoNot: 'exist'} ]);
 
-      assert.containsAllDeepKeys(testSet, {thisIs: 'anExampleObject'});
-      assert.containsAllDeepKeys(testSet, [{thisIs: 'anExampleObject'}, {doingThisBecauseOf: 'referential equality'}]);
+    // Ensure the assertions above use strict equality
+    assert.doesNotHaveAnyKeys(testSet, {thisIs: 'anExampleObject'});
+    assert.doesNotHaveAllKeys(testSet, [ {thisIs: 'anExampleObject'}, {doingThisBecauseOf: 'referential equality'} ]);
 
-      assert.doesNotHaveAnyDeepKeys(testSet, {twenty: 'twenty'});
-      assert.doesNotHaveAnyDeepKeys(testSet, [{twenty: 'twenty'}, {fifty: 'fifty'}]);
+    err(function(){
+      assert.hasAnyKeys(testSet, [ {thisIs: 'anExampleObject'} ]);
+    });
 
-      assert.doesNotHaveAllDeepKeys(testSet, {twenty: 'twenty'});
-      assert.doesNotHaveAllDeepKeys(testSet, [{thisIs: 'anExampleObject'}, {fifty: 'fifty'}]);
+    err(function(){
+      assert.hasAllKeys(testSet, [ {thisIs: 'anExampleObject'}, {doingThisBecauseOf: 'referential equality'} ]);
+    });
 
-      var weirdSetKey1 = Object.create(null)
-        , weirdSetKey2 = {toString: NaN}
-        , weirdSetKey3 = []
-        , weirdSet = new Set();
+    err(function(){
+      assert.containsAllKeys(testSet, [ {thisIs: 'anExampleObject'} ]);
+    });
 
-      weirdSet.add(weirdSetKey1);
-      weirdSet.add(weirdSetKey2);
+    // Tests for the deep variations of the keys assertion
+    assert.hasAnyDeepKeys(testSet, {thisIs: 'anExampleObject'});
+    assert.hasAnyDeepKeys(testSet, [{thisIs: 'anExampleObject'}, {three: 'three'}]);
+    assert.hasAnyDeepKeys(testSet, [{thisIs: 'anExampleObject'}, {doingThisBecauseOf: 'referential equality'}]);
 
-      assert.hasAllKeys(weirdSet, [weirdSetKey1, weirdSetKey2]);
-      assert.doesNotHaveAllKeys(weirdSet, [weirdSetKey1, weirdSetKey3]);
+    assert.hasAllDeepKeys(testSet, [{thisIs: 'anExampleObject'}, {doingThisBecauseOf: 'referential equality'}]);
 
-      if (typeof Symbol === 'function') {
-        var symSetKey1 = Symbol()
-          , symSetKey2 = Symbol()
-          , symSetKey3 = Symbol()
-          , symSet = new Set();
+    assert.containsAllDeepKeys(testSet, {thisIs: 'anExampleObject'});
+    assert.containsAllDeepKeys(testSet, [{thisIs: 'anExampleObject'}, {doingThisBecauseOf: 'referential equality'}]);
 
-        symSet.add(symSetKey1);
-        symSet.add(symSetKey2);
+    assert.doesNotHaveAnyDeepKeys(testSet, {twenty: 'twenty'});
+    assert.doesNotHaveAnyDeepKeys(testSet, [{twenty: 'twenty'}, {fifty: 'fifty'}]);
 
-        assert.hasAllKeys(symSet, [symSetKey1, symSetKey2]);
-        assert.hasAnyKeys(symSet, [symSetKey1, symSetKey3]);
-        assert.containsAllKeys(symSet, [symSetKey2, symSetKey1]);
+    assert.doesNotHaveAllDeepKeys(testSet, {twenty: 'twenty'});
+    assert.doesNotHaveAllDeepKeys(testSet, [{thisIs: 'anExampleObject'}, {fifty: 'fifty'}]);
 
-        assert.doesNotHaveAllKeys(symSet, [symSetKey1, symSetKey3]);
-        assert.doesNotHaveAnyKeys(symSet, [symSetKey3]);
-      }
+    var weirdSetKey1 = Object.create(null)
+      , weirdSetKey2 = {toString: NaN}
+      , weirdSetKey3 = []
+      , weirdSet = new Set();
 
-      var errSet = new Set();
+    weirdSet.add(weirdSetKey1);
+    weirdSet.add(weirdSetKey2);
 
-      errSet.add({1: 20});
-      errSet.add('number');
+    assert.hasAllKeys(weirdSet, [weirdSetKey1, weirdSetKey2]);
+    assert.doesNotHaveAllKeys(weirdSet, [weirdSetKey1, weirdSetKey3]);
 
-      err(function(){
-        assert.hasAllKeys(errSet, [], 'blah');
-      }, "blah: keys required");
+    var symSetKey1 = Symbol()
+      , symSetKey2 = Symbol()
+      , symSetKey3 = Symbol()
+      , symSet = new Set();
 
-      err(function(){
-        assert.containsAllKeys(errSet, [], 'blah');
-      }, "blah: keys required");
+    symSet.add(symSetKey1);
+    symSet.add(symSetKey2);
 
-      err(function(){
-        assert.doesNotHaveAllKeys(errSet, [], 'blah');
-      }, "blah: keys required");
+    assert.hasAllKeys(symSet, [symSetKey1, symSetKey2]);
+    assert.hasAnyKeys(symSet, [symSetKey1, symSetKey3]);
+    assert.containsAllKeys(symSet, [symSetKey2, symSetKey1]);
 
-      err(function(){
-        assert.hasAnyKeys(errSet, [], 'blah');
-      }, "blah: keys required");
+    assert.doesNotHaveAllKeys(symSet, [symSetKey1, symSetKey3]);
+    assert.doesNotHaveAnyKeys(symSet, [symSetKey3]);
 
-      err(function(){
-        assert.doesNotHaveAnyKeys(errSet, [], 'blah');
-      }, "blah: keys required");
+    var errSet = new Set();
 
-      // Uncomment this after solving https://github.com/chaijs/chai/issues/662
-      // This should fail because of referential equality (this is a strict comparison)
-      // err(function(){
-      //   assert.containsAllKeys(new Set([{foo: 1}]), { foo: 1 });
-      // }, 'expected [ [ { foo: 1 }, 'bar' ] ] to contain key { foo: 1 }');
+    errSet.add({1: 20});
+    errSet.add('number');
 
-      // err(function(){
-      //   assert.containsAllDeepKeys(new Set([{foo: 1}]), { iDoNotExist: 0 })
-      // }, 'expected [ { foo: 1 } ] to deeply contain key { iDoNotExist: 0 }');
-    }
+    err(function(){
+      assert.hasAllKeys(errSet, [], 'blah');
+    }, "blah: keys required");
+
+    err(function(){
+      assert.containsAllKeys(errSet, [], 'blah');
+    }, "blah: keys required");
+
+    err(function(){
+      assert.doesNotHaveAllKeys(errSet, [], 'blah');
+    }, "blah: keys required");
+
+    err(function(){
+      assert.hasAnyKeys(errSet, [], 'blah');
+    }, "blah: keys required");
+
+    err(function(){
+      assert.doesNotHaveAnyKeys(errSet, [], 'blah');
+    }, "blah: keys required");
+
+    // Uncomment this after solving https://github.com/chaijs/chai/issues/662
+    // This should fail because of referential equality (this is a strict comparison)
+    // err(function(){
+    //   assert.containsAllKeys(new Set([{foo: 1}]), { foo: 1 });
+    // }, 'expected [ [ { foo: 1 }, 'bar' ] ] to contain key { foo: 1 }');
+
+    // err(function(){
+    //   assert.containsAllDeepKeys(new Set([{foo: 1}]), { iDoNotExist: 0 })
+    // }, 'expected [ { foo: 1 } ] to deeply contain key { iDoNotExist: 0 }');
 
     err(function(){
       assert.hasAllKeys({ foo: 1 }, [], 'blah');
@@ -1468,33 +1412,29 @@ describe('assert', function () {
       assert.lengthOf(1, 5);
      }, "expected 1 to have property \'length\'");
 
-    if (typeof Map === 'function') {
-      assert.lengthOf(new Map, 0);
+    assert.lengthOf(new Map, 0);
 
-      var map = new Map;
-      map.set('a', 1);
-      map.set('b', 2);
+    var map = new Map;
+    map.set('a', 1);
+    map.set('b', 2);
 
-      assert.lengthOf(map, 2);
+    assert.lengthOf(map, 2);
 
-      err(function(){
-        assert.lengthOf(map, 3, 'blah');
-      }, "blah: expected Map{ 'a' => 1, 'b' => 2 } to have a size of 3 but got 2");
-    }
+    err(function(){
+      assert.lengthOf(map, 3, 'blah');
+    }, "blah: expected Map{ 'a' => 1, 'b' => 2 } to have a size of 3 but got 2");
 
-    if (typeof Set === 'function') {
-      assert.lengthOf(new Set, 0);
+    assert.lengthOf(new Set, 0);
 
-      var set = new Set;
-      set.add(1);
-      set.add(2);
+    var set = new Set;
+    set.add(1);
+    set.add(2);
 
-      assert.lengthOf(set, 2);
+    assert.lengthOf(set, 2);
 
-      err(function(){
-        assert.lengthOf(set, 3, 'blah');
-      }, "blah: expected Set{ 1, 2 } to have a size of 3 but got 2");
-    }
+    err(function(){
+      assert.lengthOf(set, 3, 'blah');
+    }, "blah: expected Set{ 1, 2 } to have a size of 3 but got 2");
   });
 
   it('match', function () {
@@ -2556,18 +2496,16 @@ describe('assert', function () {
         assert[isExtensible](undefined);
       }, 'expected undefined to be extensible');
 
-      if (typeof Proxy === 'function') {
-        var proxy = new Proxy({}, {
-          isExtensible: function() {
-            throw new TypeError();
-          }
-        });
+      var proxy = new Proxy({}, {
+        isExtensible: function() {
+          throw new TypeError();
+        }
+      });
 
-        err(function() {
-          // isExtensible should not suppress errors, thrown in proxy traps
-          assert[isExtensible](proxy);
-        }, { name: 'TypeError' }, true);
-      }
+      err(function() {
+        // isExtensible should not suppress errors, thrown in proxy traps
+        assert[isExtensible](proxy);
+      }, { name: 'TypeError' }, true);
     });
   });
 
@@ -2588,23 +2526,18 @@ describe('assert', function () {
       assert[isNotExtensible]('foo');
       assert[isNotExtensible](false);
       assert[isNotExtensible](undefined);
+      assert[isNotExtensible](Symbol());
 
-      if (typeof Symbol === 'function') {
-        assert[isNotExtensible](Symbol());
-      }
+      var proxy = new Proxy({}, {
+        isExtensible: function() {
+          throw new TypeError();
+        }
+      });
 
-      if (typeof Proxy === 'function') {
-        var proxy = new Proxy({}, {
-          isExtensible: function() {
-            throw new TypeError();
-          }
-        });
-
-        err(function() {
-          // isNotExtensible should not suppress errors, thrown in proxy traps
-          assert[isNotExtensible](proxy);
-        }, { name: 'TypeError' }, true);
-      }
+      err(function() {
+        // isNotExtensible should not suppress errors, thrown in proxy traps
+        assert[isNotExtensible](proxy);
+      }, { name: 'TypeError' }, true);
     });
   });
 
@@ -2625,26 +2558,21 @@ describe('assert', function () {
       assert[isSealed]('foo');
       assert[isSealed](false);
       assert[isSealed](undefined);
+      assert[isSealed](Symbol());
 
-      if (typeof Symbol === 'function') {
-        assert[isSealed](Symbol());
-      }
+      var proxy = new Proxy({}, {
+        ownKeys: function() {
+          throw new TypeError();
+        }
+      });
 
-      if (typeof Proxy === 'function') {
-        var proxy = new Proxy({}, {
-          ownKeys: function() {
-            throw new TypeError();
-          }
-        });
+      // Object.isSealed will call ownKeys trap only if object is not extensible
+      Object.preventExtensions(proxy);
 
-        // Object.isSealed will call ownKeys trap only if object is not extensible
-        Object.preventExtensions(proxy);
-
-        err(function() {
-          // isSealed should not suppress errors, thrown in proxy traps
-          assert[isSealed](proxy);
-        }, { name: 'TypeError' }, true);
-      }
+      err(function() {
+        // isSealed should not suppress errors, thrown in proxy traps
+        assert[isSealed](proxy);
+      }, { name: 'TypeError' }, true);
     });
   });
 
@@ -2680,21 +2608,19 @@ describe('assert', function () {
         assert[isNotSealed](undefined);
       }, 'expected undefined to not be sealed');
 
-      if (typeof Proxy === 'function') {
-        var proxy = new Proxy({}, {
-          ownKeys: function() {
-            throw new TypeError();
-          }
-        });
+      var proxy = new Proxy({}, {
+        ownKeys: function() {
+          throw new TypeError();
+        }
+      });
 
-        // Object.isSealed will call ownKeys trap only if object is not extensible
-        Object.preventExtensions(proxy);
+      // Object.isSealed will call ownKeys trap only if object is not extensible
+      Object.preventExtensions(proxy);
 
-        err(function() {
-          // isNotSealed should not suppress errors, thrown in proxy traps
-          assert[isNotSealed](proxy);
-        }, { name: 'TypeError' }, true);
-      }
+      err(function() {
+        // isNotSealed should not suppress errors, thrown in proxy traps
+        assert[isNotSealed](proxy);
+      }, { name: 'TypeError' }, true);
     });
   });
 
@@ -2715,26 +2641,21 @@ describe('assert', function () {
       assert[isFrozen]('foo');
       assert[isFrozen](false);
       assert[isFrozen](undefined);
+      assert[isFrozen](Symbol());
 
-      if (typeof Symbol === 'function') {
-        assert[isFrozen](Symbol());
-      }
+      var proxy = new Proxy({}, {
+        ownKeys: function() {
+          throw new TypeError();
+        }
+      });
 
-      if (typeof Proxy === 'function') {
-        var proxy = new Proxy({}, {
-          ownKeys: function() {
-            throw new TypeError();
-          }
-        });
+      // Object.isFrozen will call ownKeys trap only if object is not extensible
+      Object.preventExtensions(proxy);
 
-        // Object.isFrozen will call ownKeys trap only if object is not extensible
-        Object.preventExtensions(proxy);
-
-        err(function() {
-          // isFrozen should not suppress errors, thrown in proxy traps
-          assert[isFrozen](proxy);
-        }, { name: 'TypeError' }, true);
-      }
+      err(function() {
+        // isFrozen should not suppress errors, thrown in proxy traps
+        assert[isFrozen](proxy);
+      }, { name: 'TypeError' }, true);
     });
   });
 
@@ -2770,21 +2691,19 @@ describe('assert', function () {
         assert[isNotFrozen](undefined);
       }, 'expected undefined to not be frozen');
 
-      if (typeof Proxy === 'function') {
-        var proxy = new Proxy({}, {
-          ownKeys: function() {
-            throw new TypeError();
-          }
-        });
+      var proxy = new Proxy({}, {
+        ownKeys: function() {
+          throw new TypeError();
+        }
+      });
 
-        // Object.isFrozen will call ownKeys trap only if object is not extensible
-        Object.preventExtensions(proxy);
+      // Object.isFrozen will call ownKeys trap only if object is not extensible
+      Object.preventExtensions(proxy);
 
-        err(function() {
-          // isNotFrozen should not suppress errors, thrown in proxy traps
-          assert[isNotFrozen](proxy);
-        }, { name: 'TypeError' }, true);
-      }
+      err(function() {
+        // isNotFrozen should not suppress errors, thrown in proxy traps
+        assert[isNotFrozen](proxy);
+      }, { name: 'TypeError' }, true);
     });
   });
 
@@ -2798,33 +2717,24 @@ describe('assert', function () {
       assert[isEmpty](new FakeArgs);
       assert[isEmpty]({});
 
-      if (typeof WeakMap === 'function') {
-        err(function(){
-          assert[isEmpty](new WeakMap, 'blah');
-        }, "blah: .empty was passed a weak collection");
-      }
+      err(function(){
+        assert[isEmpty](new WeakMap, 'blah');
+      }, "blah: .empty was passed a weak collection");
 
-      if (typeof WeakSet === 'function') {
-        err(function(){
-          assert[isEmpty](new WeakSet, 'blah');
-        }, "blah: .empty was passed a weak collection");
-      }
+      err(function(){
+        assert[isEmpty](new WeakSet, 'blah');
+      }, "blah: .empty was passed a weak collection");
 
-      if (typeof Map === 'function') {
-        assert[isEmpty](new Map);
+      assert[isEmpty](new Map);
 
-        var map = new Map;
-        map.key = 'val';
-        assert[isEmpty](map);
-      }
+      var map = new Map;
+      map.key = 'val';
+      assert[isEmpty](map);
+      assert[isEmpty](new Set);
 
-      if (typeof Set === 'function') {
-        assert[isEmpty](new Set);
-
-        var set = new Set;
-        set.key = 'val';
-        assert[isEmpty](set);
-      }
+      var set = new Set;
+      set.key = 'val';
+      assert[isEmpty](set);
 
       err(function(){
         assert[isEmpty]('foo', 'blah');
@@ -2870,15 +2780,13 @@ describe('assert', function () {
         assert[isEmpty](false);
       }, ".empty was passed non-string primitive false");
 
-      if (typeof Symbol !== 'undefined') {
-        err(function(){
-          assert[isEmpty](Symbol());
-        }, ".empty was passed non-string primitive Symbol()");
+      err(function(){
+        assert[isEmpty](Symbol());
+      }, ".empty was passed non-string primitive Symbol()");
 
-        err(function(){
-          assert[isEmpty](Symbol.iterator);
-        }, ".empty was passed non-string primitive Symbol(Symbol.iterator)");
-      }
+      err(function(){
+        assert[isEmpty](Symbol.iterator);
+      }, ".empty was passed non-string primitive Symbol(Symbol.iterator)");
 
       err(function(){
         assert[isEmpty](function() {}, 'blah');
@@ -2902,39 +2810,29 @@ describe('assert', function () {
       assert[isNotEmpty]({arguments: 0});
       assert[isNotEmpty]({foo: 'bar'});
 
-      if (typeof WeakMap === 'function') {
-        err(function(){
-          assert[isNotEmpty](new WeakMap, 'blah');
-        }, "blah: .empty was passed a weak collection");
-      }
+      err(function(){
+        assert[isNotEmpty](new WeakMap, 'blah');
+      }, "blah: .empty was passed a weak collection");
 
-      if (typeof WeakSet === 'function') {
-        err(function(){
-          assert[isNotEmpty](new WeakSet, 'blah');
-        }, "blah: .empty was passed a weak collection");
-      }
+      err(function(){
+        assert[isNotEmpty](new WeakSet, 'blah');
+      }, "blah: .empty was passed a weak collection");
 
-      if (typeof Map === 'function') {
-        // Not using Map constructor args because not supported in IE 11.
-        var map = new Map;
-        map.set('a', 1);
-        assert[isNotEmpty](map);
+      var map = new Map();
+      map.set('a', 1);
+      assert[isNotEmpty](map);
 
-        err(function(){
-          assert[isNotEmpty](new Map);
-        }, "expected Map{} not to be empty");
-      }
+      err(function(){
+        assert[isNotEmpty](new Map);
+      }, "expected Map{} not to be empty");
 
-      if (typeof Set === 'function') {
-        // Not using Set constructor args because not supported in IE 11.
-        var set = new Set;
-        set.add(1);
-        assert[isNotEmpty](set);
+      var set = new Set();
+      set.add(1);
+      assert[isNotEmpty](set);
 
-        err(function(){
-          assert[isNotEmpty](new Set);
-        }, "expected Set{} not to be empty");
-      }
+      err(function(){
+        assert[isNotEmpty](new Set);
+      }, "expected Set{} not to be empty");
 
       err(function(){
         assert[isNotEmpty]('', 'blah');
@@ -2980,15 +2878,13 @@ describe('assert', function () {
         assert[isNotEmpty](false);
       }, ".empty was passed non-string primitive false");
 
-      if (typeof Symbol !== 'undefined') {
-        err(function(){
-          assert[isNotEmpty](Symbol());
-        }, ".empty was passed non-string primitive Symbol()");
+      err(function(){
+        assert[isNotEmpty](Symbol());
+      }, ".empty was passed non-string primitive Symbol()");
 
-        err(function(){
-          assert[isNotEmpty](Symbol.iterator);
-        }, ".empty was passed non-string primitive Symbol(Symbol.iterator)");
-      }
+      err(function(){
+        assert[isNotEmpty](Symbol.iterator);
+      }, ".empty was passed non-string primitive Symbol(Symbol.iterator)");
 
       err(function(){
         assert[isNotEmpty](function() {}, 'blah');

--- a/test/configuration.js
+++ b/test/configuration.js
@@ -105,10 +105,7 @@ describe('configuration', function () {
 
           it('should include Chai frames in stack trace', function () {
             expect(caughtErr.stack).to.contain('propertyGetter');
-
-            if (typeof Proxy !== 'undefined' && typeof Reflect !== 'undefined') {
-              expect(caughtErr.stack).to.contain('proxyGetter');
-            }
+            expect(caughtErr.stack).to.contain('proxyGetter');
           });
 
           it('should include user frames in stack trace', function () {
@@ -131,10 +128,7 @@ describe('configuration', function () {
 
           it('should include Chai frames in stack trace', function () {
             expect(caughtErr.stack).to.contain('overwritingPropertyGetter');
-
-            if (typeof Proxy !== 'undefined' && typeof Reflect !== 'undefined') {
-              expect(caughtErr.stack).to.contain('proxyGetter');
-            }
+            expect(caughtErr.stack).to.contain('proxyGetter');
           });
 
           it('should include user frames in stack trace', function () {
@@ -247,10 +241,7 @@ describe('configuration', function () {
 
           it('should not include Chai frames in stack trace', function () {
             expect(caughtErr.stack).to.not.contain('propertyGetter');
-
-            if (typeof Proxy !== 'undefined' && typeof Reflect !== 'undefined') {
-              expect(caughtErr.stack).to.not.contain('proxyGetter');
-            }
+            expect(caughtErr.stack).to.not.contain('proxyGetter');
           });
 
           it('should include user frames in stack trace', function () {
@@ -273,10 +264,7 @@ describe('configuration', function () {
 
           it('should not include Chai frames in stack trace', function () {
             expect(caughtErr.stack).to.not.contain('overwritingPropertyGetter');
-
-            if (typeof Proxy !== 'undefined' && typeof Reflect !== 'undefined') {
-              expect(caughtErr.stack).to.not.contain('proxyGetter');
-            }
+            expect(caughtErr.stack).to.not.contain('proxyGetter');
           });
 
           it('should include user frames in stack trace', function () {
@@ -411,10 +399,7 @@ describe('configuration', function () {
 
           it('should include Chai frames in stack trace', function () {
             expect(caughtErr.stack).to.contain('propertyGetter');
-
-            if (typeof Proxy !== 'undefined' && typeof Reflect !== 'undefined') {
-              expect(caughtErr.stack).to.contain('proxyGetter');
-            }
+            expect(caughtErr.stack).to.contain('proxyGetter');
           });
 
           it('should include user frames in stack trace', function () {
@@ -437,10 +422,7 @@ describe('configuration', function () {
 
           it('should include Chai frames in stack trace', function () {
             expect(caughtErr.stack).to.contain('overwritingPropertyGetter');
-
-            if (typeof Proxy !== 'undefined' && typeof Reflect !== 'undefined') {
-              expect(caughtErr.stack).to.contain('proxyGetter');
-            }
+            expect(caughtErr.stack).to.contain('proxyGetter');
           });
 
           it('should include user frames in stack trace', function () {
@@ -553,10 +535,7 @@ describe('configuration', function () {
 
           it('should not include Chai frames in stack trace', function () {
             expect(caughtErr.stack).to.not.contain('propertyGetter');
-
-            if (typeof Proxy !== 'undefined' && typeof Reflect !== 'undefined') {
-              expect(caughtErr.stack).to.not.contain('proxyGetter');
-            }
+            expect(caughtErr.stack).to.not.contain('proxyGetter');
           });
 
           it('should include user frames in stack trace', function () {
@@ -579,10 +558,7 @@ describe('configuration', function () {
 
           it('should not include Chai frames in stack trace', function () {
             expect(caughtErr.stack).to.not.contain('overwritingPropertyGetter');
-
-            if (typeof Proxy !== 'undefined' && typeof Reflect !== 'undefined') {
-              expect(caughtErr.stack).to.not.contain('proxyGetter');
-            }
+            expect(caughtErr.stack).to.not.contain('proxyGetter');
           });
 
           it('should include user frames in stack trace', function () {
@@ -767,11 +743,7 @@ describe('configuration', function () {
 
     describe('when true', function() {
       it('should use proxy unless user\'s environment doesn\'t support', function() {
-        if (typeof Proxy !== 'undefined' && typeof Reflect !== 'undefined') {
-          expect(readNoExistentProperty).to.throw('Invalid Chai property: tue');
-        } else {
-          expect(readNoExistentProperty).to.not.throw('Invalid Chai property: tue');
-        }
+        expect(readNoExistentProperty).to.throw('Invalid Chai property: tue');
       });
     });
 
@@ -806,13 +778,8 @@ describe('configuration', function () {
     it('should throw for properties which are not on the `proxyExcludedKeys` Array in an environment with proxy support', function() {
       chai.config.proxyExcludedKeys = [];
 
-      if (typeof Proxy !== 'undefined' && typeof Reflect !== 'undefined') {
-        expect(readNoExistentProperty('then')).to.throw('Invalid Chai property: then');
-        expect(readNoExistentProperty('inspect')).to.throw('Invalid Chai property: inspect');
-      } else {
-        expect(readNoExistentProperty('then')).to.not.throw();
-        expect(readNoExistentProperty('inspect')).to.not.throw();
-      }
+      expect(readNoExistentProperty('then')).to.throw('Invalid Chai property: then');
+      expect(readNoExistentProperty('inspect')).to.throw('Invalid Chai property: inspect');
     });
   });
 

--- a/test/expect.js
+++ b/test/expect.js
@@ -52,8 +52,6 @@ describe('expect', function () {
     });
 
     describe('proxify', function () {
-      if (typeof Proxy === 'undefined' || typeof Reflect === 'undefined') return;
-
       it('throws when invalid property follows expect', function () {
         err(function () {
           expect(42).pizza;
@@ -371,10 +369,7 @@ describe('expect', function () {
     expect([]).to.be.a('array');
     expect(function() {}).to.be.a('function');
     expect(null).to.be.a('null');
-
-    if (typeof Symbol === 'function') {
-      expect(Symbol()).to.be.a('symbol');
-    }
+    expect(Symbol()).to.be.a('symbol');
 
     err(function(){
       expect(5).to.not.be.a('number', 'blah');
@@ -519,31 +514,29 @@ describe('expect', function () {
       expect(t).to.an.instanceof(Thing);
     }, 'The instanceof assertion needs a constructor but Function was given.', true)
 
-    if (typeof Symbol !== 'undefined' && typeof Symbol.hasInstance !== 'undefined') {
-        err(function(){
-          expect(new Foo()).to.an.instanceof(Symbol());
-        }, "The instanceof assertion needs a constructor but Symbol was given.");
+    err(function(){
+      expect(new Foo()).to.an.instanceof(Symbol());
+    }, "The instanceof assertion needs a constructor but Symbol was given.");
 
-        err(function() {
-            var FakeConstructor = {};
-            var fakeInstanceB = 4;
-            FakeConstructor[Symbol.hasInstance] = function (val) {
-                return val === 3;
-            };
+    err(function() {
+        var FakeConstructor = {};
+        var fakeInstanceB = 4;
+        FakeConstructor[Symbol.hasInstance] = function (val) {
+            return val === 3;
+        };
 
-            expect(fakeInstanceB).to.be.an.instanceof(FakeConstructor);
-        }, 'expected 4 to be an instance of an unnamed constructor')
+        expect(fakeInstanceB).to.be.an.instanceof(FakeConstructor);
+    }, 'expected 4 to be an instance of an unnamed constructor')
 
-        err(function() {
-            var FakeConstructor = {};
-            var fakeInstanceB = 4;
-            FakeConstructor[Symbol.hasInstance] = function (val) {
-                return val === 4;
-            };
+    err(function() {
+        var FakeConstructor = {};
+        var fakeInstanceB = 4;
+        FakeConstructor[Symbol.hasInstance] = function (val) {
+            return val === 4;
+        };
 
-            expect(fakeInstanceB).to.not.be.an.instanceof(FakeConstructor);
-        }, 'expected 4 to not be an instance of an unnamed constructor')
-    }
+        expect(fakeInstanceB).to.not.be.an.instanceof(FakeConstructor);
+    }, 'expected 4 to not be an instance of an unnamed constructor')
 
     err(function(){
       expect(3).to.an.instanceof(Foo, 'blah');
@@ -644,47 +637,43 @@ describe('expect', function () {
       expect(1).to.have.lengthOf.within(5, 7, 'blah');
     }, "blah: expected 1 to have property 'length'");
 
-    if (typeof Map === 'function') {
-      expect(new Map).to.have.length.within(0, 0);
-      expect(new Map).to.have.lengthOf.within(0, 0);
+    expect(new Map).to.have.length.within(0, 0);
+    expect(new Map).to.have.lengthOf.within(0, 0);
 
-      var map = new Map;
-      map.set('a', 1);
-      map.set('b', 2);
-      map.set('c', 3);
+    var map = new Map;
+    map.set('a', 1);
+    map.set('b', 2);
+    map.set('c', 3);
 
-      expect(map).to.have.length.within(2, 4);
-      expect(map).to.have.lengthOf.within(2, 4);
+    expect(map).to.have.length.within(2, 4);
+    expect(map).to.have.lengthOf.within(2, 4);
 
-      err(function () {
-        expect(map).to.have.length.within(5, 7, 'blah');
-      }, "blah: expected Map{ 'a' => 1, 'b' => 2, 'c' => 3 } to have a size within 5..7");
+    err(function () {
+      expect(map).to.have.length.within(5, 7, 'blah');
+    }, "blah: expected Map{ 'a' => 1, 'b' => 2, 'c' => 3 } to have a size within 5..7");
 
-      err(function () {
-        expect(map).to.have.lengthOf.within(5, 7, 'blah');
-      }, "blah: expected Map{ 'a' => 1, 'b' => 2, 'c' => 3 } to have a size within 5..7");
-    }
+    err(function () {
+      expect(map).to.have.lengthOf.within(5, 7, 'blah');
+    }, "blah: expected Map{ 'a' => 1, 'b' => 2, 'c' => 3 } to have a size within 5..7");
 
-    if (typeof Set === 'function') {
-      expect(new Set).to.have.length.within(0, 0);
-      expect(new Set).to.have.lengthOf.within(0, 0);
+    expect(new Set).to.have.length.within(0, 0);
+    expect(new Set).to.have.lengthOf.within(0, 0);
 
-      var set = new Set;
-      set.add(1);
-      set.add(2);
-      set.add(3);
+    var set = new Set;
+    set.add(1);
+    set.add(2);
+    set.add(3);
 
-      expect(set).to.have.length.within(2, 4);
-      expect(set).to.have.lengthOf.within(2, 4);
+    expect(set).to.have.length.within(2, 4);
+    expect(set).to.have.lengthOf.within(2, 4);
 
-      err(function () {
-        expect(set).to.have.length.within(5, 7, 'blah');
-      }, "blah: expected Set{ 1, 2, 3 } to have a size within 5..7");
+    err(function () {
+      expect(set).to.have.length.within(5, 7, 'blah');
+    }, "blah: expected Set{ 1, 2, 3 } to have a size within 5..7");
 
-      err(function () {
-        expect(set).to.have.lengthOf.within(5, 7, 'blah');
-      }, "blah: expected Set{ 1, 2, 3 } to have a size within 5..7");
-    }
+    err(function () {
+      expect(set).to.have.lengthOf.within(5, 7, 'blah');
+    }, "blah: expected Set{ 1, 2, 3 } to have a size within 5..7");
   });
 
   it('within(start, finish) (dates)', function(){
@@ -819,47 +808,43 @@ describe('expect', function () {
       expect(1).to.have.lengthOf.above(0, 'blah');
     }, "blah: expected 1 to have property 'length'");
 
-    if (typeof Map === 'function') {
-      expect(new Map).to.have.length.above(-1);
-      expect(new Map).to.have.lengthOf.above(-1);
+    expect(new Map).to.have.length.above(-1);
+    expect(new Map).to.have.lengthOf.above(-1);
 
-      var map = new Map;
-      map.set('a', 1);
-      map.set('b', 2);
-      map.set('c', 3);
+    var map = new Map;
+    map.set('a', 1);
+    map.set('b', 2);
+    map.set('c', 3);
 
-      expect(map).to.have.length.above(2);
-      expect(map).to.have.lengthOf.above(2);
+    expect(map).to.have.length.above(2);
+    expect(map).to.have.lengthOf.above(2);
 
-      err(function () {
-        expect(map).to.have.length.above(5, 'blah');
-      }, "blah: expected Map{ 'a' => 1, 'b' => 2, 'c' => 3 } to have a size above 5 but got 3");
+    err(function () {
+      expect(map).to.have.length.above(5, 'blah');
+    }, "blah: expected Map{ 'a' => 1, 'b' => 2, 'c' => 3 } to have a size above 5 but got 3");
 
-      err(function () {
-        expect(map).to.have.lengthOf.above(5, 'blah');
-      }, "blah: expected Map{ 'a' => 1, 'b' => 2, 'c' => 3 } to have a size above 5 but got 3");
-    }
+    err(function () {
+      expect(map).to.have.lengthOf.above(5, 'blah');
+    }, "blah: expected Map{ 'a' => 1, 'b' => 2, 'c' => 3 } to have a size above 5 but got 3");
 
-    if (typeof Set === 'function') {
-      expect(new Set).to.have.length.above(-1);
-      expect(new Set).to.have.lengthOf.above(-1);
+    expect(new Set).to.have.length.above(-1);
+    expect(new Set).to.have.lengthOf.above(-1);
 
-      var set = new Set;
-      set.add(1);
-      set.add(2);
-      set.add(3);
+    var set = new Set;
+    set.add(1);
+    set.add(2);
+    set.add(3);
 
-      expect(set).to.have.length.above(2);
-      expect(set).to.have.lengthOf.above(2);
+    expect(set).to.have.length.above(2);
+    expect(set).to.have.lengthOf.above(2);
 
-      err(function () {
-        expect(set).to.have.length.above(5, 'blah');
-      }, "blah: expected Set{ 1, 2, 3 } to have a size above 5 but got 3");
+    err(function () {
+      expect(set).to.have.length.above(5, 'blah');
+    }, "blah: expected Set{ 1, 2, 3 } to have a size above 5 but got 3");
 
-      err(function () {
-        expect(set).to.have.lengthOf.above(5, 'blah');
-      }, "blah: expected Set{ 1, 2, 3 } to have a size above 5 but got 3");
-    }
+    err(function () {
+      expect(set).to.have.lengthOf.above(5, 'blah');
+    }, "blah: expected Set{ 1, 2, 3 } to have a size above 5 but got 3");
   });
 
   it('above(n) (dates)', function(){
@@ -986,47 +971,43 @@ describe('expect', function () {
       expect(1).to.have.lengthOf.at.least(0, 'blah');
     }, "blah: expected 1 to have property 'length'");
 
-    if (typeof Map === 'function') {
-      expect(new Map).to.have.length.of.at.least(0);
-      expect(new Map).to.have.lengthOf.at.least(0);
+    expect(new Map).to.have.length.of.at.least(0);
+    expect(new Map).to.have.lengthOf.at.least(0);
 
-      var map = new Map;
-      map.set('a', 1);
-      map.set('b', 2);
-      map.set('c', 3);
+    var map = new Map;
+    map.set('a', 1);
+    map.set('b', 2);
+    map.set('c', 3);
 
-      expect(map).to.have.length.of.at.least(3);
-      expect(map).to.have.lengthOf.at.least(3);
+    expect(map).to.have.length.of.at.least(3);
+    expect(map).to.have.lengthOf.at.least(3);
 
-      err(function () {
-        expect(map).to.have.length.of.at.least(4, 'blah');
-      }, "blah: expected Map{ 'a' => 1, 'b' => 2, 'c' => 3 } to have a size at least 4 but got 3");
+    err(function () {
+      expect(map).to.have.length.of.at.least(4, 'blah');
+    }, "blah: expected Map{ 'a' => 1, 'b' => 2, 'c' => 3 } to have a size at least 4 but got 3");
 
-      err(function () {
-        expect(map).to.have.lengthOf.at.least(4, 'blah');
-      }, "blah: expected Map{ 'a' => 1, 'b' => 2, 'c' => 3 } to have a size at least 4 but got 3");
-    }
+    err(function () {
+      expect(map).to.have.lengthOf.at.least(4, 'blah');
+    }, "blah: expected Map{ 'a' => 1, 'b' => 2, 'c' => 3 } to have a size at least 4 but got 3");
 
-    if (typeof Set === 'function') {
-      expect(new Set).to.have.length.of.at.least(0);
-      expect(new Set).to.have.lengthOf.at.least(0);
+    expect(new Set).to.have.length.of.at.least(0);
+    expect(new Set).to.have.lengthOf.at.least(0);
 
-      var set = new Set;
-      set.add(1);
-      set.add(2);
-      set.add(3);
+    var set = new Set;
+    set.add(1);
+    set.add(2);
+    set.add(3);
 
-      expect(set).to.have.length.of.at.least(3);
-      expect(set).to.have.lengthOf.at.least(3);
+    expect(set).to.have.length.of.at.least(3);
+    expect(set).to.have.lengthOf.at.least(3);
 
-      err(function () {
-        expect(set).to.have.length.of.at.least(4, 'blah');
-      }, "blah: expected Set{ 1, 2, 3 } to have a size at least 4 but got 3");
+    err(function () {
+      expect(set).to.have.length.of.at.least(4, 'blah');
+    }, "blah: expected Set{ 1, 2, 3 } to have a size at least 4 but got 3");
 
-      err(function () {
-        expect(set).to.have.lengthOf.at.least(4, 'blah');
-      }, "blah: expected Set{ 1, 2, 3 } to have a size at least 4 but got 3");
-    }
+    err(function () {
+      expect(set).to.have.lengthOf.at.least(4, 'blah');
+    }, "blah: expected Set{ 1, 2, 3 } to have a size at least 4 but got 3");
   });
 
   it('below(n)', function(){
@@ -1107,47 +1088,43 @@ describe('expect', function () {
       expect(1).to.have.lengthOf.below(0, 'blah');
     }, "blah: expected 1 to have property 'length'");
 
-    if (typeof Map === 'function') {
-      expect(new Map).to.have.length.below(1);
-      expect(new Map).to.have.lengthOf.below(1);
+    expect(new Map).to.have.length.below(1);
+    expect(new Map).to.have.lengthOf.below(1);
 
-      var map = new Map;
-      map.set('a', 1);
-      map.set('b', 2);
-      map.set('c', 3);
+    var map = new Map;
+    map.set('a', 1);
+    map.set('b', 2);
+    map.set('c', 3);
 
-      expect(map).to.have.length.below(4);
-      expect(map).to.have.lengthOf.below(4);
+    expect(map).to.have.length.below(4);
+    expect(map).to.have.lengthOf.below(4);
 
-      err(function () {
-        expect(map).to.have.length.below(2, 'blah');
-      }, "blah: expected Map{ 'a' => 1, 'b' => 2, 'c' => 3 } to have a size below 2 but got 3");
+    err(function () {
+      expect(map).to.have.length.below(2, 'blah');
+    }, "blah: expected Map{ 'a' => 1, 'b' => 2, 'c' => 3 } to have a size below 2 but got 3");
 
-      err(function () {
-        expect(map).to.have.lengthOf.below(2, 'blah');
-      }, "blah: expected Map{ 'a' => 1, 'b' => 2, 'c' => 3 } to have a size below 2 but got 3");
-    }
+    err(function () {
+      expect(map).to.have.lengthOf.below(2, 'blah');
+    }, "blah: expected Map{ 'a' => 1, 'b' => 2, 'c' => 3 } to have a size below 2 but got 3");
 
-    if (typeof Set === 'function') {
-      expect(new Set).to.have.length.below(1);
-      expect(new Set).to.have.lengthOf.below(1);
+    expect(new Set).to.have.length.below(1);
+    expect(new Set).to.have.lengthOf.below(1);
 
-      var set = new Set;
-      set.add(1);
-      set.add(2);
-      set.add(3);
+    var set = new Set;
+    set.add(1);
+    set.add(2);
+    set.add(3);
 
-      expect(set).to.have.length.below(4);
-      expect(set).to.have.lengthOf.below(4);
+    expect(set).to.have.length.below(4);
+    expect(set).to.have.lengthOf.below(4);
 
-      err(function () {
-        expect(set).to.have.length.below(2, 'blah');
-      }, "blah: expected Set{ 1, 2, 3 } to have a size below 2 but got 3");
+    err(function () {
+      expect(set).to.have.length.below(2, 'blah');
+    }, "blah: expected Set{ 1, 2, 3 } to have a size below 2 but got 3");
 
-      err(function () {
-        expect(set).to.have.lengthOf.below(2, 'blah');
-      }, "blah: expected Set{ 1, 2, 3 } to have a size below 2 but got 3");
-    }
+    err(function () {
+      expect(set).to.have.lengthOf.below(2, 'blah');
+    }, "blah: expected Set{ 1, 2, 3 } to have a size below 2 but got 3");
   });
 
   it('below(n) (dates)', function(){
@@ -1278,47 +1255,43 @@ describe('expect', function () {
       expect(1).to.have.lengthOf.at.most(0, 'blah');
     }, "blah: expected 1 to have property 'length'");
 
-    if (typeof Map === 'function') {
-      expect(new Map).to.have.length.of.at.most(0);
-      expect(new Map).to.have.lengthOf.at.most(0);
+    expect(new Map).to.have.length.of.at.most(0);
+    expect(new Map).to.have.lengthOf.at.most(0);
 
-      var map = new Map;
-      map.set('a', 1);
-      map.set('b', 2);
-      map.set('c', 3);
+    var map = new Map;
+    map.set('a', 1);
+    map.set('b', 2);
+    map.set('c', 3);
 
-      expect(map).to.have.length.of.at.most(3);
-      expect(map).to.have.lengthOf.at.most(3);
+    expect(map).to.have.length.of.at.most(3);
+    expect(map).to.have.lengthOf.at.most(3);
 
-      err(function () {
-        expect(map).to.have.length.of.at.most(2, 'blah');
-      }, "blah: expected Map{ 'a' => 1, 'b' => 2, 'c' => 3 } to have a size at most 2 but got 3");
+    err(function () {
+      expect(map).to.have.length.of.at.most(2, 'blah');
+    }, "blah: expected Map{ 'a' => 1, 'b' => 2, 'c' => 3 } to have a size at most 2 but got 3");
 
-      err(function () {
-        expect(map).to.have.lengthOf.at.most(2, 'blah');
-      }, "blah: expected Map{ 'a' => 1, 'b' => 2, 'c' => 3 } to have a size at most 2 but got 3");
-    }
+    err(function () {
+      expect(map).to.have.lengthOf.at.most(2, 'blah');
+    }, "blah: expected Map{ 'a' => 1, 'b' => 2, 'c' => 3 } to have a size at most 2 but got 3");
 
-    if (typeof Set === 'function') {
-      expect(new Set).to.have.length.of.at.most(0);
-      expect(new Set).to.have.lengthOf.at.most(0);
+    expect(new Set).to.have.length.of.at.most(0);
+    expect(new Set).to.have.lengthOf.at.most(0);
 
-      var set = new Set;
-      set.add(1);
-      set.add(2);
-      set.add(3);
+    var set = new Set;
+    set.add(1);
+    set.add(2);
+    set.add(3);
 
-      expect(set).to.have.length.of.at.most(3);
-      expect(set).to.have.lengthOf.at.most(3);
+    expect(set).to.have.length.of.at.most(3);
+    expect(set).to.have.lengthOf.at.most(3);
 
-      err(function () {
-        expect(set).to.have.length.of.at.most(2, 'blah');
-      }, "blah: expected Set{ 1, 2, 3 } to have a size at most 2 but got 3");
+    err(function () {
+      expect(set).to.have.length.of.at.most(2, 'blah');
+    }, "blah: expected Set{ 1, 2, 3 } to have a size at most 2 but got 3");
 
-      err(function () {
-        expect(set).to.have.lengthOf.at.most(2, 'blah');
-      }, "blah: expected Set{ 1, 2, 3 } to have a size at most 2 but got 3");
-    }
+    err(function () {
+      expect(set).to.have.lengthOf.at.most(2, 'blah');
+    }, "blah: expected Set{ 1, 2, 3 } to have a size at most 2 but got 3");
   });
 
   it('most(n) (dates)', function(){
@@ -1424,47 +1397,43 @@ describe('expect', function () {
       expect('asd').to.not.have.lengthOf(3, 'blah');
     }, "blah: expected 'asd' to not have a length of 3");
 
-    if (typeof Map === 'function') {
-      expect(new Map).to.have.length(0);
-      expect(new Map).to.have.lengthOf(0);
+    expect(new Map).to.have.length(0);
+    expect(new Map).to.have.lengthOf(0);
 
-      var map = new Map;
-      map.set('a', 1);
-      map.set('b', 2);
-      map.set('c', 3);
+    var map = new Map;
+    map.set('a', 1);
+    map.set('b', 2);
+    map.set('c', 3);
 
-      expect(map).to.have.length(3);
-      expect(map).to.have.lengthOf(3);
+    expect(map).to.have.length(3);
+    expect(map).to.have.lengthOf(3);
 
-      err(function(){
-        expect(map).to.not.have.length(3, 'blah');
-      }, "blah: expected Map{ 'a' => 1, 'b' => 2, 'c' => 3 } to not have a size of 3");
+    err(function(){
+      expect(map).to.not.have.length(3, 'blah');
+    }, "blah: expected Map{ 'a' => 1, 'b' => 2, 'c' => 3 } to not have a size of 3");
 
-      err(function(){
-        expect(map).to.not.have.lengthOf(3, 'blah');
-      }, "blah: expected Map{ 'a' => 1, 'b' => 2, 'c' => 3 } to not have a size of 3");
-    }
+    err(function(){
+      expect(map).to.not.have.lengthOf(3, 'blah');
+    }, "blah: expected Map{ 'a' => 1, 'b' => 2, 'c' => 3 } to not have a size of 3");
 
-    if (typeof Set === 'function') {
-      expect(new Set).to.have.length(0);
-      expect(new Set).to.have.lengthOf(0);
+    expect(new Set).to.have.length(0);
+    expect(new Set).to.have.lengthOf(0);
 
-      var set = new Set;
-      set.add(1);
-      set.add(2);
-      set.add(3);
+    var set = new Set;
+    set.add(1);
+    set.add(2);
+    set.add(3);
 
-      expect(set).to.have.length(3);
-      expect(set).to.have.lengthOf(3);
+    expect(set).to.have.length(3);
+    expect(set).to.have.lengthOf(3);
 
-      err(function(){
-        expect(set).to.not.have.length(3, 'blah');
-      }, "blah: expected Set{ 1, 2, 3 } to not have a size of 3");
+    err(function(){
+      expect(set).to.not.have.length(3, 'blah');
+    }, "blah: expected Set{ 1, 2, 3 } to not have a size of 3");
 
-      err(function(){
-        expect(set).to.not.have.lengthOf(3, 'blah');;
-      }, "blah: expected Set{ 1, 2, 3 } to not have a size of 3");
-    }
+    err(function(){
+      expect(set).to.not.have.lengthOf(3, 'blah');;
+    }, "blah: expected Set{ 1, 2, 3 } to not have a size of 3");
   });
 
   it('eql(val)', function(){
@@ -1473,34 +1442,30 @@ describe('expect', function () {
     expect(1).to.eql(1);
     expect('4').to.not.eql(4);
 
-    if (typeof Symbol === 'function') {
-      var sym = Symbol();
-      expect(sym).to.eql(sym);
-    }
+    var sym = Symbol();
+    expect(sym).to.eql(sym);
 
     err(function(){
       expect(4).to.eql(3, 'blah');
     }, 'blah: expected 4 to deeply equal 3');
   });
 
-  if ('undefined' !== typeof Buffer) {
-    it('Buffer eql()', function () {
-      expect(Buffer.from([ 1 ])).to.eql(Buffer.from([ 1 ]));
+  it('Buffer eql()', function () {
+    if (typeof Buffer === 'undefined') return;
 
-      err(function () {
-        expect(Buffer.from([ 0 ])).to.eql(Buffer.from([ 1 ]));
-      }, 'expected Buffer[ 0 ] to deeply equal Buffer[ 1 ]');
-    });
-  }
+    expect(Buffer.from([ 1 ])).to.eql(Buffer.from([ 1 ]));
+
+    err(function () {
+      expect(Buffer.from([ 0 ])).to.eql(Buffer.from([ 1 ]));
+    }, 'expected Buffer[ 0 ] to deeply equal Buffer[ 1 ]');
+  });
 
   it('equal(val)', function(){
     expect('test').to.equal('test');
     expect(1).to.equal(1);
 
-    if (typeof Symbol === 'function') {
-      var sym = Symbol();
-      expect(sym).to.equal(sym);
-    }
+    var sym = Symbol();
+    expect(sym).to.equal(sym);
 
     err(function(){
       expect(4).to.equal(3, 'blah');
@@ -1590,59 +1555,51 @@ describe('expect', function () {
     expect({}).to.be.empty;
     expect({foo: 'bar'}).not.to.be.empty;
 
-    if (typeof WeakMap === 'function') {
-      err(function(){
-        expect(new WeakMap, 'blah').not.to.be.empty;
-      }, "blah: .empty was passed a weak collection");
-    }
+    err(function(){
+      expect(new WeakMap, 'blah').not.to.be.empty;
+    }, "blah: .empty was passed a weak collection");
 
-    if (typeof WeakSet === 'function') {
-      err(function(){
-        expect(new WeakSet, 'blah').not.to.be.empty;
-      }, "blah: .empty was passed a weak collection");
-    }
+    err(function(){
+      expect(new WeakSet, 'blah').not.to.be.empty;
+    }, "blah: .empty was passed a weak collection");
 
-    if (typeof Map === 'function') {
-      expect(new Map).to.be.empty;
+    expect(new Map).to.be.empty;
 
-      // Not using Map constructor args because not supported in IE 11.
-      var map = new Map;
-      map.set('a', 1);
+    // Not using Map constructor args because not supported in IE 11.
+    var map = new Map;
+    map.set('a', 1);
+    expect(map).not.to.be.empty;
+
+    err(function(){
+      expect(new Map).not.to.be.empty;
+    }, "expected Map{} not to be empty");
+
+    map = new Map;
+    map.key = 'val';
+    expect(map).to.be.empty;
+
+    err(function(){
       expect(map).not.to.be.empty;
+    }, "expected Map{} not to be empty");
 
-      err(function(){
-        expect(new Map).not.to.be.empty;
-      }, "expected Map{} not to be empty");
+    expect(new Set).to.be.empty;
 
-      map = new Map;
-      map.key = 'val';
-      expect(map).to.be.empty;
+    // Not using Set constructor args because not supported in IE 11.
+    var set = new Set;
+    set.add(1);
+    expect(set).not.to.be.empty;
 
-      err(function(){
-        expect(map).not.to.be.empty;
-      }, "expected Map{} not to be empty");
-    }
+    err(function(){
+      expect(new Set).not.to.be.empty;
+    }, "expected Set{} not to be empty");
 
-    if (typeof Set === 'function') {
-      expect(new Set).to.be.empty;
+    set = new Set;
+    set.key = 'val';
+    expect(set).to.be.empty;
 
-      // Not using Set constructor args because not supported in IE 11.
-      var set = new Set;
-      set.add(1);
+    err(function(){
       expect(set).not.to.be.empty;
-
-      err(function(){
-        expect(new Set).not.to.be.empty;
-      }, "expected Set{} not to be empty");
-
-      set = new Set;
-      set.key = 'val';
-      expect(set).to.be.empty;
-
-      err(function(){
-        expect(set).not.to.be.empty;
-      }, "expected Set{} not to be empty");
-    }
+    }, "expected Set{} not to be empty");
 
     err(function(){
       expect('', 'blah').not.to.be.empty;
@@ -1716,15 +1673,13 @@ describe('expect', function () {
       expect(false).to.be.empty;
     }, ".empty was passed non-string primitive false");
 
-    if (typeof Symbol !== 'undefined') {
-      err(function(){
-        expect(Symbol()).to.be.empty;
-      }, ".empty was passed non-string primitive Symbol()");
+    err(function(){
+      expect(Symbol()).to.be.empty;
+    }, ".empty was passed non-string primitive Symbol()");
 
-      err(function(){
-        expect(Symbol.iterator).to.be.empty;
-      }, ".empty was passed non-string primitive Symbol(Symbol.iterator)");
-    }
+    err(function(){
+      expect(Symbol.iterator).to.be.empty;
+    }, ".empty was passed non-string primitive Symbol(Symbol.iterator)");
 
     err(function(){
       expect(function() {}, 'blah').to.be.empty;
@@ -2275,13 +2230,10 @@ describe('expect', function () {
     // .include should work with Error objects and objects with a custom
     // `@@toStringTag`.
     expect(new Error('foo')).to.include({message: 'foo'});
-    if (typeof Symbol !== 'undefined'
-        && typeof Symbol.toStringTag !== 'undefined') {
-      var customObj = {a: 1};
-      customObj[Symbol.toStringTag] = 'foo';
+    var customObj = {a: 1};
+    customObj[Symbol.toStringTag] = 'foo';
 
-      expect(customObj).to.include({a: 1});
-    }
+    expect(customObj).to.include({a: 1});
 
     var obj1 = {a: 1}
       , obj2 = {b: 2};
@@ -2292,59 +2244,51 @@ describe('expect', function () {
     expect({foo: obj1, bar: obj2}).to.not.include({foo: {a: 1}});
     expect({foo: obj1, bar: obj2}).to.not.include({foo: obj1, bar: {b: 2}});
 
-    if (typeof Map === 'function') {
-      var map = new Map();
-      var val = [{a: 1}];
-      map.set('a', val);
-      map.set('b', 2);
-      map.set('c', -0);
-      map.set('d', NaN);
+    var map = new Map();
+    var val = [{a: 1}];
+    map.set('a', val);
+    map.set('b', 2);
+    map.set('c', -0);
+    map.set('d', NaN);
 
-      expect(map).to.include(val);
-      expect(map).to.not.include([{a: 1}]);
-      expect(map).to.include(2);
-      expect(map).to.not.include(3);
-      expect(map).to.include(0);
-      expect(map).to.include(NaN);
+    expect(map).to.include(val);
+    expect(map).to.not.include([{a: 1}]);
+    expect(map).to.include(2);
+    expect(map).to.not.include(3);
+    expect(map).to.include(0);
+    expect(map).to.include(NaN);
+
+    var set = new Set();
+    var val = [{a: 1}];
+    set.add(val);
+    set.add(2);
+    set.add(-0);
+    set.add(NaN);
+
+    expect(set).to.include(val);
+    expect(set).to.not.include([{a: 1}]);
+    expect(set).to.include(2);
+    expect(set).to.not.include(3);
+    if (set.has(0)) {
+      // This test is skipped in IE11 because (contrary to spec) IE11 uses
+      // SameValue instead of SameValueZero equality for sets.
+      expect(set).to.include(0);
     }
+    expect(set).to.include(NaN);
 
-    if (typeof Set === 'function') {
-      var set = new Set();
-      var val = [{a: 1}];
-      set.add(val);
-      set.add(2);
-      set.add(-0);
-      set.add(NaN);
+    var ws = new WeakSet();
+    var val = [{a: 1}];
+    ws.add(val);
 
-      expect(set).to.include(val);
-      expect(set).to.not.include([{a: 1}]);
-      expect(set).to.include(2);
-      expect(set).to.not.include(3);
-      if (set.has(0)) {
-        // This test is skipped in IE11 because (contrary to spec) IE11 uses
-        // SameValue instead of SameValueZero equality for sets.
-        expect(set).to.include(0);
-      }
-      expect(set).to.include(NaN);
-    }
+    expect(ws).to.include(val);
+    expect(ws).to.not.include([{a: 1}]);
+    expect(ws).to.not.include({});
 
-    if (typeof WeakSet === 'function') {
-      var ws = new WeakSet();
-      var val = [{a: 1}];
-      ws.add(val);
-
-      expect(ws).to.include(val);
-      expect(ws).to.not.include([{a: 1}]);
-      expect(ws).to.not.include({});
-    }
-
-    if (typeof Symbol === 'function') {
-      var sym1 = Symbol()
-        , sym2 = Symbol()
-        , sym3 = Symbol();
-      expect([sym1, sym2]).to.include(sym1);
-      expect([sym1, sym2]).to.not.include(sym3);
-    }
+    var sym1 = Symbol()
+      , sym2 = Symbol()
+      , sym3 = Symbol();
+    expect([sym1, sym2]).to.include(sym1);
+    expect([sym1, sym2]).to.not.include(sym3);
 
     err(function(){
       expect(['foo']).to.include('bar', 'blah');
@@ -2467,25 +2411,19 @@ describe('expect', function () {
     expect({foo: obj1, bar: obj2}).to.not.deep.include({baz: {a: 1}});
     expect({foo: obj1, bar: obj2}).to.not.deep.include({foo: {a: 1}, bar: {b: 9}});
 
-    if (typeof Map === 'function') {
-      var map = new Map();
-      map.set(1, [{a: 1}]);
+    var map = new Map();
+    map.set(1, [{a: 1}]);
 
-      expect(map).to.deep.include([{a: 1}]);
-    }
+    expect(map).to.deep.include([{a: 1}]);
 
-    if (typeof Set === 'function') {
-      var set = new Set();
-      set.add([{a: 1}]);
+    var set = new Set();
+    set.add([{a: 1}]);
 
-      expect(set).to.deep.include([{a: 1}]);
-    }
+    expect(set).to.deep.include([{a: 1}]);
 
-    if (typeof WeakSet === 'function') {
-      err(function() {
-        expect(new WeakSet()).to.deep.include({}, 'foo');
-      }, 'foo: unable to use .deep.include with WeakSet');
-    }
+    err(function() {
+      expect(new WeakSet()).to.deep.include({}, 'foo');
+    }, 'foo: unable to use .deep.include with WeakSet');
 
     err(function () {
       expect([obj1, obj2]).to.deep.include({a: 9}, 'blah');
@@ -2686,286 +2624,276 @@ describe('expect', function () {
     expect(obj).to.have.all.keys([enumProp1, enumProp2]);
     expect(obj).to.not.have.all.keys([enumProp1, enumProp2, nonEnumProp]);
 
-    if (typeof Symbol === 'function') {
-      var sym1 = Symbol('sym1')
-        , sym2 = Symbol('sym2')
-        , sym3 = Symbol('sym3')
-        , str = 'str'
-        , obj = {};
-
-      obj[sym1] = 'sym1';
-      obj[sym2] = 'sym2';
-      obj[str] = 'str';
-
-      Object.defineProperty(obj, sym3, {
-        enumerable: false,
-        value: 'sym3'
-      });
-
-      expect(obj).to.have.all.keys([sym1, sym2, str]);
-      expect(obj).to.not.have.all.keys([sym1, sym2, sym3, str]);
-    }
-
-    if (typeof Map !== 'undefined') {
-      // Not using Map constructor args because not supported in IE 11.
-      var aKey = {thisIs: 'anExampleObject'}
-        , anotherKey = {doingThisBecauseOf: 'referential equality'}
-        , testMap = new Map();
-
-      testMap.set(aKey, 'aValue');
-      testMap.set(anotherKey, 'anotherValue');
+    var sym1 = Symbol('sym1')
+      , sym2 = Symbol('sym2')
+      , sym3 = Symbol('sym3')
+      , str = 'str'
+      , obj = {};
 
-      expect(testMap).to.have.any.keys(aKey);
-      expect(testMap).to.have.any.keys('thisDoesNotExist', 'thisToo', aKey);
-      expect(testMap).to.have.all.keys(aKey, anotherKey);
+    obj[sym1] = 'sym1';
+    obj[sym2] = 'sym2';
+    obj[str] = 'str';
+
+    Object.defineProperty(obj, sym3, {
+      enumerable: false,
+      value: 'sym3'
+    });
+
+    expect(obj).to.have.all.keys([sym1, sym2, str]);
+    expect(obj).to.not.have.all.keys([sym1, sym2, sym3, str]);
 
-      expect(testMap).to.contain.all.keys(aKey);
-      expect(testMap).to.not.contain.all.keys(aKey, 'thisDoesNotExist');
-
-      expect(testMap).to.not.have.any.keys({iDoNot: 'exist'});
-      expect(testMap).to.not.have.any.keys('thisIsNotAkey', {iDoNot: 'exist'}, {33: 20});
-      expect(testMap).to.not.have.all.keys('thisDoesNotExist', 'thisToo', anotherKey);
-
-      expect(testMap).to.have.any.keys([aKey]);
-      expect(testMap).to.have.any.keys([20, 1, aKey]);
-      expect(testMap).to.have.all.keys([aKey, anotherKey]);
-
-      expect(testMap).to.not.have.any.keys([{13: 37}, 'thisDoesNotExist', 'thisToo']);
-      expect(testMap).to.not.have.any.keys([20, 1, {13: 37}]);
-      expect(testMap).to.not.have.all.keys([aKey, {'iDoNot': 'exist'}]);
-
-      // Ensure the assertions above use strict equality
-      err(function() {
-        expect(testMap).to.have.any.keys({thisIs: 'anExampleObject'});
-      });
-
-      err(function() {
-        expect(testMap).to.have.all.keys({thisIs: 'anExampleObject'}, {doingThisBecauseOf: 'referential equality'});
-      });
-
-      err(function() {
-        expect(testMap).to.contain.all.keys({thisIs: 'anExampleObject'});
-      });
-
-      err(function() {
-        expect(testMap).to.have.any.keys([{thisIs: 'anExampleObject'}]);
-      });
-
-      err(function() {
-        expect(testMap).to.have.all.keys([{thisIs: 'anExampleObject'}, {doingThisBecauseOf: 'referential equality'}]);
-      });
-
-      // Using the same assertions as above but with `.deep` flag instead of using referential equality
-      expect(testMap).to.have.any.deep.keys({thisIs: 'anExampleObject'});
-      expect(testMap).to.have.any.deep.keys('thisDoesNotExist', 'thisToo', {thisIs: 'anExampleObject'});
-
-      expect(testMap).to.contain.all.deep.keys({thisIs: 'anExampleObject'});
-      expect(testMap).to.not.contain.all.deep.keys({thisIs: 'anExampleObject'}, 'thisDoesNotExist');
-
-      expect(testMap).to.not.have.any.deep.keys({iDoNot: 'exist'});
-      expect(testMap).to.not.have.any.deep.keys('thisIsNotAkey', {iDoNot: 'exist'}, {33: 20});
-      expect(testMap).to.not.have.all.deep.keys('thisDoesNotExist', 'thisToo', {doingThisBecauseOf: 'referential equality'});
-
-      expect(testMap).to.have.any.deep.keys([{thisIs: 'anExampleObject'}]);
-      expect(testMap).to.have.any.deep.keys([20, 1, {thisIs: 'anExampleObject'}]);
-
-      expect(testMap).to.have.all.deep.keys({thisIs: 'anExampleObject'}, {doingThisBecauseOf: 'referential equality'});
-
-      expect(testMap).to.not.have.any.deep.keys([{13: 37}, 'thisDoesNotExist', 'thisToo']);
-      expect(testMap).to.not.have.any.deep.keys([20, 1, {13: 37}]);
-      expect(testMap).to.not.have.all.deep.keys([{thisIs: 'anExampleObject'}, {'iDoNot': 'exist'}]);
-
-      var weirdMapKey1 = Object.create(null)
-        , weirdMapKey2 = {toString: NaN}
-        , weirdMapKey3 = []
-        , weirdMap = new Map();
-
-      weirdMap.set(weirdMapKey1, 'val1');
-      weirdMap.set(weirdMapKey2, 'val2');
-
-      expect(weirdMap).to.have.all.keys([weirdMapKey1, weirdMapKey2]);
-      expect(weirdMap).to.not.have.all.keys([weirdMapKey1, weirdMapKey3]);
-
-      if (typeof Symbol === 'function') {
-        var symMapKey1 = Symbol()
-          , symMapKey2 = Symbol()
-          , symMapKey3 = Symbol()
-          , symMap = new Map();
-
-        symMap.set(symMapKey1, 'val1');
-        symMap.set(symMapKey2, 'val2');
-
-        expect(symMap).to.have.all.keys(symMapKey1, symMapKey2);
-        expect(symMap).to.have.any.keys(symMapKey1, symMapKey3);
-        expect(symMap).to.contain.all.keys(symMapKey2, symMapKey1);
-        expect(symMap).to.contain.any.keys(symMapKey3, symMapKey1);
-
-        expect(symMap).to.not.have.all.keys(symMapKey1, symMapKey3);
-        expect(symMap).to.not.have.any.keys(symMapKey3);
-        expect(symMap).to.not.contain.all.keys(symMapKey3, symMapKey1);
-        expect(symMap).to.not.contain.any.keys(symMapKey3);
-      }
-
-      var errMap = new Map();
-
-      errMap.set({ foo: 1 });
-
-      err(function(){
-        expect(errMap, 'blah').to.have.keys();
-      }, "blah: keys required");
-
-      err(function(){
-        expect(errMap).to.have.keys([]);
-      }, "keys required");
+    // Not using Map constructor args because not supported in IE 11.
+    var aKey = {thisIs: 'anExampleObject'}
+      , anotherKey = {doingThisBecauseOf: 'referential equality'}
+      , testMap = new Map();
 
-      err(function(){
-        expect(errMap).to.contain.keys();
-      }, "keys required");
-
-      err(function(){
-        expect(errMap).to.contain.keys([]);
-      }, "keys required");
-
-      // Uncomment this after solving https://github.com/chaijs/chai/issues/662
-      // This should fail because of referential equality (this is a strict comparison)
-      // err(function(){
-      //   expect(new Map([[{foo: 1}, 'bar']])).to.contain.keys({ foo: 1 });
-      // }, 'expected [ [ { foo: 1 }, 'bar' ] ] to contain key { foo: 1 }');
-
-      // err(function(){
-      //   expect(new Map([[{foo: 1}, 'bar']])).to.contain.deep.keys({ iDoNotExist: 0 })
-      // }, 'expected [ { foo: 1 } ] to deeply contain key { iDoNotExist: 0 }');
-    }
-
-    if (typeof Set !== 'undefined') {
-      // Not using Set constructor args because not supported in IE 11.
-      var aKey = {thisIs: 'anExampleObject'}
-        , anotherKey = {doingThisBecauseOf: 'referential equality'}
-        , testSet = new Set();
-
-      testSet.add(aKey);
-      testSet.add(anotherKey);
-
-      expect(testSet).to.have.any.keys(aKey);
-      expect(testSet).to.have.any.keys('thisDoesNotExist', 'thisToo', aKey);
-      expect(testSet).to.have.all.keys(aKey, anotherKey);
-
-      expect(testSet).to.contain.all.keys(aKey);
-      expect(testSet).to.not.contain.all.keys(aKey, 'thisDoesNotExist');
-
-      expect(testSet).to.not.have.any.keys({iDoNot: 'exist'});
-      expect(testSet).to.not.have.any.keys('thisIsNotAkey', {iDoNot: 'exist'}, {33: 20});
-      expect(testSet).to.not.have.all.keys('thisDoesNotExist', 'thisToo', anotherKey);
-
-      expect(testSet).to.have.any.keys([aKey]);
-      expect(testSet).to.have.any.keys([20, 1, aKey]);
-      expect(testSet).to.have.all.keys([aKey, anotherKey]);
-
-      expect(testSet).to.not.have.any.keys([{13: 37}, 'thisDoesNotExist', 'thisToo']);
-      expect(testSet).to.not.have.any.keys([20, 1, {13: 37}]);
-      expect(testSet).to.not.have.all.keys([aKey, {'iDoNot': 'exist'}]);
-
-      // Ensure the assertions above use strict equality
-      err(function() {
-        expect(testSet).to.have.any.keys({thisIs: 'anExampleObject'});
-      });
-
-      err(function() {
-        expect(testSet).to.have.all.keys({thisIs: 'anExampleObject'}, {doingThisBecauseOf: 'referential equality'});
-      });
-
-      err(function() {
-        expect(testSet).to.contain.all.keys({thisIs: 'anExampleObject'});
-      });
-
-      err(function() {
-        expect(testSet).to.have.any.keys([{thisIs: 'anExampleObject'}]);
-      });
-
-      err(function() {
-        expect(testSet).to.have.all.keys([{thisIs: 'anExampleObject'}, {doingThisBecauseOf: 'referential equality'}]);
-      });
-
-      // Using the same assertions as above but with `.deep` flag instead of using referential equality
-      expect(testSet).to.have.any.deep.keys({thisIs: 'anExampleObject'});
-      expect(testSet).to.have.any.deep.keys('thisDoesNotExist', 'thisToo', {thisIs: 'anExampleObject'});
-
-      expect(testSet).to.contain.all.deep.keys({thisIs: 'anExampleObject'});
-      expect(testSet).to.not.contain.all.deep.keys({thisIs: 'anExampleObject'}, 'thisDoesNotExist');
-
-      expect(testSet).to.not.have.any.deep.keys({iDoNot: 'exist'});
-      expect(testSet).to.not.have.any.deep.keys('thisIsNotAkey', {iDoNot: 'exist'}, {33: 20});
-      expect(testSet).to.not.have.all.deep.keys('thisDoesNotExist', 'thisToo', {doingThisBecauseOf: 'referential equality'});
-
-      expect(testSet).to.have.any.deep.keys([{thisIs: 'anExampleObject'}]);
-      expect(testSet).to.have.any.deep.keys([20, 1, {thisIs: 'anExampleObject'}]);
-
-      expect(testSet).to.have.all.deep.keys([{thisIs: 'anExampleObject'}, {doingThisBecauseOf: 'referential equality'}]);
-
-      expect(testSet).to.not.have.any.deep.keys([{13: 37}, 'thisDoesNotExist', 'thisToo']);
-      expect(testSet).to.not.have.any.deep.keys([20, 1, {13: 37}]);
-      expect(testSet).to.not.have.all.deep.keys([{thisIs: 'anExampleObject'}, {'iDoNot': 'exist'}]);
-
-      var weirdSetKey1 = Object.create(null)
-        , weirdSetKey2 = {toString: NaN}
-        , weirdSetKey3 = []
-        , weirdSet = new Set();
-
-      weirdSet.add(weirdSetKey1);
-      weirdSet.add(weirdSetKey2);
-
-      expect(weirdSet).to.have.all.keys([weirdSetKey1, weirdSetKey2]);
-      expect(weirdSet).to.not.have.all.keys([weirdSetKey1, weirdSetKey3]);
-
-      if (typeof Symbol === 'function') {
-        var symSetKey1 = Symbol()
-          , symSetKey2 = Symbol()
-          , symSetKey3 = Symbol()
-          , symSet = new Set();
-
-        symSet.add(symSetKey1);
-        symSet.add(symSetKey2);
-
-        expect(symSet).to.have.all.keys(symSetKey1, symSetKey2);
-        expect(symSet).to.have.any.keys(symSetKey1, symSetKey3);
-        expect(symSet).to.contain.all.keys(symSetKey2, symSetKey1);
-        expect(symSet).to.contain.any.keys(symSetKey3, symSetKey1);
-
-        expect(symSet).to.not.have.all.keys(symSetKey1, symSetKey3);
-        expect(symSet).to.not.have.any.keys(symSetKey3);
-        expect(symSet).to.not.contain.all.keys(symSetKey3, symSetKey1);
-        expect(symSet).to.not.contain.any.keys(symSetKey3);
-      }
-
-      var errSet = new Set();
-      errSet.add({ foo: 1});
-
-      err(function(){
-        expect(errSet, 'blah').to.have.keys();
-      }, "blah: keys required");
-
-      err(function(){
-        expect(errSet).to.have.keys([]);
-      }, "keys required");
-
-      err(function(){
-        expect(errSet).to.contain.keys();
-      }, "keys required");
-
-      err(function(){
-        expect(errSet).to.contain.keys([]);
-      }, "keys required");
-
-      // Uncomment this after solving https://github.com/chaijs/chai/issues/662
-      // This should fail because of referential equality (this is a strict comparison)
-      // err(function(){
-      //   expect(new Set([{foo: 1}])).to.contain.keys({ foo: 1 });
-      // }, 'expected [ { foo: 1 } ] to deeply contain key { foo: 1 }');
-
-      // err(function(){
-      //   expect(new Set([{foo: 1}])).to.contain.deep.keys({ iDoNotExist: 0 });
-      // }, 'expected [ { foo: 1 } ] to deeply contain key { iDoNotExist: 0 }');
-    }
+    testMap.set(aKey, 'aValue');
+    testMap.set(anotherKey, 'anotherValue');
+
+    expect(testMap).to.have.any.keys(aKey);
+    expect(testMap).to.have.any.keys('thisDoesNotExist', 'thisToo', aKey);
+    expect(testMap).to.have.all.keys(aKey, anotherKey);
+
+    expect(testMap).to.contain.all.keys(aKey);
+    expect(testMap).to.not.contain.all.keys(aKey, 'thisDoesNotExist');
+
+    expect(testMap).to.not.have.any.keys({iDoNot: 'exist'});
+    expect(testMap).to.not.have.any.keys('thisIsNotAkey', {iDoNot: 'exist'}, {33: 20});
+    expect(testMap).to.not.have.all.keys('thisDoesNotExist', 'thisToo', anotherKey);
+
+    expect(testMap).to.have.any.keys([aKey]);
+    expect(testMap).to.have.any.keys([20, 1, aKey]);
+    expect(testMap).to.have.all.keys([aKey, anotherKey]);
+
+    expect(testMap).to.not.have.any.keys([{13: 37}, 'thisDoesNotExist', 'thisToo']);
+    expect(testMap).to.not.have.any.keys([20, 1, {13: 37}]);
+    expect(testMap).to.not.have.all.keys([aKey, {'iDoNot': 'exist'}]);
+
+    // Ensure the assertions above use strict equality
+    err(function() {
+      expect(testMap).to.have.any.keys({thisIs: 'anExampleObject'});
+    });
+
+    err(function() {
+      expect(testMap).to.have.all.keys({thisIs: 'anExampleObject'}, {doingThisBecauseOf: 'referential equality'});
+    });
+
+    err(function() {
+      expect(testMap).to.contain.all.keys({thisIs: 'anExampleObject'});
+    });
+
+    err(function() {
+      expect(testMap).to.have.any.keys([{thisIs: 'anExampleObject'}]);
+    });
+
+    err(function() {
+      expect(testMap).to.have.all.keys([{thisIs: 'anExampleObject'}, {doingThisBecauseOf: 'referential equality'}]);
+    });
+
+    // Using the same assertions as above but with `.deep` flag instead of using referential equality
+    expect(testMap).to.have.any.deep.keys({thisIs: 'anExampleObject'});
+    expect(testMap).to.have.any.deep.keys('thisDoesNotExist', 'thisToo', {thisIs: 'anExampleObject'});
+
+    expect(testMap).to.contain.all.deep.keys({thisIs: 'anExampleObject'});
+    expect(testMap).to.not.contain.all.deep.keys({thisIs: 'anExampleObject'}, 'thisDoesNotExist');
+
+    expect(testMap).to.not.have.any.deep.keys({iDoNot: 'exist'});
+    expect(testMap).to.not.have.any.deep.keys('thisIsNotAkey', {iDoNot: 'exist'}, {33: 20});
+    expect(testMap).to.not.have.all.deep.keys('thisDoesNotExist', 'thisToo', {doingThisBecauseOf: 'referential equality'});
+
+    expect(testMap).to.have.any.deep.keys([{thisIs: 'anExampleObject'}]);
+    expect(testMap).to.have.any.deep.keys([20, 1, {thisIs: 'anExampleObject'}]);
+
+    expect(testMap).to.have.all.deep.keys({thisIs: 'anExampleObject'}, {doingThisBecauseOf: 'referential equality'});
+
+    expect(testMap).to.not.have.any.deep.keys([{13: 37}, 'thisDoesNotExist', 'thisToo']);
+    expect(testMap).to.not.have.any.deep.keys([20, 1, {13: 37}]);
+    expect(testMap).to.not.have.all.deep.keys([{thisIs: 'anExampleObject'}, {'iDoNot': 'exist'}]);
+
+    var weirdMapKey1 = Object.create(null)
+      , weirdMapKey2 = {toString: NaN}
+      , weirdMapKey3 = []
+      , weirdMap = new Map();
+
+    weirdMap.set(weirdMapKey1, 'val1');
+    weirdMap.set(weirdMapKey2, 'val2');
+
+    expect(weirdMap).to.have.all.keys([weirdMapKey1, weirdMapKey2]);
+    expect(weirdMap).to.not.have.all.keys([weirdMapKey1, weirdMapKey3]);
+
+    var symMapKey1 = Symbol()
+      , symMapKey2 = Symbol()
+      , symMapKey3 = Symbol()
+      , symMap = new Map();
+
+    symMap.set(symMapKey1, 'val1');
+    symMap.set(symMapKey2, 'val2');
+
+    expect(symMap).to.have.all.keys(symMapKey1, symMapKey2);
+    expect(symMap).to.have.any.keys(symMapKey1, symMapKey3);
+    expect(symMap).to.contain.all.keys(symMapKey2, symMapKey1);
+    expect(symMap).to.contain.any.keys(symMapKey3, symMapKey1);
+
+    expect(symMap).to.not.have.all.keys(symMapKey1, symMapKey3);
+    expect(symMap).to.not.have.any.keys(symMapKey3);
+    expect(symMap).to.not.contain.all.keys(symMapKey3, symMapKey1);
+    expect(symMap).to.not.contain.any.keys(symMapKey3);
+
+    var errMap = new Map();
+
+    errMap.set({ foo: 1 });
+
+    err(function(){
+      expect(errMap, 'blah').to.have.keys();
+    }, "blah: keys required");
+
+    err(function(){
+      expect(errMap).to.have.keys([]);
+    }, "keys required");
+
+    err(function(){
+      expect(errMap).to.contain.keys();
+    }, "keys required");
+
+    err(function(){
+      expect(errMap).to.contain.keys([]);
+    }, "keys required");
+
+    // Uncomment this after solving https://github.com/chaijs/chai/issues/662
+    // This should fail because of referential equality (this is a strict comparison)
+    // err(function(){
+    //   expect(new Map([[{foo: 1}, 'bar']])).to.contain.keys({ foo: 1 });
+    // }, 'expected [ [ { foo: 1 }, 'bar' ] ] to contain key { foo: 1 }');
+
+    // err(function(){
+    //   expect(new Map([[{foo: 1}, 'bar']])).to.contain.deep.keys({ iDoNotExist: 0 })
+    // }, 'expected [ { foo: 1 } ] to deeply contain key { iDoNotExist: 0 }');
+
+    // Not using Set constructor args because not supported in IE 11.
+    var aKey = {thisIs: 'anExampleObject'}
+      , anotherKey = {doingThisBecauseOf: 'referential equality'}
+      , testSet = new Set();
+
+    testSet.add(aKey);
+    testSet.add(anotherKey);
+
+    expect(testSet).to.have.any.keys(aKey);
+    expect(testSet).to.have.any.keys('thisDoesNotExist', 'thisToo', aKey);
+    expect(testSet).to.have.all.keys(aKey, anotherKey);
+
+    expect(testSet).to.contain.all.keys(aKey);
+    expect(testSet).to.not.contain.all.keys(aKey, 'thisDoesNotExist');
+
+    expect(testSet).to.not.have.any.keys({iDoNot: 'exist'});
+    expect(testSet).to.not.have.any.keys('thisIsNotAkey', {iDoNot: 'exist'}, {33: 20});
+    expect(testSet).to.not.have.all.keys('thisDoesNotExist', 'thisToo', anotherKey);
+
+    expect(testSet).to.have.any.keys([aKey]);
+    expect(testSet).to.have.any.keys([20, 1, aKey]);
+    expect(testSet).to.have.all.keys([aKey, anotherKey]);
+
+    expect(testSet).to.not.have.any.keys([{13: 37}, 'thisDoesNotExist', 'thisToo']);
+    expect(testSet).to.not.have.any.keys([20, 1, {13: 37}]);
+    expect(testSet).to.not.have.all.keys([aKey, {'iDoNot': 'exist'}]);
+
+    // Ensure the assertions above use strict equality
+    err(function() {
+      expect(testSet).to.have.any.keys({thisIs: 'anExampleObject'});
+    });
+
+    err(function() {
+      expect(testSet).to.have.all.keys({thisIs: 'anExampleObject'}, {doingThisBecauseOf: 'referential equality'});
+    });
+
+    err(function() {
+      expect(testSet).to.contain.all.keys({thisIs: 'anExampleObject'});
+    });
+
+    err(function() {
+      expect(testSet).to.have.any.keys([{thisIs: 'anExampleObject'}]);
+    });
+
+    err(function() {
+      expect(testSet).to.have.all.keys([{thisIs: 'anExampleObject'}, {doingThisBecauseOf: 'referential equality'}]);
+    });
+
+    // Using the same assertions as above but with `.deep` flag instead of using referential equality
+    expect(testSet).to.have.any.deep.keys({thisIs: 'anExampleObject'});
+    expect(testSet).to.have.any.deep.keys('thisDoesNotExist', 'thisToo', {thisIs: 'anExampleObject'});
+
+    expect(testSet).to.contain.all.deep.keys({thisIs: 'anExampleObject'});
+    expect(testSet).to.not.contain.all.deep.keys({thisIs: 'anExampleObject'}, 'thisDoesNotExist');
+
+    expect(testSet).to.not.have.any.deep.keys({iDoNot: 'exist'});
+    expect(testSet).to.not.have.any.deep.keys('thisIsNotAkey', {iDoNot: 'exist'}, {33: 20});
+    expect(testSet).to.not.have.all.deep.keys('thisDoesNotExist', 'thisToo', {doingThisBecauseOf: 'referential equality'});
+
+    expect(testSet).to.have.any.deep.keys([{thisIs: 'anExampleObject'}]);
+    expect(testSet).to.have.any.deep.keys([20, 1, {thisIs: 'anExampleObject'}]);
+
+    expect(testSet).to.have.all.deep.keys([{thisIs: 'anExampleObject'}, {doingThisBecauseOf: 'referential equality'}]);
+
+    expect(testSet).to.not.have.any.deep.keys([{13: 37}, 'thisDoesNotExist', 'thisToo']);
+    expect(testSet).to.not.have.any.deep.keys([20, 1, {13: 37}]);
+    expect(testSet).to.not.have.all.deep.keys([{thisIs: 'anExampleObject'}, {'iDoNot': 'exist'}]);
+
+    var weirdSetKey1 = Object.create(null)
+      , weirdSetKey2 = {toString: NaN}
+      , weirdSetKey3 = []
+      , weirdSet = new Set();
+
+    weirdSet.add(weirdSetKey1);
+    weirdSet.add(weirdSetKey2);
+
+    expect(weirdSet).to.have.all.keys([weirdSetKey1, weirdSetKey2]);
+    expect(weirdSet).to.not.have.all.keys([weirdSetKey1, weirdSetKey3]);
+
+    var symSetKey1 = Symbol()
+      , symSetKey2 = Symbol()
+      , symSetKey3 = Symbol()
+      , symSet = new Set();
+
+    symSet.add(symSetKey1);
+    symSet.add(symSetKey2);
+
+    expect(symSet).to.have.all.keys(symSetKey1, symSetKey2);
+    expect(symSet).to.have.any.keys(symSetKey1, symSetKey3);
+    expect(symSet).to.contain.all.keys(symSetKey2, symSetKey1);
+    expect(symSet).to.contain.any.keys(symSetKey3, symSetKey1);
+
+    expect(symSet).to.not.have.all.keys(symSetKey1, symSetKey3);
+    expect(symSet).to.not.have.any.keys(symSetKey3);
+    expect(symSet).to.not.contain.all.keys(symSetKey3, symSetKey1);
+    expect(symSet).to.not.contain.any.keys(symSetKey3);
+
+    var errSet = new Set();
+    errSet.add({ foo: 1});
+
+    err(function(){
+      expect(errSet, 'blah').to.have.keys();
+    }, "blah: keys required");
+
+    err(function(){
+      expect(errSet).to.have.keys([]);
+    }, "keys required");
+
+    err(function(){
+      expect(errSet).to.contain.keys();
+    }, "keys required");
+
+    err(function(){
+      expect(errSet).to.contain.keys([]);
+    }, "keys required");
+
+    // Uncomment this after solving https://github.com/chaijs/chai/issues/662
+    // This should fail because of referential equality (this is a strict comparison)
+    // err(function(){
+    //   expect(new Set([{foo: 1}])).to.contain.keys({ foo: 1 });
+    // }, 'expected [ { foo: 1 } ] to deeply contain key { foo: 1 }');
+
+    // err(function(){
+    //   expect(new Set([{foo: 1}])).to.contain.deep.keys({ iDoNotExist: 0 });
+    // }, 'expected [ { foo: 1 } ] to deeply contain key { iDoNotExist: 0 }');
 
     err(function(){
       expect({ foo: 1 }, 'blah').to.have.keys();
@@ -3873,9 +3801,7 @@ describe('expect', function () {
     expect(false).to.not.be.extensible;
     expect(undefined).to.not.be.extensible;
 
-    if (typeof Symbol === 'function') {
-      expect(Symbol()).to.not.be.extensible;
-    }
+    expect(Symbol()).to.not.be.extensible;
 
     err(function() {
       expect(42).to.be.extensible;
@@ -3897,18 +3823,16 @@ describe('expect', function () {
       expect(undefined).to.be.extensible;
     }, 'expected undefined to be extensible');
 
-    if (typeof Proxy === 'function') {
-      var proxy = new Proxy({}, {
-        isExtensible: function() {
-          throw new TypeError();
-        }
-      });
+    var proxy = new Proxy({}, {
+      isExtensible: function() {
+        throw new TypeError();
+      }
+    });
 
-      err(function() {
-        // .extensible should not suppress errors, thrown in proxy traps
-        expect(proxy).to.be.extensible;
-      }, { name: 'TypeError' }, true);
-    }
+    err(function() {
+      // .extensible should not suppress errors, thrown in proxy traps
+      expect(proxy).to.be.extensible;
+    }, { name: 'TypeError' }, true);
   });
 
   it('sealed', function() {
@@ -3932,10 +3856,7 @@ describe('expect', function () {
     expect('foo').to.be.sealed;
     expect(false).to.be.sealed;
     expect(undefined).to.be.sealed;
-
-    if (typeof Symbol === 'function') {
-      expect(Symbol()).to.be.sealed;
-    }
+    expect(Symbol()).to.be.sealed;
 
     err(function() {
       expect(42).to.not.be.sealed;
@@ -3957,21 +3878,19 @@ describe('expect', function () {
       expect(undefined).to.not.be.sealed;
     }, 'expected undefined to not be sealed');
 
-    if (typeof Proxy === 'function') {
-      var proxy = new Proxy({}, {
-        ownKeys: function() {
-          throw new TypeError();
-        }
-      });
+    var proxy = new Proxy({}, {
+      ownKeys: function() {
+        throw new TypeError();
+      }
+    });
 
-      // Object.isSealed will call ownKeys trap only if object is not extensible
-      Object.preventExtensions(proxy);
+    // Object.isSealed will call ownKeys trap only if object is not extensible
+    Object.preventExtensions(proxy);
 
-      err(function() {
-        // .sealed should not suppress errors, thrown in proxy traps
-        expect(proxy).to.be.sealed;
-      }, { name: 'TypeError' }, true);
-    }
+    err(function() {
+      // .sealed should not suppress errors, thrown in proxy traps
+      expect(proxy).to.be.sealed;
+    }, { name: 'TypeError' }, true);
   });
 
   it('frozen', function() {
@@ -3995,10 +3914,7 @@ describe('expect', function () {
     expect('foo').to.be.frozen;
     expect(false).to.be.frozen;
     expect(undefined).to.be.frozen;
-
-    if (typeof Symbol === 'function') {
-      expect(Symbol()).to.be.frozen;
-    }
+    expect(Symbol()).to.be.frozen;
 
     err(function() {
       expect(42).to.not.be.frozen;
@@ -4020,20 +3936,18 @@ describe('expect', function () {
       expect(undefined).to.not.be.frozen;
     }, 'expected undefined to not be frozen');
 
-    if (typeof Proxy === 'function') {
-      var proxy = new Proxy({}, {
-        ownKeys: function() {
-          throw new TypeError();
-        }
-      });
+    var proxy = new Proxy({}, {
+      ownKeys: function() {
+        throw new TypeError();
+      }
+    });
 
-      // Object.isFrozen will call ownKeys trap only if object is not extensible
-      Object.preventExtensions(proxy);
+    // Object.isFrozen will call ownKeys trap only if object is not extensible
+    Object.preventExtensions(proxy);
 
-      err(function() {
-        // .frozen should not suppress errors, thrown in proxy traps
-        expect(proxy).to.be.frozen;
-      }, { name: 'TypeError' }, true);
-    }
+    err(function() {
+      // .frozen should not suppress errors, thrown in proxy traps
+      expect(proxy).to.be.frozen;
+    }, { name: 'TypeError' }, true);
   });
 });

--- a/test/expect.js
+++ b/test/expect.js
@@ -637,10 +637,10 @@ describe('expect', function () {
       expect(1).to.have.lengthOf.within(5, 7, 'blah');
     }, "blah: expected 1 to have property 'length'");
 
-    expect(new Map).to.have.length.within(0, 0);
-    expect(new Map).to.have.lengthOf.within(0, 0);
+    expect(new Map()).to.have.length.within(0, 0);
+    expect(new Map()).to.have.lengthOf.within(0, 0);
 
-    var map = new Map;
+    var map = new Map();
     map.set('a', 1);
     map.set('b', 2);
     map.set('c', 3);
@@ -656,10 +656,10 @@ describe('expect', function () {
       expect(map).to.have.lengthOf.within(5, 7, 'blah');
     }, "blah: expected Map{ 'a' => 1, 'b' => 2, 'c' => 3 } to have a size within 5..7");
 
-    expect(new Set).to.have.length.within(0, 0);
-    expect(new Set).to.have.lengthOf.within(0, 0);
+    expect(new Set()).to.have.length.within(0, 0);
+    expect(new Set()).to.have.lengthOf.within(0, 0);
 
-    var set = new Set;
+    var set = new Set();
     set.add(1);
     set.add(2);
     set.add(3);
@@ -808,10 +808,10 @@ describe('expect', function () {
       expect(1).to.have.lengthOf.above(0, 'blah');
     }, "blah: expected 1 to have property 'length'");
 
-    expect(new Map).to.have.length.above(-1);
-    expect(new Map).to.have.lengthOf.above(-1);
+    expect(new Map()).to.have.length.above(-1);
+    expect(new Map()).to.have.lengthOf.above(-1);
 
-    var map = new Map;
+    var map = new Map();
     map.set('a', 1);
     map.set('b', 2);
     map.set('c', 3);
@@ -827,10 +827,10 @@ describe('expect', function () {
       expect(map).to.have.lengthOf.above(5, 'blah');
     }, "blah: expected Map{ 'a' => 1, 'b' => 2, 'c' => 3 } to have a size above 5 but got 3");
 
-    expect(new Set).to.have.length.above(-1);
-    expect(new Set).to.have.lengthOf.above(-1);
+    expect(new Set()).to.have.length.above(-1);
+    expect(new Set()).to.have.lengthOf.above(-1);
 
-    var set = new Set;
+    var set = new Set();
     set.add(1);
     set.add(2);
     set.add(3);
@@ -971,10 +971,10 @@ describe('expect', function () {
       expect(1).to.have.lengthOf.at.least(0, 'blah');
     }, "blah: expected 1 to have property 'length'");
 
-    expect(new Map).to.have.length.of.at.least(0);
-    expect(new Map).to.have.lengthOf.at.least(0);
+    expect(new Map()).to.have.length.of.at.least(0);
+    expect(new Map()).to.have.lengthOf.at.least(0);
 
-    var map = new Map;
+    var map = new Map();
     map.set('a', 1);
     map.set('b', 2);
     map.set('c', 3);
@@ -990,10 +990,10 @@ describe('expect', function () {
       expect(map).to.have.lengthOf.at.least(4, 'blah');
     }, "blah: expected Map{ 'a' => 1, 'b' => 2, 'c' => 3 } to have a size at least 4 but got 3");
 
-    expect(new Set).to.have.length.of.at.least(0);
-    expect(new Set).to.have.lengthOf.at.least(0);
+    expect(new Set()).to.have.length.of.at.least(0);
+    expect(new Set()).to.have.lengthOf.at.least(0);
 
-    var set = new Set;
+    var set = new Set();
     set.add(1);
     set.add(2);
     set.add(3);
@@ -1088,10 +1088,10 @@ describe('expect', function () {
       expect(1).to.have.lengthOf.below(0, 'blah');
     }, "blah: expected 1 to have property 'length'");
 
-    expect(new Map).to.have.length.below(1);
-    expect(new Map).to.have.lengthOf.below(1);
+    expect(new Map()).to.have.length.below(1);
+    expect(new Map()).to.have.lengthOf.below(1);
 
-    var map = new Map;
+    var map = new Map();
     map.set('a', 1);
     map.set('b', 2);
     map.set('c', 3);
@@ -1107,10 +1107,10 @@ describe('expect', function () {
       expect(map).to.have.lengthOf.below(2, 'blah');
     }, "blah: expected Map{ 'a' => 1, 'b' => 2, 'c' => 3 } to have a size below 2 but got 3");
 
-    expect(new Set).to.have.length.below(1);
-    expect(new Set).to.have.lengthOf.below(1);
+    expect(new Set()).to.have.length.below(1);
+    expect(new Set()).to.have.lengthOf.below(1);
 
-    var set = new Set;
+    var set = new Set();
     set.add(1);
     set.add(2);
     set.add(3);
@@ -1255,10 +1255,10 @@ describe('expect', function () {
       expect(1).to.have.lengthOf.at.most(0, 'blah');
     }, "blah: expected 1 to have property 'length'");
 
-    expect(new Map).to.have.length.of.at.most(0);
-    expect(new Map).to.have.lengthOf.at.most(0);
+    expect(new Map()).to.have.length.of.at.most(0);
+    expect(new Map()).to.have.lengthOf.at.most(0);
 
-    var map = new Map;
+    var map = new Map();
     map.set('a', 1);
     map.set('b', 2);
     map.set('c', 3);
@@ -1274,10 +1274,10 @@ describe('expect', function () {
       expect(map).to.have.lengthOf.at.most(2, 'blah');
     }, "blah: expected Map{ 'a' => 1, 'b' => 2, 'c' => 3 } to have a size at most 2 but got 3");
 
-    expect(new Set).to.have.length.of.at.most(0);
-    expect(new Set).to.have.lengthOf.at.most(0);
+    expect(new Set()).to.have.length.of.at.most(0);
+    expect(new Set()).to.have.lengthOf.at.most(0);
 
-    var set = new Set;
+    var set = new Set();
     set.add(1);
     set.add(2);
     set.add(3);
@@ -1397,10 +1397,10 @@ describe('expect', function () {
       expect('asd').to.not.have.lengthOf(3, 'blah');
     }, "blah: expected 'asd' to not have a length of 3");
 
-    expect(new Map).to.have.length(0);
-    expect(new Map).to.have.lengthOf(0);
+    expect(new Map()).to.have.length(0);
+    expect(new Map()).to.have.lengthOf(0);
 
-    var map = new Map;
+    var map = new Map();
     map.set('a', 1);
     map.set('b', 2);
     map.set('c', 3);
@@ -1416,10 +1416,10 @@ describe('expect', function () {
       expect(map).to.not.have.lengthOf(3, 'blah');
     }, "blah: expected Map{ 'a' => 1, 'b' => 2, 'c' => 3 } to not have a size of 3");
 
-    expect(new Set).to.have.length(0);
-    expect(new Set).to.have.lengthOf(0);
+    expect(new Set()).to.have.length(0);
+    expect(new Set()).to.have.lengthOf(0);
 
-    var set = new Set;
+    var set = new Set();
     set.add(1);
     set.add(2);
     set.add(3);
@@ -1550,31 +1550,31 @@ describe('expect', function () {
     expect('foo').not.to.be.empty;
     expect([]).to.be.empty;
     expect(['foo']).not.to.be.empty;
-    expect(new FakeArgs).to.be.empty;
+    expect(new FakeArgs()).to.be.empty;
     expect({arguments: 0}).not.to.be.empty;
     expect({}).to.be.empty;
     expect({foo: 'bar'}).not.to.be.empty;
 
     err(function(){
-      expect(new WeakMap, 'blah').not.to.be.empty;
+      expect(new WeakMap(), 'blah').not.to.be.empty;
     }, "blah: .empty was passed a weak collection");
 
     err(function(){
-      expect(new WeakSet, 'blah').not.to.be.empty;
+      expect(new WeakSet(), 'blah').not.to.be.empty;
     }, "blah: .empty was passed a weak collection");
 
-    expect(new Map).to.be.empty;
+    expect(new Map()).to.be.empty;
 
     // Not using Map constructor args because not supported in IE 11.
-    var map = new Map;
+    var map = new Map();
     map.set('a', 1);
     expect(map).not.to.be.empty;
 
     err(function(){
-      expect(new Map).not.to.be.empty;
+      expect(new Map()).not.to.be.empty;
     }, "expected Map{} not to be empty");
 
-    map = new Map;
+    map = new Map();
     map.key = 'val';
     expect(map).to.be.empty;
 
@@ -1582,18 +1582,18 @@ describe('expect', function () {
       expect(map).not.to.be.empty;
     }, "expected Map{} not to be empty");
 
-    expect(new Set).to.be.empty;
+    expect(new Set()).to.be.empty;
 
     // Not using Set constructor args because not supported in IE 11.
-    var set = new Set;
+    var set = new Set();
     set.add(1);
     expect(set).not.to.be.empty;
 
     err(function(){
-      expect(new Set).not.to.be.empty;
+      expect(new Set()).not.to.be.empty;
     }, "expected Set{} not to be empty");
 
-    set = new Set;
+    set = new Set();
     set.key = 'val';
     expect(set).to.be.empty;
 
@@ -1618,7 +1618,7 @@ describe('expect', function () {
     }, "expected [ \'foo\' ] to be empty");
 
     err(function(){
-      expect(new FakeArgs).not.to.be.empty;
+      expect(new FakeArgs()).not.to.be.empty;
     }, "expected FakeArgs{} not to be empty");
 
     err(function(){

--- a/test/globalErr.js
+++ b/test/globalErr.js
@@ -186,12 +186,12 @@ describe('globalErr', function () {
       , undefined
     ];
 
-    if (typeof Symbol === 'function') vals.push(Symbol());
-    if (typeof Map === 'function') vals.push(new Map());
-    if (typeof WeakMap === 'function') vals.push(new WeakMap());
-    if (typeof Set === 'function') vals.push(new Set());
-    if (typeof WeakSet === 'function') vals.push(new WeakSet());
-    if (typeof Promise === 'function') vals.push(new Promise(noop));
+    vals.push(Symbol());
+    vals.push(new Map());
+    vals.push(new Set());
+    vals.push(new WeakMap());
+    vals.push(new WeakSet());
+    vals.push(new Promise(noop));
 
     vals.forEach(function (val) {
       err(function () { err(val) }, 'Invalid fn')
@@ -207,12 +207,12 @@ describe('globalErr', function () {
       , null
     ];
 
-    if (typeof Symbol === 'function') vals.push(Symbol());
-    if (typeof Map === 'function') vals.push(new Map());
-    if (typeof WeakMap === 'function') vals.push(new WeakMap());
-    if (typeof Set === 'function') vals.push(new Set());
-    if (typeof WeakSet === 'function') vals.push(new WeakSet());
-    if (typeof Promise === 'function') vals.push(new Promise(noop));
+    vals.push(Symbol());
+    vals.push(new Map());
+    vals.push(new WeakMap());
+    vals.push(new Set());
+    vals.push(new WeakSet());
+    vals.push(new Promise(noop));
 
     vals.forEach(function (val) {
       err(function () {

--- a/test/should.js
+++ b/test/should.js
@@ -1390,15 +1390,13 @@ describe('should', function() {
       false.should.be.empty;
     }, ".empty was passed non-string primitive false");
 
-    if (typeof Symbol !== 'undefined') {
-      err(function(){
-        Symbol().should.be.empty;
-      }, ".empty was passed non-string primitive Symbol()");
+    err(function(){
+      Symbol().should.be.empty;
+    }, ".empty was passed non-string primitive Symbol()");
 
-      err(function(){
-        Symbol.iterator.should.be.empty;
-      }, ".empty was passed non-string primitive Symbol(Symbol.iterator)");
-    }
+    err(function(){
+      Symbol.iterator.should.be.empty;
+    }, ".empty was passed non-string primitive Symbol(Symbol.iterator)");
 
     err(function(){
       (function() {}).should.be.empty;
@@ -1812,13 +1810,10 @@ describe('should', function() {
     // .include should work with Error objects and objects with a custom
     // `@@toStringTag`.
     (new Error('foo')).should.include({message: 'foo'});
-    if (typeof Symbol !== 'undefined'
-        && typeof Symbol.toStringTag !== 'undefined') {
-      var customObj = {a: 1};
-      customObj[Symbol.toStringTag] = 'foo';
+    var customObj = {a: 1};
+    customObj[Symbol.toStringTag] = 'foo';
 
-      customObj.should.include({a: 1});
-    }
+    customObj.should.include({a: 1});
 
     ({a: 1}).should.include({'toString': Object.prototype.toString});
 

--- a/test/should.js
+++ b/test/should.js
@@ -585,10 +585,10 @@ describe('should', function() {
       (1).should.have.lengthOf.within(5,7, 'blah');
     }, "blah: expected 1 to have property 'length'");
 
-    (new Map).should.have.length.within(0, 0);
-    (new Map).should.have.lengthOf.within(0, 0);
+    (new Map()).should.have.length.within(0, 0);
+    (new Map()).should.have.lengthOf.within(0, 0);
 
-    var map = new Map;
+    var map = new Map();
     map.set('a', 1);
     map.set('b', 2);
     map.set('c', 3);
@@ -604,10 +604,10 @@ describe('should', function() {
       map.should.have.lengthOf.within(5, 7, 'blah');
     }, "blah: expected Map{ 'a' => 1, 'b' => 2, 'c' => 3 } to have a size within 5..7");
 
-    (new Set).should.have.length.within(0, 0);
-    (new Set).should.have.lengthOf.within(0, 0);
+    (new Set()).should.have.length.within(0, 0);
+    (new Set()).should.have.lengthOf.within(0, 0);
 
-    var set = new Set;
+    var set = new Set();
     set.add(1);
     set.add(2);
     set.add(3);
@@ -728,10 +728,10 @@ describe('should', function() {
       (1).should.have.lengthOf.above(0, 'blah');
     }, "blah: expected 1 to have property 'length'");
 
-    (new Map).should.have.length.above(-1);
-    (new Map).should.have.lengthOf.above(-1);
+    (new Map()).should.have.length.above(-1);
+    (new Map()).should.have.lengthOf.above(-1);
 
-    var map = new Map;
+    var map = new Map();
     map.set('a', 1);
     map.set('b', 2);
     map.set('c', 3);
@@ -747,10 +747,10 @@ describe('should', function() {
       map.should.have.lengthOf.above(5, 'blah');
     }, "blah: expected Map{ 'a' => 1, 'b' => 2, 'c' => 3 } to have a size above 5 but got 3");
 
-    (new Set).should.have.length.above(-1);
-    (new Set).should.have.lengthOf.above(-1);
+    (new Set()).should.have.length.above(-1);
+    (new Set()).should.have.lengthOf.above(-1);
 
-    var set = new Set;
+    var set = new Set();
     set.add(1);
     set.add(2);
     set.add(3);
@@ -846,10 +846,10 @@ describe('should', function() {
       (1).should.not.be.at.least(null, 'blah');
     }, "blah: the argument to least must be a number");
 
-    (new Map).should.have.length.of.at.least(0);
-    (new Map).should.have.lengthOf.at.least(0);
+    (new Map()).should.have.length.of.at.least(0);
+    (new Map()).should.have.lengthOf.at.least(0);
 
-    var map = new Map;
+    var map = new Map();
     map.set('a', 1);
     map.set('b', 2);
     map.set('c', 3);
@@ -865,10 +865,10 @@ describe('should', function() {
       map.should.have.lengthOf.at.least(4, 'blah');
     }, "blah: expected Map{ 'a' => 1, 'b' => 2, 'c' => 3 } to have a size at least 4 but got 3");
 
-    (new Set).should.have.length.of.at.least(0);
-    (new Set).should.have.lengthOf.at.least(0);
+    (new Set()).should.have.length.of.at.least(0);
+    (new Set()).should.have.lengthOf.at.least(0);
 
-    var set = new Set;
+    var set = new Set();
     set.add(1);
     set.add(2);
     set.add(3);
@@ -931,10 +931,10 @@ describe('should', function() {
       (1).should.have.lengthOf.below(0, 'blah');
     }, "blah: expected 1 to have property 'length'");
 
-    (new Map).should.have.length.below(1);
-    (new Map).should.have.lengthOf.below(1);
+    (new Map()).should.have.length.below(1);
+    (new Map()).should.have.lengthOf.below(1);
 
-    var map = new Map;
+    var map = new Map();
     map.set('a', 1);
     map.set('b', 2);
     map.set('c', 3);
@@ -950,10 +950,10 @@ describe('should', function() {
       map.should.have.lengthOf.below(2, 'blah');
     }, "blah: expected Map{ 'a' => 1, 'b' => 2, 'c' => 3 } to have a size below 2 but got 3");
 
-    (new Set).should.have.length.below(1);
-    (new Set).should.have.lengthOf.below(1);
+    (new Set()).should.have.length.below(1);
+    (new Set()).should.have.lengthOf.below(1);
 
-    var set = new Set;
+    var set = new Set();
     set.add(1);
     set.add(2);
     set.add(3);
@@ -1057,10 +1057,10 @@ describe('should', function() {
       (1).should.have.lengthOf.at.most(0, 'blah');
     }, "blah: expected 1 to have property 'length'");
 
-    (new Map).should.have.length.of.at.most(0);
-    (new Map).should.have.lengthOf.at.most(0);
+    (new Map()).should.have.length.of.at.most(0);
+    (new Map()).should.have.lengthOf.at.most(0);
 
-    var map = new Map;
+    var map = new Map();
     map.set('a', 1);
     map.set('b', 2);
     map.set('c', 3);
@@ -1076,10 +1076,10 @@ describe('should', function() {
       map.should.have.lengthOf.at.most(2, 'blah');
     }, "blah: expected Map{ 'a' => 1, 'b' => 2, 'c' => 3 } to have a size at most 2 but got 3");
 
-    (new Set).should.have.length.of.at.most(0);
-    (new Set).should.have.lengthOf.at.most(0);
+    (new Set()).should.have.length.of.at.most(0);
+    (new Set()).should.have.lengthOf.at.most(0);
 
-    var set = new Set;
+    var set = new Set();
     set.add(1);
     set.add(2);
     set.add(3);
@@ -1186,10 +1186,10 @@ describe('should', function() {
       'asd'.should.not.have.lengthOf(3, 'blah');
     }, "blah: expected 'asd' to not have a length of 3");
 
-    (new Map).should.have.length(0);
-    (new Map).should.have.lengthOf(0);
+    (new Map()).should.have.length(0);
+    (new Map()).should.have.lengthOf(0);
 
-    var map = new Map;
+    var map = new Map();
     map.set('a', 1);
     map.set('b', 2);
     map.set('c', 3);
@@ -1205,10 +1205,10 @@ describe('should', function() {
       map.should.not.have.lengthOf(3, 'blah');
     }, "blah: expected Map{ 'a' => 1, 'b' => 2, 'c' => 3 } to not have a size of 3");
 
-    (new Set).should.have.length(0);
-    (new Set).should.have.lengthOf(0);
+    (new Set()).should.have.length(0);
+    (new Set()).should.have.lengthOf(0);
 
-    var set = new Set;
+    var set = new Set();
     set.add(1);
     set.add(2);
     set.add(3);
@@ -1291,31 +1291,31 @@ describe('should', function() {
     'foo'.should.not.be.empty;
     ([]).should.be.empty;
     (['foo']).should.not.be.empty;
-    (new FakeArgs).should.be.empty;
+    (new FakeArgs()).should.be.empty;
     ({arguments: 0}).should.not.be.empty;
     ({}).should.be.empty;
     ({foo: 'bar'}).should.not.be.empty;
 
     err(function(){
-      (new WeakMap).should.not.be.empty;
+      (new WeakMap()).should.not.be.empty;
     }, ".empty was passed a weak collection");
 
     err(function(){
-      (new WeakSet).should.not.be.empty;
+      (new WeakSet()).should.not.be.empty;
     }, ".empty was passed a weak collection");
 
-    (new Map).should.be.empty;
+    (new Map()).should.be.empty;
 
     // Not using Map constructor args because not supported in IE 11.
-    var map = new Map;
+    var map = new Map();
     map.set('a', 1);
     map.should.not.be.empty;
 
     err(function(){
-      (new Map).should.not.be.empty;
+      (new Map()).should.not.be.empty;
     }, "expected Map{} not to be empty");
 
-    map = new Map;
+    map = new Map();
     map.key = 'val';
     map.should.be.empty;
 
@@ -1323,18 +1323,18 @@ describe('should', function() {
       map.should.not.be.empty;
     }, "expected Map{} not to be empty");
 
-    (new Set).should.be.empty;
+    (new Set()).should.be.empty;
 
     // Not using Set constructor args because not supported in IE 11.
-    var set = new Set;
+    var set = new Set();
     set.add(1);
     set.should.not.be.empty;
 
     err(function(){
-      (new Set).should.not.be.empty;
+      (new Set()).should.not.be.empty;
     }, "expected Set{} not to be empty");
 
-    set = new Set;
+    set = new Set();
     set.key = 'val';
     set.should.be.empty;
 
@@ -1359,7 +1359,7 @@ describe('should', function() {
     }, "expected [ \'foo\' ] to be empty");
 
     err(function(){
-      (new FakeArgs).should.not.be.empty;
+      (new FakeArgs()).should.not.be.empty;
     }, "expected FakeArgs{} not to be empty");
 
     err(function(){

--- a/test/utilities.js
+++ b/test/utilities.js
@@ -750,8 +750,6 @@ describe('utilities', function () {
   });
 
   it('inspect Symbol', function () {
-    if (typeof Symbol !== 'function') return;
-
     chai.use(function (_chai, _) {
       expect(_.inspect(Symbol())).to.equal('Symbol()');
       expect(_.inspect(Symbol('cat'))).to.equal('Symbol(cat)');
@@ -759,8 +757,6 @@ describe('utilities', function () {
   });
 
   it('inspect BigInt', function () {
-    if (typeof BigInt !== 'function') return;
-
     chai.use(function (_chai, _) {
       expect(_.inspect(BigInt(0))).to.equal('0n');
       expect(_.inspect(BigInt(1234))).to.equal('1234n');
@@ -1089,11 +1085,9 @@ describe('utilities', function () {
       expect(cbi({'cat': [['dog', 1]]}, {'cat': [['dog', 2]]})).to.equal(-1);
       expect(cbi({'cat': [['dog', 2]]}, {'cat': [['dog', 1]]})).to.equal(1);
 
-      if (typeof Symbol === 'function') {
-        // "Symbol(c" is less than "Symbol(d"
-        expect(cbi(Symbol('cat'), Symbol('dog'))).to.equal(-1);
-        expect(cbi(Symbol('dog'), Symbol('cat'))).to.equal(1);
-      }
+      // "Symbol(c" is less than "Symbol(d"
+      expect(cbi(Symbol('cat'), Symbol('dog'))).to.equal(-1);
+      expect(cbi(Symbol('dog'), Symbol('cat'))).to.equal(1);
     });
   });
 
@@ -1116,8 +1110,6 @@ describe('utilities', function () {
     });
 
     it('returns enumerable symbols only', function () {
-      if (typeof Symbol !== 'function') return;
-
       var cat = Symbol('cat')
         , dog = Symbol('dog')
         , frog = Symbol('frog')
@@ -1165,8 +1157,6 @@ describe('utilities', function () {
     });
 
     it('returns enumerable property names and symbols', function () {
-      if (typeof Symbol !== 'function') return;
-
       var cat = Symbol('cat')
         , dog = Symbol('dog')
         , frog = Symbol('frog')
@@ -1193,8 +1183,6 @@ describe('utilities', function () {
   });
 
   describe('proxified object', function () {
-    if (typeof Proxy === 'undefined' || typeof Reflect === 'undefined') return;
-
     var proxify;
 
     beforeEach(function () {
@@ -1324,27 +1312,15 @@ describe('utilities', function () {
       chai.config.useProxy = origUseProxy;
     });
 
-    if (typeof Proxy !== 'undefined' && typeof Reflect !== 'undefined') {
-      it("returns true if Proxy and Reflect are defined, and useProxy is true", function () {
-        expect(isProxyEnabled()).to.be.true;
-      });
+    it("returns true if Proxy and Reflect are defined, and useProxy is true", function () {
+      expect(isProxyEnabled()).to.be.true;
+    });
 
-      it("returns false if Proxy and Reflect are defined, and useProxy is false", function () {
-        chai.config.useProxy = false;
+    it("returns false if Proxy and Reflect are defined, and useProxy is false", function () {
+      chai.config.useProxy = false;
 
-        expect(isProxyEnabled()).to.be.false;
-      });
-    } else {
-      it("returns false if Proxy and/or Reflect are undefined, and useProxy is true", function () {
-        expect(isProxyEnabled()).to.be.false;
-      });
-
-      it("returns false if Proxy and/or Reflect are undefined, and useProxy is false", function () {
-        chai.config.useProxy = false;
-
-        expect(isProxyEnabled()).to.be.false;
-      });
-    }
+      expect(isProxyEnabled()).to.be.false;
+    });
   });
 
   describe('getOperator', function() {


### PR DESCRIPTION
I thought I already done this but I guess not? These APIs should be supported in all environments that we test in so we can remove these guards. I also noticed that we don't have parentheses on some constructor calls so I added those.