### PR TITLE
Cleanup jsdoc comments

### DIFF
--- a/lib/chai/interface/assert.js
+++ b/lib/chai/interface/assert.js
@@ -17,7 +17,7 @@ import {AssertionError} from 'assertion-error';
  *     assert('foo' !== 'bar', 'foo is not bar');
  *     assert(Array.isArray([]), 'empty arrays are arrays');
  *
- * @param {Mixed} expression to test for truthiness
+ * @param {unknown} expression to test for truthiness
  * @param {String} message to display on error
  * @name assert
  * @namespace Assert
@@ -48,8 +48,8 @@ export {assert};
  *     assert.fail(1, 2, undefined, ">");
  *
  * @name fail
- * @param {Mixed} actual
- * @param {Mixed} expected
+ * @param {unknown} actual
+ * @param {unknown} expected
  * @param {String} message
  * @param {String} operator
  * @namespace Assert
@@ -81,7 +81,7 @@ assert.fail = function (actual, expected, message, operator) {
  *
  * @name isOk
  * @alias ok
- * @param {Mixed} object to test
+ * @param {unknown} object to test
  * @param {String} message
  * @namespace Assert
  * @public
@@ -100,7 +100,7 @@ assert.isOk = function (val, msg) {
  *
  * @name isNotOk
  * @alias notOk
- * @param {Mixed} object to test
+ * @param {unknown} object to test
  * @param {String} message
  * @namespace Assert
  * @public
@@ -117,8 +117,8 @@ assert.isNotOk = function (val, msg) {
  *     assert.equal(3, '3', '== coerces values to strings');
  *
  * @name equal
- * @param {Mixed} actual
- * @param {Mixed} expected
+ * @param {unknown} actual
+ * @param {unknown} expected
  * @param {String} message
  * @namespace Assert
  * @public
@@ -144,8 +144,8 @@ assert.equal = function (act, exp, msg) {
  *     assert.notEqual(3, 4, 'these numbers are not equal');
  *
  * @name notEqual
- * @param {Mixed} actual
- * @param {Mixed} expected
+ * @param {unknown} actual
+ * @param {unknown} expected
  * @param {String} message
  * @namespace Assert
  * @public
@@ -171,8 +171,8 @@ assert.notEqual = function (act, exp, msg) {
  *     assert.strictEqual(true, true, 'these booleans are strictly equal');
  *
  * @name strictEqual
- * @param {Mixed} actual
- * @param {Mixed} expected
+ * @param {unknown} actual
+ * @param {unknown} expected
  * @param {String} message
  * @namespace Assert
  * @public
@@ -189,8 +189,8 @@ assert.strictEqual = function (act, exp, msg) {
  *     assert.notStrictEqual(3, '3', 'no coercion for strict equality');
  *
  * @name notStrictEqual
- * @param {Mixed} actual
- * @param {Mixed} expected
+ * @param {unknown} actual
+ * @param {unknown} expected
  * @param {String} message
  * @namespace Assert
  * @public
@@ -207,8 +207,8 @@ assert.notStrictEqual = function (act, exp, msg) {
  *     assert.deepEqual({ tea: 'green' }, { tea: 'green' });
  *
  * @name deepEqual
- * @param {Mixed} actual
- * @param {Mixed} expected
+ * @param {unknown} actual
+ * @param {unknown} expected
  * @param {String} message
  * @alias deepStrictEqual
  * @namespace Assert
@@ -226,8 +226,8 @@ assert.deepEqual = assert.deepStrictEqual = function (act, exp, msg) {
  *     assert.notDeepEqual({ tea: 'green' }, { tea: 'jasmine' });
  *
  * @name notDeepEqual
- * @param {Mixed} actual
- * @param {Mixed} expected
+ * @param {unknown} actual
+ * @param {unknown} expected
  * @param {String} message
  * @namespace Assert
  * @public
@@ -244,8 +244,8 @@ assert.notDeepEqual = function (act, exp, msg) {
  *     assert.isAbove(5, 2, '5 is strictly greater than 2');
  *
  * @name isAbove
- * @param {Mixed} valueToCheck
- * @param {Mixed} valueToBeAbove
+ * @param {unknown} valueToCheck
+ * @param {unknown} valueToBeAbove
  * @param {String} message
  * @namespace Assert
  * @public
@@ -263,8 +263,8 @@ assert.isAbove = function (val, abv, msg) {
  *     assert.isAtLeast(3, 3, '3 is greater or equal to 3');
  *
  * @name isAtLeast
- * @param {Mixed} valueToCheck
- * @param {Mixed} valueToBeAtLeast
+ * @param {unknown} valueToCheck
+ * @param {unknown} valueToBeAtLeast
  * @param {String} message
  * @namespace Assert
  * @public
@@ -281,8 +281,8 @@ assert.isAtLeast = function (val, atlst, msg) {
  *     assert.isBelow(3, 6, '3 is strictly less than 6');
  *
  * @name isBelow
- * @param {Mixed} valueToCheck
- * @param {Mixed} valueToBeBelow
+ * @param {unknown} valueToCheck
+ * @param {unknown} valueToBeBelow
  * @param {String} message
  * @namespace Assert
  * @public
@@ -300,8 +300,8 @@ assert.isBelow = function (val, blw, msg) {
  *     assert.isAtMost(4, 4, '4 is less than or equal to 4');
  *
  * @name isAtMost
- * @param {Mixed} valueToCheck
- * @param {Mixed} valueToBeAtMost
+ * @param {unknown} valueToCheck
+ * @param {unknown} valueToBeAtMost
  * @param {String} message
  * @namespace Assert
  * @public
@@ -319,7 +319,7 @@ assert.isAtMost = function (val, atmst, msg) {
  *     assert.isTrue(teaServed, 'the tea has been served');
  *
  * @name isTrue
- * @param {Mixed} value
+ * @param {unknown} value
  * @param {String} message
  * @namespace Assert
  * @public
@@ -337,7 +337,7 @@ assert.isTrue = function (val, msg) {
  *     assert.isNotTrue(tea, 'great, time for tea!');
  *
  * @name isNotTrue
- * @param {Mixed} value
+ * @param {unknown} value
  * @param {String} message
  * @namespace Assert
  * @public
@@ -355,7 +355,7 @@ assert.isNotTrue = function (val, msg) {
  *     assert.isFalse(teaServed, 'no tea yet? hmm...');
  *
  * @name isFalse
- * @param {Mixed} value
+ * @param {unknown} value
  * @param {String} message
  * @namespace Assert
  * @public
@@ -373,7 +373,7 @@ assert.isFalse = function (val, msg) {
  *     assert.isNotFalse(tea, 'great, time for tea!');
  *
  * @name isNotFalse
- * @param {Mixed} value
+ * @param {unknown} value
  * @param {String} message
  * @namespace Assert
  * @public
@@ -390,7 +390,7 @@ assert.isNotFalse = function (val, msg) {
  *     assert.isNull(err, 'there was no error');
  *
  * @name isNull
- * @param {Mixed} value
+ * @param {unknown} value
  * @param {String} message
  * @namespace Assert
  * @public
@@ -408,7 +408,7 @@ assert.isNull = function (val, msg) {
  *     assert.isNotNull(tea, 'great, time for tea!');
  *
  * @name isNotNull
- * @param {Mixed} value
+ * @param {unknown} value
  * @param {String} message
  * @namespace Assert
  * @public
@@ -425,7 +425,7 @@ assert.isNotNull = function (val, msg) {
  *     assert.isNaN(NaN, 'NaN is NaN');
  *
  * @name isNaN
- * @param {Mixed} value
+ * @param {unknown} value
  * @param {String} message
  * @namespace Assert
  * @public
@@ -442,7 +442,7 @@ assert.isNaN = function (val, msg) {
  *     assert.isNotNaN(4, '4 is not NaN');
  *
  * @name isNotNaN
- * @param {Mixed} value
+ * @param {unknown} value
  * @param {String} message
  * @namespace Assert
  * @public
@@ -460,7 +460,7 @@ assert.isNaN = function (val, msg) {
  *     assert.exists(foo, 'foo is neither `null` nor `undefined`');
  *
  * @name exists
- * @param {Mixed} value
+ * @param {unknown} value
  * @param {String} message
  * @namespace Assert
  * @public
@@ -481,7 +481,7 @@ assert.exists = function (val, msg) {
  *     assert.notExists(baz, 'baz is either null or undefined');
  *
  * @name notExists
- * @param {Mixed} value
+ * @param {unknown} value
  * @param {String} message
  * @namespace Assert
  * @public
@@ -499,7 +499,7 @@ assert.notExists = function (val, msg) {
  *     assert.isUndefined(tea, 'no tea defined');
  *
  * @name isUndefined
- * @param {Mixed} value
+ * @param {unknown} value
  * @param {String} message
  * @namespace Assert
  * @public
@@ -517,7 +517,7 @@ assert.isUndefined = function (val, msg) {
  *     assert.isDefined(tea, 'tea has been defined');
  *
  * @name isDefined
- * @param {Mixed} value
+ * @param {unknown} value
  * @param {String} message
  * @namespace Assert
  * @public
@@ -535,7 +535,7 @@ assert.isDefined = function (val, msg) {
  *     assert.isCallable(serveTea, 'great, we can have tea now');
  *
  * @name isCallable
- * @param {Mixed} value
+ * @param {unknown} value
  * @param {String} message
  * @namespace Assert
  * @public
@@ -552,7 +552,7 @@ assert.isDefined = function (val, msg) {
  *     assert.isNotCallable(serveTea, 'great, we have listed the steps');
  *
  * @name isNotCallable
- * @param {Mixed} value
+ * @param {unknown} value
  * @param {String} message
  * @namespace Assert
  * @public
@@ -570,7 +570,7 @@ assert.isDefined = function (val, msg) {
  *     assert.isObject(selection, 'tea selection is an object');
  *
  * @name isObject
- * @param {Mixed} value
+ * @param {unknown} value
  * @param {String} message
  * @namespace Assert
  * @public
@@ -589,7 +589,7 @@ assert.isObject = function (val, msg) {
  *     assert.isNotObject(null, 'null is not an object');
  *
  * @name isNotObject
- * @param {Mixed} value
+ * @param {unknown} value
  * @param {String} message
  * @namespace Assert
  * @public
@@ -607,7 +607,7 @@ assert.isNotObject = function (val, msg) {
  *     assert.isArray(menu, 'what kind of tea do we want?');
  *
  * @name isArray
- * @param {Mixed} value
+ * @param {unknown} value
  * @param {String} message
  * @namespace Assert
  * @public
@@ -625,7 +625,7 @@ assert.isArray = function (val, msg) {
  *     assert.isNotArray(menu, 'what kind of tea do we want?');
  *
  * @name isNotArray
- * @param {Mixed} value
+ * @param {unknown} value
  * @param {String} message
  * @namespace Assert
  * @public
@@ -643,7 +643,7 @@ assert.isNotArray = function (val, msg) {
  *     assert.isString(teaOrder, 'order placed');
  *
  * @name isString
- * @param {Mixed} value
+ * @param {unknown} value
  * @param {String} message
  * @namespace Assert
  * @public
@@ -661,7 +661,7 @@ assert.isString = function (val, msg) {
  *     assert.isNotString(teaOrder, 'order placed');
  *
  * @name isNotString
- * @param {Mixed} value
+ * @param {unknown} value
  * @param {String} message
  * @namespace Assert
  * @public
@@ -697,7 +697,7 @@ assert.isNumber = function (val, msg) {
  *     assert.isNotNumber(cups, 'how many cups');
  *
  * @name isNotNumber
- * @param {Mixed} value
+ * @param {unknown} value
  * @param {String} message
  * @namespace Assert
  * @public
@@ -738,7 +738,7 @@ assert.isFinite = function (val, msg) {
  *     assert.isBoolean(teaServed, 'has tea been served');
  *
  * @name isBoolean
- * @param {Mixed} value
+ * @param {unknown} value
  * @param {String} message
  * @namespace Assert
  * @public
@@ -759,7 +759,7 @@ assert.isBoolean = function (val, msg) {
  *     assert.isNotBoolean(teaServed, 'has tea been served');
  *
  * @name isNotBoolean
- * @param {Mixed} value
+ * @param {unknown} value
  * @param {String} message
  * @namespace Assert
  * @public
@@ -782,7 +782,7 @@ assert.isNotBoolean = function (val, msg) {
  *     assert.typeOf(undefined, 'undefined', 'we have an undefined');
  *
  * @name typeOf
- * @param {Mixed} value
+ * @param {unknown} value
  * @param {String} name
  * @param {String} message
  * @namespace Assert
@@ -801,7 +801,7 @@ assert.typeOf = function (val, type, msg) {
  *     assert.notTypeOf('tea', 'number', 'strings are not numbers');
  *
  * @name notTypeOf
- * @param {Mixed} value
+ * @param {unknown} value
  * @param {String} typeof name
  * @param {String} message
  * @namespace Assert
@@ -879,7 +879,7 @@ assert.notInstanceOf = function (val, type, msg) {
  *
  * @name include
  * @param {Array|String} haystack
- * @param {Mixed} needle
+ * @param {unknown} needle
  * @param {String} message
  * @namespace Assert
  * @public
@@ -914,7 +914,7 @@ assert.include = function (exp, inc, msg) {
  *
  * @name notInclude
  * @param {Array|String} haystack
- * @param {Mixed} needle
+ * @param {unknown} needle
  * @param {String} message
  * @namespace Assert
  * @public
@@ -938,7 +938,7 @@ assert.notInclude = function (exp, inc, msg) {
  *
  * @name deepInclude
  * @param {Array|String} haystack
- * @param {Mixed} needle
+ * @param {unknown} needle
  * @param {String} message
  * @namespace Assert
  * @public
@@ -962,7 +962,7 @@ assert.deepInclude = function (exp, inc, msg) {
  *
  * @name notDeepInclude
  * @param {Array|String} haystack
- * @param {Mixed} needle
+ * @param {unknown} needle
  * @param {String} message
  * @namespace Assert
  * @public
@@ -1162,7 +1162,7 @@ assert.notDeepOwnInclude = function(exp, inc, msg) {
  *     assert.match('foobar', /^foo/, 'regexp matches');
  *
  * @name match
- * @param {Mixed} value
+ * @param {unknown} value
  * @param {RegExp} regexp
  * @param {String} message
  * @namespace Assert
@@ -1180,7 +1180,7 @@ assert.match = function (exp, re, msg) {
  *     assert.notMatch('foobar', /^foo/, 'regexp does not match');
  *
  * @name notMatch
- * @param {Mixed} value
+ * @param {unknown} value
  * @param {RegExp} regexp
  * @param {String} message
  * @namespace Assert
@@ -1242,7 +1242,7 @@ assert.notProperty = function (obj, prop, msg) {
  * @name propertyVal
  * @param {Object} object
  * @param {String} property
- * @param {Mixed} value
+ * @param {unknown} value
  * @param {String} message
  * @namespace Assert
  * @public
@@ -1265,7 +1265,7 @@ assert.propertyVal = function (obj, prop, val, msg) {
  * @name notPropertyVal
  * @param {Object} object
  * @param {String} property
- * @param {Mixed} value
+ * @param {unknown} value
  * @param {String} message
  * @namespace Assert
  * @public
@@ -1286,7 +1286,7 @@ assert.notPropertyVal = function (obj, prop, val, msg) {
  * @name deepPropertyVal
  * @param {Object} object
  * @param {String} property
- * @param {Mixed} value
+ * @param {unknown} value
  * @param {String} message
  * @namespace Assert
  * @public
@@ -1309,7 +1309,7 @@ assert.deepPropertyVal = function (obj, prop, val, msg) {
  * @name notDeepPropertyVal
  * @param {Object} object
  * @param {String} property
- * @param {Mixed} value
+ * @param {unknown} value
  * @param {String} message
  * @namespace Assert
  * @public
@@ -1370,7 +1370,7 @@ assert.notOwnProperty = function (obj, prop, msg) {
  * @name ownPropertyVal
  * @param {Object} object
  * @param {String} property
- * @param {Mixed} value
+ * @param {unknown} value
  * @param {String} message
  * @public
  */
@@ -1392,7 +1392,7 @@ assert.ownPropertyVal = function (obj, prop, value, msg) {
  * @name notOwnPropertyVal
  * @param {Object} object
  * @param {String} property
- * @param {Mixed} value
+ * @param {unknown} value
  * @param {String} message
  * @public
  */
@@ -1413,7 +1413,7 @@ assert.notOwnPropertyVal = function (obj, prop, value, msg) {
  * @name deepOwnPropertyVal
  * @param {Object} object
  * @param {String} property
- * @param {Mixed} value
+ * @param {unknown} value
  * @param {String} message
  * @public
  */
@@ -1437,7 +1437,7 @@ assert.deepOwnPropertyVal = function (obj, prop, value, msg) {
  * @name notDeepOwnPropertyVal
  * @param {Object} object
  * @param {String} property
- * @param {Mixed} value
+ * @param {unknown} value
  * @param {String} message
  * @public
  */
@@ -1500,7 +1500,7 @@ assert.notNestedProperty = function (obj, prop, msg) {
  * @name nestedPropertyVal
  * @param {Object} object
  * @param {String} property
- * @param {Mixed} value
+ * @param {unknown} value
  * @param {String} message
  * @namespace Assert
  * @public
@@ -1523,7 +1523,7 @@ assert.nestedPropertyVal = function (obj, prop, val, msg) {
  * @name notNestedPropertyVal
  * @param {Object} object
  * @param {String} property
- * @param {Mixed} value
+ * @param {unknown} value
  * @param {String} message
  * @namespace Assert
  * @public
@@ -1545,7 +1545,7 @@ assert.notNestedPropertyVal = function (obj, prop, val, msg) {
  * @name deepNestedPropertyVal
  * @param {Object} object
  * @param {String} property
- * @param {Mixed} value
+ * @param {unknown} value
  * @param {String} message
  * @namespace Assert
  * @public
@@ -1569,7 +1569,7 @@ assert.deepNestedPropertyVal = function (obj, prop, val, msg) {
  * @name notDeepNestedPropertyVal
  * @param {Object} object
  * @param {String} property
- * @param {Mixed} value
+ * @param {unknown} value
  * @param {String} message
  * @namespace Assert
  * @public
@@ -1590,7 +1590,7 @@ assert.notDeepNestedPropertyVal = function (obj, prop, val, msg) {
  *     assert.lengthOf(new Map([['a',1],['b',2],['c',3]]), 3, 'map has size of 3');
  *
  * @name lengthOf
- * @param {Mixed} object
+ * @param {unknown} object
  * @param {Number} length
  * @param {String} message
  * @namespace Assert
@@ -1613,7 +1613,7 @@ assert.lengthOf = function (exp, len, msg) {
  *     assert.hasAnyKeys(new Set([{foo: 'bar'}, 'anotherKey']), [{foo: 'bar'}, 'anotherKey']);
  *
  * @name hasAnyKeys
- * @param {Mixed} object
+ * @param {unknown} object
  * @param {Array|Object} keys
  * @param {String} message
  * @namespace Assert
@@ -1636,7 +1636,7 @@ assert.hasAnyKeys = function (obj, keys, msg) {
  *     assert.hasAllKeys(new Set([{foo: 'bar'}, 'anotherKey'], [{foo: 'bar'}, 'anotherKey']);
  *
  * @name hasAllKeys
- * @param {Mixed} object
+ * @param {unknown} object
  * @param {String[]} keys
  * @param {String} message
  * @namespace Assert
@@ -1663,7 +1663,7 @@ assert.hasAllKeys = function (obj, keys, msg) {
  *     assert.containsAllKeys(new Set([{foo: 'bar'}, 'anotherKey'], [{foo: 'bar'}, 'anotherKey']);
  *
  * @name containsAllKeys
- * @param {Mixed} object
+ * @param {unknown} object
  * @param {String[]} keys
  * @param {String} message
  * @namespace Assert
@@ -1687,7 +1687,7 @@ assert.containsAllKeys = function (obj, keys, msg) {
  *     assert.doesNotHaveAnyKeys(new Set([{foo: 'bar'}, 'anotherKey'], [{one: 'two'}, 'example']);
  *
  * @name doesNotHaveAnyKeys
- * @param {Mixed} object
+ * @param {unknown} object
  * @param {String[]} keys
  * @param {String} message
  * @namespace Assert
@@ -1711,7 +1711,7 @@ assert.doesNotHaveAnyKeys = function (obj, keys, msg) {
  *     assert.doesNotHaveAllKeys(new Set([{foo: 'bar'}, 'anotherKey'], [{one: 'two'}, 'example']);
  *
  * @name doesNotHaveAllKeys
- * @param {Mixed} object
+ * @param {unknown} object
  * @param {String[]} keys
  * @param {String} message
  * @namespace Assert
@@ -1739,7 +1739,7 @@ assert.doesNotHaveAllKeys = function (obj, keys, msg) {
  *     assert.hasAnyDeepKeys(new Set([{one: 'one'}, {two: 'two'}]), [{one: 'one'}, {two: 'two'}]);
  *
  * @name hasAnyDeepKeys
- * @param {Mixed} object
+ * @param {unknown} object
  * @param {Array|Object} keys
  * @param {String} message
  * @namespace Assert
@@ -1765,7 +1765,7 @@ assert.hasAnyDeepKeys = function (obj, keys, msg) {
  *     assert.hasAllDeepKeys(new Set([{one: 'one'}, {two: 'two'}]), [{one: 'one'}, {two: 'two'}]);
  *
  * @name hasAllDeepKeys
- * @param {Mixed} object
+ * @param {unknown} object
  * @param {Array|Object} keys
  * @param {String} message
  * @namespace Assert
@@ -1791,7 +1791,7 @@ assert.hasAllDeepKeys = function (obj, keys, msg) {
  *     assert.containsAllDeepKeys(new Set([{one: 'one'}, {two: 'two'}]), [{one: 'one'}, {two: 'two'}]);
  *
  * @name containsAllDeepKeys
- * @param {Mixed} object
+ * @param {unknown} object
  * @param {Array|Object} keys
  * @param {String} message
  * @namespace Assert
@@ -1817,7 +1817,7 @@ assert.containsAllDeepKeys = function (obj, keys, msg) {
  *     assert.doesNotHaveAnyDeepKeys(new Set([{one: 'one'}, {two: 'two'}]), [{twenty: 'twenty'}, {fifty: 'fifty'}]);
  *
  * @name doesNotHaveAnyDeepKeys
- * @param {Mixed} object
+ * @param {unknown} object
  * @param {Array|Object} keys
  * @param {String} message
  * @namespace Assert
@@ -1843,7 +1843,7 @@ assert.doesNotHaveAnyDeepKeys = function (obj, keys, msg) {
  *     assert.doesNotHaveAllDeepKeys(new Set([{one: 'one'}, {two: 'two'}]), [{one: 'one'}, {fifty: 'fifty'}]);
  *
  * @name doesNotHaveAllDeepKeys
- * @param {Mixed} object
+ * @param {unknown} object
  * @param {Array|Object} keys
  * @param {String} message
  * @namespace Assert
@@ -1942,9 +1942,9 @@ assert.doesNotThrow = function (fn, errorLike, errMsgMatcher, msg) {
  *     assert.operator(1, '>', 2, 'this will fail');
  *
  * @name operator
- * @param {Mixed} val1
+ * @param {unknown} val1
  * @param {String} operator
- * @param {Mixed} val2
+ * @param {unknown} val2
  * @param {String} message
  * @namespace Assert
  * @public

--- a/lib/chai/interface/assert.js
+++ b/lib/chai/interface/assert.js
@@ -8,7 +8,6 @@ import * as chai from '../../../index.js';
 import {Assertion} from '../assertion.js';
 import {flag, inspect} from '../utils/index.js';
 import {AssertionError} from 'assertion-error';
-import {type} from '../utils/type-detect.js';
 
 /**
  * ### assert(expression, message)

--- a/lib/chai/interface/assert.js
+++ b/lib/chai/interface/assert.js
@@ -21,7 +21,7 @@ import {AssertionError} from 'assertion-error';
  * @param {String} message to display on error
  * @name assert
  * @namespace Assert
- * @api public
+ * @public
  */
 
 function assert(express, errmsg) {
@@ -54,7 +54,7 @@ export {assert};
  * @param {String} message
  * @param {String} operator
  * @namespace Assert
- * @api public
+ * @public
  */
 
 assert.fail = function (actual, expected, message, operator) {
@@ -86,7 +86,7 @@ assert.fail = function (actual, expected, message, operator) {
  * @param {Mixed} object to test
  * @param {String} message
  * @namespace Assert
- * @api public
+ * @public
  */
 
 assert.isOk = function (val, msg) {
@@ -106,7 +106,7 @@ assert.isOk = function (val, msg) {
  * @param {Mixed} object to test
  * @param {String} message
  * @namespace Assert
- * @api public
+ * @public
  */
 
 assert.isNotOk = function (val, msg) {
@@ -125,7 +125,7 @@ assert.isNotOk = function (val, msg) {
  * @param {Mixed} expected
  * @param {String} message
  * @namespace Assert
- * @api public
+ * @public
  */
 
 assert.equal = function (act, exp, msg) {
@@ -153,7 +153,7 @@ assert.equal = function (act, exp, msg) {
  * @param {Mixed} expected
  * @param {String} message
  * @namespace Assert
- * @api public
+ * @public
  */
 
 assert.notEqual = function (act, exp, msg) {
@@ -181,7 +181,7 @@ assert.notEqual = function (act, exp, msg) {
  * @param {Mixed} expected
  * @param {String} message
  * @namespace Assert
- * @api public
+ * @public
  */
 
 assert.strictEqual = function (act, exp, msg) {
@@ -200,7 +200,7 @@ assert.strictEqual = function (act, exp, msg) {
  * @param {Mixed} expected
  * @param {String} message
  * @namespace Assert
- * @api public
+ * @public
  */
 
 assert.notStrictEqual = function (act, exp, msg) {
@@ -220,7 +220,7 @@ assert.notStrictEqual = function (act, exp, msg) {
  * @param {String} message
  * @alias deepStrictEqual
  * @namespace Assert
- * @api public
+ * @public
  */
 
 assert.deepEqual = assert.deepStrictEqual = function (act, exp, msg) {
@@ -239,7 +239,7 @@ assert.deepEqual = assert.deepStrictEqual = function (act, exp, msg) {
  * @param {Mixed} expected
  * @param {String} message
  * @namespace Assert
- * @api public
+ * @public
  */
 
 assert.notDeepEqual = function (act, exp, msg) {
@@ -258,7 +258,7 @@ assert.notDeepEqual = function (act, exp, msg) {
  * @param {Mixed} valueToBeAbove
  * @param {String} message
  * @namespace Assert
- * @api public
+ * @public
  */
 
 assert.isAbove = function (val, abv, msg) {
@@ -278,7 +278,7 @@ assert.isAbove = function (val, abv, msg) {
  * @param {Mixed} valueToBeAtLeast
  * @param {String} message
  * @namespace Assert
- * @api public
+ * @public
  */
 
 assert.isAtLeast = function (val, atlst, msg) {
@@ -297,7 +297,7 @@ assert.isAtLeast = function (val, atlst, msg) {
  * @param {Mixed} valueToBeBelow
  * @param {String} message
  * @namespace Assert
- * @api public
+ * @public
  */
 
 assert.isBelow = function (val, blw, msg) {
@@ -317,7 +317,7 @@ assert.isBelow = function (val, blw, msg) {
  * @param {Mixed} valueToBeAtMost
  * @param {String} message
  * @namespace Assert
- * @api public
+ * @public
  */
 
 assert.isAtMost = function (val, atmst, msg) {
@@ -336,7 +336,7 @@ assert.isAtMost = function (val, atmst, msg) {
  * @param {Mixed} value
  * @param {String} message
  * @namespace Assert
- * @api public
+ * @public
  */
 
 assert.isTrue = function (val, msg) {
@@ -355,7 +355,7 @@ assert.isTrue = function (val, msg) {
  * @param {Mixed} value
  * @param {String} message
  * @namespace Assert
- * @api public
+ * @public
  */
 
 assert.isNotTrue = function (val, msg) {
@@ -374,7 +374,7 @@ assert.isNotTrue = function (val, msg) {
  * @param {Mixed} value
  * @param {String} message
  * @namespace Assert
- * @api public
+ * @public
  */
 
 assert.isFalse = function (val, msg) {
@@ -393,7 +393,7 @@ assert.isFalse = function (val, msg) {
  * @param {Mixed} value
  * @param {String} message
  * @namespace Assert
- * @api public
+ * @public
  */
 
 assert.isNotFalse = function (val, msg) {
@@ -411,7 +411,7 @@ assert.isNotFalse = function (val, msg) {
  * @param {Mixed} value
  * @param {String} message
  * @namespace Assert
- * @api public
+ * @public
  */
 
 assert.isNull = function (val, msg) {
@@ -430,7 +430,7 @@ assert.isNull = function (val, msg) {
  * @param {Mixed} value
  * @param {String} message
  * @namespace Assert
- * @api public
+ * @public
  */
 
 assert.isNotNull = function (val, msg) {
@@ -448,7 +448,7 @@ assert.isNotNull = function (val, msg) {
  * @param {Mixed} value
  * @param {String} message
  * @namespace Assert
- * @api public
+ * @public
  */
 
 assert.isNaN = function (val, msg) {
@@ -466,7 +466,7 @@ assert.isNaN = function (val, msg) {
  * @param {Mixed} value
  * @param {String} message
  * @namespace Assert
- * @api public
+ * @public
  */
 assert.isNotNaN = function (val, msg) {
   new Assertion(val, msg, assert.isNotNaN, true).not.to.be.NaN;
@@ -485,7 +485,7 @@ assert.isNotNaN = function (val, msg) {
  * @param {Mixed} value
  * @param {String} message
  * @namespace Assert
- * @api public
+ * @public
  */
 
 assert.exists = function (val, msg) {
@@ -507,7 +507,7 @@ assert.exists = function (val, msg) {
  * @param {Mixed} value
  * @param {String} message
  * @namespace Assert
- * @api public
+ * @public
  */
 
 assert.notExists = function (val, msg) {
@@ -526,7 +526,7 @@ assert.notExists = function (val, msg) {
  * @param {Mixed} value
  * @param {String} message
  * @namespace Assert
- * @api public
+ * @public
  */
 
 assert.isUndefined = function (val, msg) {
@@ -545,7 +545,7 @@ assert.isUndefined = function (val, msg) {
  * @param {Mixed} value
  * @param {String} message
  * @namespace Assert
- * @api public
+ * @public
  */
 
 assert.isDefined = function (val, msg) {
@@ -564,7 +564,7 @@ assert.isDefined = function (val, msg) {
  * @param {Mixed} value
  * @param {String} message
  * @namespace Assert
- * @api public
+ * @public
  */
 assert.isCallable = function (val, msg) {
   new Assertion(val, msg, assert.isCallable, true).is.callable;
@@ -582,7 +582,7 @@ assert.isCallable = function (val, msg) {
  * @param {Mixed} value
  * @param {String} message
  * @namespace Assert
- * @api public
+ * @public
  */
 assert.isNotCallable = function (val, msg) {
   new Assertion(val, msg, assert.isNotCallable, true).is.not.callable;
@@ -601,7 +601,7 @@ assert.isNotCallable = function (val, msg) {
  * @param {Mixed} value
  * @param {String} message
  * @namespace Assert
- * @api public
+ * @public
  */
 
 assert.isObject = function (val, msg) {
@@ -621,7 +621,7 @@ assert.isObject = function (val, msg) {
  * @param {Mixed} value
  * @param {String} message
  * @namespace Assert
- * @api public
+ * @public
  */
 
 assert.isNotObject = function (val, msg) {
@@ -640,7 +640,7 @@ assert.isNotObject = function (val, msg) {
  * @param {Mixed} value
  * @param {String} message
  * @namespace Assert
- * @api public
+ * @public
  */
 
 assert.isArray = function (val, msg) {
@@ -659,7 +659,7 @@ assert.isArray = function (val, msg) {
  * @param {Mixed} value
  * @param {String} message
  * @namespace Assert
- * @api public
+ * @public
  */
 
 assert.isNotArray = function (val, msg) {
@@ -678,7 +678,7 @@ assert.isNotArray = function (val, msg) {
  * @param {Mixed} value
  * @param {String} message
  * @namespace Assert
- * @api public
+ * @public
  */
 
 assert.isString = function (val, msg) {
@@ -697,7 +697,7 @@ assert.isString = function (val, msg) {
  * @param {Mixed} value
  * @param {String} message
  * @namespace Assert
- * @api public
+ * @public
  */
 
 assert.isNotString = function (val, msg) {
@@ -716,7 +716,7 @@ assert.isNotString = function (val, msg) {
  * @param {Number} value
  * @param {String} message
  * @namespace Assert
- * @api public
+ * @public
  */
 
 assert.isNumber = function (val, msg) {
@@ -735,7 +735,7 @@ assert.isNumber = function (val, msg) {
  * @param {Mixed} value
  * @param {String} message
  * @namespace Assert
- * @api public
+ * @public
  */
 
 assert.isNotNumber = function (val, msg) {
@@ -756,7 +756,7 @@ assert.isNotNumber = function (val, msg) {
  * @param {Number} value
  * @param {String} message
  * @namespace Assert
- * @api public
+ * @public
  */
 
 assert.isFinite = function (val, msg) {
@@ -778,7 +778,7 @@ assert.isFinite = function (val, msg) {
  * @param {Mixed} value
  * @param {String} message
  * @namespace Assert
- * @api public
+ * @public
  */
 
 assert.isBoolean = function (val, msg) {
@@ -800,7 +800,7 @@ assert.isBoolean = function (val, msg) {
  * @param {Mixed} value
  * @param {String} message
  * @namespace Assert
- * @api public
+ * @public
  */
 
 assert.isNotBoolean = function (val, msg) {
@@ -825,7 +825,7 @@ assert.isNotBoolean = function (val, msg) {
  * @param {String} name
  * @param {String} message
  * @namespace Assert
- * @api public
+ * @public
  */
 
 assert.typeOf = function (val, type, msg) {
@@ -845,7 +845,7 @@ assert.typeOf = function (val, type, msg) {
  * @param {String} typeof name
  * @param {String} message
  * @namespace Assert
- * @api public
+ * @public
  */
 
 assert.notTypeOf = function (val, type, msg) {
@@ -867,7 +867,7 @@ assert.notTypeOf = function (val, type, msg) {
  * @param {Constructor} constructor
  * @param {String} message
  * @namespace Assert
- * @api public
+ * @public
  */
 
 assert.instanceOf = function (val, type, msg) {
@@ -889,7 +889,7 @@ assert.instanceOf = function (val, type, msg) {
  * @param {Constructor} constructor
  * @param {String} message
  * @namespace Assert
- * @api public
+ * @public
  */
 
 assert.notInstanceOf = function (val, type, msg) {
@@ -925,7 +925,7 @@ assert.notInstanceOf = function (val, type, msg) {
  * @param {Mixed} needle
  * @param {String} message
  * @namespace Assert
- * @api public
+ * @public
  */
 
 assert.include = function (exp, inc, msg) {
@@ -961,7 +961,7 @@ assert.include = function (exp, inc, msg) {
  * @param {Mixed} needle
  * @param {String} message
  * @namespace Assert
- * @api public
+ * @public
  */
 
 assert.notInclude = function (exp, inc, msg) {
@@ -986,7 +986,7 @@ assert.notInclude = function (exp, inc, msg) {
  * @param {Mixed} needle
  * @param {String} message
  * @namespace Assert
- * @api public
+ * @public
  */
 
 assert.deepInclude = function (exp, inc, msg) {
@@ -1011,7 +1011,7 @@ assert.deepInclude = function (exp, inc, msg) {
  * @param {Mixed} needle
  * @param {String} message
  * @namespace Assert
- * @api public
+ * @public
  */
 
 assert.notDeepInclude = function (exp, inc, msg) {
@@ -1036,7 +1036,7 @@ assert.notDeepInclude = function (exp, inc, msg) {
  * @param {Object} needle
  * @param {String} message
  * @namespace Assert
- * @api public
+ * @public
  */
 
 assert.nestedInclude = function (exp, inc, msg) {
@@ -1061,7 +1061,7 @@ assert.nestedInclude = function (exp, inc, msg) {
  * @param {Object} needle
  * @param {String} message
  * @namespace Assert
- * @api public
+ * @public
  */
 
 assert.notNestedInclude = function (exp, inc, msg) {
@@ -1087,7 +1087,7 @@ assert.notNestedInclude = function (exp, inc, msg) {
  * @param {Object} needle
  * @param {String} message
  * @namespace Assert
- * @api public
+ * @public
  */
 
 assert.deepNestedInclude = function(exp, inc, msg) {
@@ -1113,7 +1113,7 @@ assert.deepNestedInclude = function(exp, inc, msg) {
  * @param {Object} needle
  * @param {String} message
  * @namespace Assert
- * @api public
+ * @public
  */
 
 assert.notDeepNestedInclude = function(exp, inc, msg) {
@@ -1135,7 +1135,7 @@ assert.notDeepNestedInclude = function(exp, inc, msg) {
  * @param {Object} needle
  * @param {String} message
  * @namespace Assert
- * @api public
+ * @public
  */
 
 assert.ownInclude = function(exp, inc, msg) {
@@ -1158,7 +1158,7 @@ assert.ownInclude = function(exp, inc, msg) {
  * @param {Object} needle
  * @param {String} message
  * @namespace Assert
- * @api public
+ * @public
  */
 
 assert.notOwnInclude = function(exp, inc, msg) {
@@ -1179,7 +1179,7 @@ assert.notOwnInclude = function(exp, inc, msg) {
  * @param {Object} needle
  * @param {String} message
  * @namespace Assert
- * @api public
+ * @public
  */
 
 assert.deepOwnInclude = function(exp, inc, msg) {
@@ -1201,7 +1201,7 @@ assert.deepOwnInclude = function(exp, inc, msg) {
  * @param {Object} needle
  * @param {String} message
  * @namespace Assert
- * @api public
+ * @public
  */
 
 assert.notDeepOwnInclude = function(exp, inc, msg) {
@@ -1221,7 +1221,7 @@ assert.notDeepOwnInclude = function(exp, inc, msg) {
  * @param {RegExp} regexp
  * @param {String} message
  * @namespace Assert
- * @api public
+ * @public
  */
 
 assert.match = function (exp, re, msg) {
@@ -1240,7 +1240,7 @@ assert.match = function (exp, re, msg) {
  * @param {RegExp} regexp
  * @param {String} message
  * @namespace Assert
- * @api public
+ * @public
  */
 
 assert.notMatch = function (exp, re, msg) {
@@ -1261,7 +1261,7 @@ assert.notMatch = function (exp, re, msg) {
  * @param {String} property
  * @param {String} message
  * @namespace Assert
- * @api public
+ * @public
  */
 
 assert.property = function (obj, prop, msg) {
@@ -1281,7 +1281,7 @@ assert.property = function (obj, prop, msg) {
  * @param {String} property
  * @param {String} message
  * @namespace Assert
- * @api public
+ * @public
  */
 
 assert.notProperty = function (obj, prop, msg) {
@@ -1304,7 +1304,7 @@ assert.notProperty = function (obj, prop, msg) {
  * @param {Mixed} value
  * @param {String} message
  * @namespace Assert
- * @api public
+ * @public
  */
 
 assert.propertyVal = function (obj, prop, val, msg) {
@@ -1328,7 +1328,7 @@ assert.propertyVal = function (obj, prop, val, msg) {
  * @param {Mixed} value
  * @param {String} message
  * @namespace Assert
- * @api public
+ * @public
  */
 
 assert.notPropertyVal = function (obj, prop, val, msg) {
@@ -1350,7 +1350,7 @@ assert.notPropertyVal = function (obj, prop, val, msg) {
  * @param {Mixed} value
  * @param {String} message
  * @namespace Assert
- * @api public
+ * @public
  */
 
 assert.deepPropertyVal = function (obj, prop, val, msg) {
@@ -1374,7 +1374,7 @@ assert.deepPropertyVal = function (obj, prop, val, msg) {
  * @param {Mixed} value
  * @param {String} message
  * @namespace Assert
- * @api public
+ * @public
  */
 
 assert.notDeepPropertyVal = function (obj, prop, val, msg) {
@@ -1394,7 +1394,7 @@ assert.notDeepPropertyVal = function (obj, prop, val, msg) {
  * @param {Object} object
  * @param {String} property
  * @param {String} message
- * @api public
+ * @public
  */
 
 assert.ownProperty = function (obj, prop, msg) {
@@ -1415,7 +1415,7 @@ assert.ownProperty = function (obj, prop, msg) {
  * @param {Object} object
  * @param {String} property
  * @param {String} message
- * @api public
+ * @public
  */
 
 assert.notOwnProperty = function (obj, prop, msg) {
@@ -1437,7 +1437,7 @@ assert.notOwnProperty = function (obj, prop, msg) {
  * @param {String} property
  * @param {Mixed} value
  * @param {String} message
- * @api public
+ * @public
  */
 
 assert.ownPropertyVal = function (obj, prop, value, msg) {
@@ -1460,7 +1460,7 @@ assert.ownPropertyVal = function (obj, prop, value, msg) {
  * @param {String} property
  * @param {Mixed} value
  * @param {String} message
- * @api public
+ * @public
  */
 
 assert.notOwnPropertyVal = function (obj, prop, value, msg) {
@@ -1482,7 +1482,7 @@ assert.notOwnPropertyVal = function (obj, prop, value, msg) {
  * @param {String} property
  * @param {Mixed} value
  * @param {String} message
- * @api public
+ * @public
  */
 
 assert.deepOwnPropertyVal = function (obj, prop, value, msg) {
@@ -1507,7 +1507,7 @@ assert.deepOwnPropertyVal = function (obj, prop, value, msg) {
  * @param {String} property
  * @param {Mixed} value
  * @param {String} message
- * @api public
+ * @public
  */
 
 assert.notDeepOwnPropertyVal = function (obj, prop, value, msg) {
@@ -1529,7 +1529,7 @@ assert.notDeepOwnPropertyVal = function (obj, prop, value, msg) {
  * @param {String} property
  * @param {String} message
  * @namespace Assert
- * @api public
+ * @public
  */
 
 assert.nestedProperty = function (obj, prop, msg) {
@@ -1551,7 +1551,7 @@ assert.nestedProperty = function (obj, prop, msg) {
  * @param {String} property
  * @param {String} message
  * @namespace Assert
- * @api public
+ * @public
  */
 
 assert.notNestedProperty = function (obj, prop, msg) {
@@ -1574,7 +1574,7 @@ assert.notNestedProperty = function (obj, prop, msg) {
  * @param {Mixed} value
  * @param {String} message
  * @namespace Assert
- * @api public
+ * @public
  */
 
 assert.nestedPropertyVal = function (obj, prop, val, msg) {
@@ -1598,7 +1598,7 @@ assert.nestedPropertyVal = function (obj, prop, val, msg) {
  * @param {Mixed} value
  * @param {String} message
  * @namespace Assert
- * @api public
+ * @public
  */
 
 assert.notNestedPropertyVal = function (obj, prop, val, msg) {
@@ -1621,7 +1621,7 @@ assert.notNestedPropertyVal = function (obj, prop, val, msg) {
  * @param {Mixed} value
  * @param {String} message
  * @namespace Assert
- * @api public
+ * @public
  */
 
 assert.deepNestedPropertyVal = function (obj, prop, val, msg) {
@@ -1646,7 +1646,7 @@ assert.deepNestedPropertyVal = function (obj, prop, val, msg) {
  * @param {Mixed} value
  * @param {String} message
  * @namespace Assert
- * @api public
+ * @public
  */
 
 assert.notDeepNestedPropertyVal = function (obj, prop, val, msg) {
@@ -1669,7 +1669,7 @@ assert.notDeepNestedPropertyVal = function (obj, prop, val, msg) {
  * @param {Number} length
  * @param {String} message
  * @namespace Assert
- * @api public
+ * @public
  */
 
 assert.lengthOf = function (exp, len, msg) {
@@ -1693,7 +1693,7 @@ assert.lengthOf = function (exp, len, msg) {
  * @param {Array|Object} keys
  * @param {String} message
  * @namespace Assert
- * @api public
+ * @public
  */
 
 assert.hasAnyKeys = function (obj, keys, msg) {
@@ -1717,7 +1717,7 @@ assert.hasAnyKeys = function (obj, keys, msg) {
  * @param {String[]} keys
  * @param {String} message
  * @namespace Assert
- * @api public
+ * @public
  */
 
 assert.hasAllKeys = function (obj, keys, msg) {
@@ -1745,7 +1745,7 @@ assert.hasAllKeys = function (obj, keys, msg) {
  * @param {String[]} keys
  * @param {String} message
  * @namespace Assert
- * @api public
+ * @public
  */
 
 assert.containsAllKeys = function (obj, keys, msg) {
@@ -1770,7 +1770,7 @@ assert.containsAllKeys = function (obj, keys, msg) {
  * @param {String[]} keys
  * @param {String} message
  * @namespace Assert
- * @api public
+ * @public
  */
 
 assert.doesNotHaveAnyKeys = function (obj, keys, msg) {
@@ -1795,7 +1795,7 @@ assert.doesNotHaveAnyKeys = function (obj, keys, msg) {
  * @param {String[]} keys
  * @param {String} message
  * @namespace Assert
- * @api public
+ * @public
  */
 
 assert.doesNotHaveAllKeys = function (obj, keys, msg) {
@@ -1824,7 +1824,7 @@ assert.doesNotHaveAllKeys = function (obj, keys, msg) {
  * @param {Array|Object} keys
  * @param {String} message
  * @namespace Assert
- * @api public
+ * @public
  */
 
 assert.hasAnyDeepKeys = function (obj, keys, msg) {
@@ -1851,7 +1851,7 @@ assert.hasAnyDeepKeys = function (obj, keys, msg) {
  * @param {Array|Object} keys
  * @param {String} message
  * @namespace Assert
- * @api public
+ * @public
  */
 
 assert.hasAllDeepKeys = function (obj, keys, msg) {
@@ -1878,7 +1878,7 @@ assert.hasAllDeepKeys = function (obj, keys, msg) {
  * @param {Array|Object} keys
  * @param {String} message
  * @namespace Assert
- * @api public
+ * @public
  */
 
 assert.containsAllDeepKeys = function (obj, keys, msg) {
@@ -1905,7 +1905,7 @@ assert.containsAllDeepKeys = function (obj, keys, msg) {
  * @param {Array|Object} keys
  * @param {String} message
  * @namespace Assert
- * @api public
+ * @public
  */
 
 assert.doesNotHaveAnyDeepKeys = function (obj, keys, msg) {
@@ -1932,7 +1932,7 @@ assert.doesNotHaveAnyDeepKeys = function (obj, keys, msg) {
  * @param {Array|Object} keys
  * @param {String} message
  * @namespace Assert
- * @api public
+ * @public
  */
 
 assert.doesNotHaveAllDeepKeys = function (obj, keys, msg) {
@@ -1968,7 +1968,7 @@ assert.doesNotHaveAllDeepKeys = function (obj, keys, msg) {
  * @param {String} message
  * @see https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Error#Error_types
  * @namespace Assert
- * @api public
+ * @public
  */
 
 assert.throws = function (fn, errorLike, errMsgMatcher, msg) {
@@ -2008,7 +2008,7 @@ assert.throws = function (fn, errorLike, errMsgMatcher, msg) {
  * @param {String} message
  * @see https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Error#Error_types
  * @namespace Assert
- * @api public
+ * @public
  */
 
 assert.doesNotThrow = function (fn, errorLike, errMsgMatcher, msg) {
@@ -2035,7 +2035,7 @@ assert.doesNotThrow = function (fn, errorLike, errMsgMatcher, msg) {
  * @param {Mixed} val2
  * @param {String} message
  * @namespace Assert
- * @api public
+ * @public
  */
 
 assert.operator = function (val, operator, val2, msg) {
@@ -2093,7 +2093,7 @@ assert.operator = function (val, operator, val2, msg) {
  * @param {Number} delta
  * @param {String} message
  * @namespace Assert
- * @api public
+ * @public
  */
 
 assert.closeTo = function (act, exp, delta, msg) {
@@ -2113,7 +2113,7 @@ assert.closeTo = function (act, exp, delta, msg) {
  * @param {Number} delta
  * @param {String} message
  * @namespace Assert
- * @api public
+ * @public
  */
 
 assert.approximately = function (act, exp, delta, msg) {
@@ -2134,7 +2134,7 @@ assert.approximately = function (act, exp, delta, msg) {
  * @param {Array} set2
  * @param {String} message
  * @namespace Assert
- * @api public
+ * @public
  */
 
 assert.sameMembers = function (set1, set2, msg) {
@@ -2155,7 +2155,7 @@ assert.sameMembers = function (set1, set2, msg) {
  * @param {Array} set2
  * @param {String} message
  * @namespace Assert
- * @api public
+ * @public
  */
 
 assert.notSameMembers = function (set1, set2, msg) {
@@ -2176,7 +2176,7 @@ assert.notSameMembers = function (set1, set2, msg) {
  * @param {Array} set2
  * @param {String} message
  * @namespace Assert
- * @api public
+ * @public
  */
 
 assert.sameDeepMembers = function (set1, set2, msg) {
@@ -2197,7 +2197,7 @@ assert.sameDeepMembers = function (set1, set2, msg) {
  * @param {Array} set2
  * @param {String} message
  * @namespace Assert
- * @api public
+ * @public
  */
 
 assert.notSameDeepMembers = function (set1, set2, msg) {
@@ -2218,7 +2218,7 @@ assert.notSameDeepMembers = function (set1, set2, msg) {
  * @param {Array} set2
  * @param {String} message
  * @namespace Assert
- * @api public
+ * @public
  */
 
 assert.sameOrderedMembers = function (set1, set2, msg) {
@@ -2239,7 +2239,7 @@ assert.sameOrderedMembers = function (set1, set2, msg) {
  * @param {Array} set2
  * @param {String} message
  * @namespace Assert
- * @api public
+ * @public
  */
 
 assert.notSameOrderedMembers = function (set1, set2, msg) {
@@ -2260,7 +2260,7 @@ assert.notSameOrderedMembers = function (set1, set2, msg) {
  * @param {Array} set2
  * @param {String} message
  * @namespace Assert
- * @api public
+ * @public
  */
 
 assert.sameDeepOrderedMembers = function (set1, set2, msg) {
@@ -2282,7 +2282,7 @@ assert.sameDeepOrderedMembers = function (set1, set2, msg) {
  * @param {Array} set2
  * @param {String} message
  * @namespace Assert
- * @api public
+ * @public
  */
 
 assert.notSameDeepOrderedMembers = function (set1, set2, msg) {
@@ -2303,7 +2303,7 @@ assert.notSameDeepOrderedMembers = function (set1, set2, msg) {
  * @param {Array} subset
  * @param {String} message
  * @namespace Assert
- * @api public
+ * @public
  */
 
 assert.includeMembers = function (superset, subset, msg) {
@@ -2324,7 +2324,7 @@ assert.includeMembers = function (superset, subset, msg) {
  * @param {Array} subset
  * @param {String} message
  * @namespace Assert
- * @api public
+ * @public
  */
 
 assert.notIncludeMembers = function (superset, subset, msg) {
@@ -2345,7 +2345,7 @@ assert.notIncludeMembers = function (superset, subset, msg) {
  * @param {Array} subset
  * @param {String} message
  * @namespace Assert
- * @api public
+ * @public
  */
 
 assert.includeDeepMembers = function (superset, subset, msg) {
@@ -2366,7 +2366,7 @@ assert.includeDeepMembers = function (superset, subset, msg) {
  * @param {Array} subset
  * @param {String} message
  * @namespace Assert
- * @api public
+ * @public
  */
 
 assert.notIncludeDeepMembers = function (superset, subset, msg) {
@@ -2388,7 +2388,7 @@ assert.notIncludeDeepMembers = function (superset, subset, msg) {
  * @param {Array} subset
  * @param {String} message
  * @namespace Assert
- * @api public
+ * @public
  */
 
 assert.includeOrderedMembers = function (superset, subset, msg) {
@@ -2411,7 +2411,7 @@ assert.includeOrderedMembers = function (superset, subset, msg) {
  * @param {Array} subset
  * @param {String} message
  * @namespace Assert
- * @api public
+ * @public
  */
 
 assert.notIncludeOrderedMembers = function (superset, subset, msg) {
@@ -2433,7 +2433,7 @@ assert.notIncludeOrderedMembers = function (superset, subset, msg) {
  * @param {Array} subset
  * @param {String} message
  * @namespace Assert
- * @api public
+ * @public
  */
 
 assert.includeDeepOrderedMembers = function (superset, subset, msg) {
@@ -2457,7 +2457,7 @@ assert.includeDeepOrderedMembers = function (superset, subset, msg) {
  * @param {Array} subset
  * @param {String} message
  * @namespace Assert
- * @api public
+ * @public
  */
 
 assert.notIncludeDeepOrderedMembers = function (superset, subset, msg) {
@@ -2477,7 +2477,7 @@ assert.notIncludeDeepOrderedMembers = function (superset, subset, msg) {
  * @param {Array<*>} list
  * @param {String} message
  * @namespace Assert
- * @api public
+ * @public
  */
 
 assert.oneOf = function (inList, list, msg) {
@@ -2499,7 +2499,7 @@ assert.oneOf = function (inList, list, msg) {
  * @param {String} property name _optional_
  * @param {String} message _optional_
  * @namespace Assert
- * @api public
+ * @public
  */
 
 assert.changes = function (fn, obj, prop, msg) {
@@ -2527,7 +2527,7 @@ assert.changes = function (fn, obj, prop, msg) {
  * @param {Number} change amount (delta)
  * @param {String} message _optional_
  * @namespace Assert
- * @api public
+ * @public
  */
 
 assert.changesBy = function (fn, obj, prop, delta, msg) {
@@ -2559,7 +2559,7 @@ assert.changesBy = function (fn, obj, prop, delta, msg) {
  * @param {String} property name _optional_
  * @param {String} message _optional_
  * @namespace Assert
- * @api public
+ * @public
  */
 
 assert.doesNotChange = function (fn, obj, prop, msg) {
@@ -2588,7 +2588,7 @@ assert.doesNotChange = function (fn, obj, prop, msg) {
  * @param {Number} change amount (delta)
  * @param {String} message _optional_
  * @namespace Assert
- * @api public
+ * @public
  */
 
 assert.changesButNotBy = function (fn, obj, prop, delta, msg) {
@@ -2620,7 +2620,7 @@ assert.changesButNotBy = function (fn, obj, prop, delta, msg) {
  * @param {String} property name _optional_
  * @param {String} message _optional_
  * @namespace Assert
- * @api public
+ * @public
  */
 
 assert.increases = function (fn, obj, prop, msg) {
@@ -2649,7 +2649,7 @@ assert.increases = function (fn, obj, prop, msg) {
  * @param {Number} change amount (delta)
  * @param {String} message _optional_
  * @namespace Assert
- * @api public
+ * @public
  */
 
 assert.increasesBy = function (fn, obj, prop, delta, msg) {
@@ -2681,7 +2681,7 @@ assert.increasesBy = function (fn, obj, prop, delta, msg) {
  * @param {String} property name _optional_
  * @param {String} message _optional_
  * @namespace Assert
- * @api public
+ * @public
  */
 
 assert.doesNotIncrease = function (fn, obj, prop, msg) {
@@ -2710,7 +2710,7 @@ assert.doesNotIncrease = function (fn, obj, prop, msg) {
  * @param {Number} change amount (delta)
  * @param {String} message _optional_
  * @namespace Assert
- * @api public
+ * @public
  */
 
 assert.increasesButNotBy = function (fn, obj, prop, delta, msg) {
@@ -2742,7 +2742,7 @@ assert.increasesButNotBy = function (fn, obj, prop, delta, msg) {
  * @param {String} property name _optional_
  * @param {String} message _optional_
  * @namespace Assert
- * @api public
+ * @public
  */
 
 assert.decreases = function (fn, obj, prop, msg) {
@@ -2771,7 +2771,7 @@ assert.decreases = function (fn, obj, prop, msg) {
  * @param {Number} change amount (delta)
  * @param {String} message _optional_
  * @namespace Assert
- * @api public
+ * @public
  */
 
 assert.decreasesBy = function (fn, obj, prop, delta, msg) {
@@ -2803,7 +2803,7 @@ assert.decreasesBy = function (fn, obj, prop, delta, msg) {
  * @param {String} property name _optional_
  * @param {String} message _optional_
  * @namespace Assert
- * @api public
+ * @public
  */
 
 assert.doesNotDecrease = function (fn, obj, prop, msg) {
@@ -2832,7 +2832,7 @@ assert.doesNotDecrease = function (fn, obj, prop, msg) {
  * @param {Number} change amount (delta)
  * @param {String} message _optional_
  * @namespace Assert
- * @api public
+ * @public
  */
 
 assert.doesNotDecreaseBy = function (fn, obj, prop, delta, msg) {
@@ -2865,7 +2865,7 @@ assert.doesNotDecreaseBy = function (fn, obj, prop, delta, msg) {
  * @param {Number} change amount (delta)
  * @param {String} message _optional_
  * @namespace Assert
- * @api public
+ * @public
  */
 
 assert.decreasesButNotBy = function (fn, obj, prop, delta, msg) {
@@ -2895,7 +2895,7 @@ assert.decreasesButNotBy = function (fn, obj, prop, delta, msg) {
  * @name ifError
  * @param {Object} object
  * @namespace Assert
- * @api public
+ * @public
  */
 
 assert.ifError = function (val) {
@@ -2916,7 +2916,7 @@ assert.ifError = function (val) {
  * @param {Object} object
  * @param {String} message _optional_
  * @namespace Assert
- * @api public
+ * @public
  */
 
 assert.isExtensible = function (obj, msg) {
@@ -2941,7 +2941,7 @@ assert.isExtensible = function (obj, msg) {
  * @param {Object} object
  * @param {String} message _optional_
  * @namespace Assert
- * @api public
+ * @public
  */
 
 assert.isNotExtensible = function (obj, msg) {
@@ -2965,7 +2965,7 @@ assert.isNotExtensible = function (obj, msg) {
  * @param {Object} object
  * @param {String} message _optional_
  * @namespace Assert
- * @api public
+ * @public
  */
 
 assert.isSealed = function (obj, msg) {
@@ -2984,7 +2984,7 @@ assert.isSealed = function (obj, msg) {
  * @param {Object} object
  * @param {String} message _optional_
  * @namespace Assert
- * @api public
+ * @public
  */
 
 assert.isNotSealed = function (obj, msg) {
@@ -3005,7 +3005,7 @@ assert.isNotSealed = function (obj, msg) {
  * @param {Object} object
  * @param {String} message _optional_
  * @namespace Assert
- * @api public
+ * @public
  */
 
 assert.isFrozen = function (obj, msg) {
@@ -3024,7 +3024,7 @@ assert.isFrozen = function (obj, msg) {
  * @param {Object} object
  * @param {String} message _optional_
  * @namespace Assert
- * @api public
+ * @public
  */
 
 assert.isNotFrozen = function (obj, msg) {
@@ -3050,7 +3050,7 @@ assert.isNotFrozen = function (obj, msg) {
  * @param {Object|Array|String|Map|Set} target
  * @param {String} message _optional_
  * @namespace Assert
- * @api public
+ * @public
  */
 
 assert.isEmpty = function(val, msg) {
@@ -3076,7 +3076,7 @@ assert.isEmpty = function(val, msg) {
  * @param {Object|Array|String|Map|Set} target
  * @param {String} message _optional_
  * @namespace Assert
- * @api public
+ * @public
  */
 
 assert.isNotEmpty = function(val, msg) {

--- a/lib/chai/interface/assert.js
+++ b/lib/chai/interface/assert.js
@@ -23,7 +23,6 @@ import {AssertionError} from 'assertion-error';
  * @namespace Assert
  * @public
  */
-
 function assert(express, errmsg) {
   var test = new Assertion(null, null, chai.assert, true);
   test.assert(
@@ -56,7 +55,6 @@ export {assert};
  * @namespace Assert
  * @public
  */
-
 assert.fail = function (actual, expected, message, operator) {
   if (arguments.length < 2) {
       // Comply with Node's fail([message]) interface
@@ -88,7 +86,6 @@ assert.fail = function (actual, expected, message, operator) {
  * @namespace Assert
  * @public
  */
-
 assert.isOk = function (val, msg) {
   new Assertion(val, msg, assert.isOk, true).is.ok;
 };
@@ -108,7 +105,6 @@ assert.isOk = function (val, msg) {
  * @namespace Assert
  * @public
  */
-
 assert.isNotOk = function (val, msg) {
   new Assertion(val, msg, assert.isNotOk, true).is.not.ok;
 };
@@ -127,7 +123,6 @@ assert.isNotOk = function (val, msg) {
  * @namespace Assert
  * @public
  */
-
 assert.equal = function (act, exp, msg) {
   var test = new Assertion(act, msg, assert.equal, true);
 
@@ -155,7 +150,6 @@ assert.equal = function (act, exp, msg) {
  * @namespace Assert
  * @public
  */
-
 assert.notEqual = function (act, exp, msg) {
   var test = new Assertion(act, msg, assert.notEqual, true);
 
@@ -183,7 +177,6 @@ assert.notEqual = function (act, exp, msg) {
  * @namespace Assert
  * @public
  */
-
 assert.strictEqual = function (act, exp, msg) {
   new Assertion(act, msg, assert.strictEqual, true).to.equal(exp);
 };
@@ -202,7 +195,6 @@ assert.strictEqual = function (act, exp, msg) {
  * @namespace Assert
  * @public
  */
-
 assert.notStrictEqual = function (act, exp, msg) {
   new Assertion(act, msg, assert.notStrictEqual, true).to.not.equal(exp);
 };
@@ -222,7 +214,6 @@ assert.notStrictEqual = function (act, exp, msg) {
  * @namespace Assert
  * @public
  */
-
 assert.deepEqual = assert.deepStrictEqual = function (act, exp, msg) {
   new Assertion(act, msg, assert.deepEqual, true).to.eql(exp);
 };
@@ -241,7 +232,6 @@ assert.deepEqual = assert.deepStrictEqual = function (act, exp, msg) {
  * @namespace Assert
  * @public
  */
-
 assert.notDeepEqual = function (act, exp, msg) {
   new Assertion(act, msg, assert.notDeepEqual, true).to.not.eql(exp);
 };
@@ -260,7 +250,6 @@ assert.notDeepEqual = function (act, exp, msg) {
  * @namespace Assert
  * @public
  */
-
 assert.isAbove = function (val, abv, msg) {
   new Assertion(val, msg, assert.isAbove, true).to.be.above(abv);
 };
@@ -280,7 +269,6 @@ assert.isAbove = function (val, abv, msg) {
  * @namespace Assert
  * @public
  */
-
 assert.isAtLeast = function (val, atlst, msg) {
   new Assertion(val, msg, assert.isAtLeast, true).to.be.least(atlst);
 };
@@ -299,7 +287,6 @@ assert.isAtLeast = function (val, atlst, msg) {
  * @namespace Assert
  * @public
  */
-
 assert.isBelow = function (val, blw, msg) {
   new Assertion(val, msg, assert.isBelow, true).to.be.below(blw);
 };
@@ -319,7 +306,6 @@ assert.isBelow = function (val, blw, msg) {
  * @namespace Assert
  * @public
  */
-
 assert.isAtMost = function (val, atmst, msg) {
   new Assertion(val, msg, assert.isAtMost, true).to.be.most(atmst);
 };
@@ -338,7 +324,6 @@ assert.isAtMost = function (val, atmst, msg) {
  * @namespace Assert
  * @public
  */
-
 assert.isTrue = function (val, msg) {
   new Assertion(val, msg, assert.isTrue, true).is['true'];
 };
@@ -357,7 +342,6 @@ assert.isTrue = function (val, msg) {
  * @namespace Assert
  * @public
  */
-
 assert.isNotTrue = function (val, msg) {
   new Assertion(val, msg, assert.isNotTrue, true).to.not.equal(true);
 };
@@ -376,7 +360,6 @@ assert.isNotTrue = function (val, msg) {
  * @namespace Assert
  * @public
  */
-
 assert.isFalse = function (val, msg) {
   new Assertion(val, msg, assert.isFalse, true).is['false'];
 };
@@ -395,7 +378,6 @@ assert.isFalse = function (val, msg) {
  * @namespace Assert
  * @public
  */
-
 assert.isNotFalse = function (val, msg) {
   new Assertion(val, msg, assert.isNotFalse, true).to.not.equal(false);
 };
@@ -413,7 +395,6 @@ assert.isNotFalse = function (val, msg) {
  * @namespace Assert
  * @public
  */
-
 assert.isNull = function (val, msg) {
   new Assertion(val, msg, assert.isNull, true).to.equal(null);
 };
@@ -432,7 +413,6 @@ assert.isNull = function (val, msg) {
  * @namespace Assert
  * @public
  */
-
 assert.isNotNull = function (val, msg) {
   new Assertion(val, msg, assert.isNotNull, true).to.not.equal(null);
 };
@@ -450,7 +430,6 @@ assert.isNotNull = function (val, msg) {
  * @namespace Assert
  * @public
  */
-
 assert.isNaN = function (val, msg) {
   new Assertion(val, msg, assert.isNaN, true).to.be.NaN;
 };
@@ -467,8 +446,7 @@ assert.isNaN = function (val, msg) {
  * @param {String} message
  * @namespace Assert
  * @public
- */
-assert.isNotNaN = function (val, msg) {
+ */assert.isNotNaN = function (val, msg) {
   new Assertion(val, msg, assert.isNotNaN, true).not.to.be.NaN;
 };
 
@@ -487,7 +465,6 @@ assert.isNotNaN = function (val, msg) {
  * @namespace Assert
  * @public
  */
-
 assert.exists = function (val, msg) {
   new Assertion(val, msg, assert.exists, true).to.exist;
 };
@@ -509,7 +486,6 @@ assert.exists = function (val, msg) {
  * @namespace Assert
  * @public
  */
-
 assert.notExists = function (val, msg) {
   new Assertion(val, msg, assert.notExists, true).to.not.exist;
 };
@@ -528,7 +504,6 @@ assert.notExists = function (val, msg) {
  * @namespace Assert
  * @public
  */
-
 assert.isUndefined = function (val, msg) {
   new Assertion(val, msg, assert.isUndefined, true).to.equal(undefined);
 };
@@ -547,7 +522,6 @@ assert.isUndefined = function (val, msg) {
  * @namespace Assert
  * @public
  */
-
 assert.isDefined = function (val, msg) {
   new Assertion(val, msg, assert.isDefined, true).to.not.equal(undefined);
 };
@@ -565,8 +539,7 @@ assert.isDefined = function (val, msg) {
  * @param {String} message
  * @namespace Assert
  * @public
- */
-assert.isCallable = function (val, msg) {
+ */assert.isCallable = function (val, msg) {
   new Assertion(val, msg, assert.isCallable, true).is.callable;
 }
 
@@ -583,8 +556,7 @@ assert.isCallable = function (val, msg) {
  * @param {String} message
  * @namespace Assert
  * @public
- */
-assert.isNotCallable = function (val, msg) {
+ */assert.isNotCallable = function (val, msg) {
   new Assertion(val, msg, assert.isNotCallable, true).is.not.callable;
 };
 
@@ -603,7 +575,6 @@ assert.isNotCallable = function (val, msg) {
  * @namespace Assert
  * @public
  */
-
 assert.isObject = function (val, msg) {
   new Assertion(val, msg, assert.isObject, true).to.be.a('object');
 };
@@ -623,7 +594,6 @@ assert.isObject = function (val, msg) {
  * @namespace Assert
  * @public
  */
-
 assert.isNotObject = function (val, msg) {
   new Assertion(val, msg, assert.isNotObject, true).to.not.be.a('object');
 };
@@ -642,7 +612,6 @@ assert.isNotObject = function (val, msg) {
  * @namespace Assert
  * @public
  */
-
 assert.isArray = function (val, msg) {
   new Assertion(val, msg, assert.isArray, true).to.be.an('array');
 };
@@ -661,7 +630,6 @@ assert.isArray = function (val, msg) {
  * @namespace Assert
  * @public
  */
-
 assert.isNotArray = function (val, msg) {
   new Assertion(val, msg, assert.isNotArray, true).to.not.be.an('array');
 };
@@ -680,7 +648,6 @@ assert.isNotArray = function (val, msg) {
  * @namespace Assert
  * @public
  */
-
 assert.isString = function (val, msg) {
   new Assertion(val, msg, assert.isString, true).to.be.a('string');
 };
@@ -699,7 +666,6 @@ assert.isString = function (val, msg) {
  * @namespace Assert
  * @public
  */
-
 assert.isNotString = function (val, msg) {
   new Assertion(val, msg, assert.isNotString, true).to.not.be.a('string');
 };
@@ -718,7 +684,6 @@ assert.isNotString = function (val, msg) {
  * @namespace Assert
  * @public
  */
-
 assert.isNumber = function (val, msg) {
   new Assertion(val, msg, assert.isNumber, true).to.be.a('number');
 };
@@ -737,7 +702,6 @@ assert.isNumber = function (val, msg) {
  * @namespace Assert
  * @public
  */
-
 assert.isNotNumber = function (val, msg) {
   new Assertion(val, msg, assert.isNotNumber, true).to.not.be.a('number');
 };
@@ -758,7 +722,6 @@ assert.isNotNumber = function (val, msg) {
  * @namespace Assert
  * @public
  */
-
 assert.isFinite = function (val, msg) {
   new Assertion(val, msg, assert.isFinite, true).to.be.finite;
 };
@@ -780,7 +743,6 @@ assert.isFinite = function (val, msg) {
  * @namespace Assert
  * @public
  */
-
 assert.isBoolean = function (val, msg) {
   new Assertion(val, msg, assert.isBoolean, true).to.be.a('boolean');
 };
@@ -802,7 +764,6 @@ assert.isBoolean = function (val, msg) {
  * @namespace Assert
  * @public
  */
-
 assert.isNotBoolean = function (val, msg) {
   new Assertion(val, msg, assert.isNotBoolean, true).to.not.be.a('boolean');
 };
@@ -827,7 +788,6 @@ assert.isNotBoolean = function (val, msg) {
  * @namespace Assert
  * @public
  */
-
 assert.typeOf = function (val, type, msg) {
   new Assertion(val, msg, assert.typeOf, true).to.be.a(type);
 };
@@ -847,7 +807,6 @@ assert.typeOf = function (val, type, msg) {
  * @namespace Assert
  * @public
  */
-
 assert.notTypeOf = function (val, type, msg) {
   new Assertion(val, msg, assert.notTypeOf, true).to.not.be.a(type);
 };
@@ -869,7 +828,6 @@ assert.notTypeOf = function (val, type, msg) {
  * @namespace Assert
  * @public
  */
-
 assert.instanceOf = function (val, type, msg) {
   new Assertion(val, msg, assert.instanceOf, true).to.be.instanceOf(type);
 };
@@ -891,7 +849,6 @@ assert.instanceOf = function (val, type, msg) {
  * @namespace Assert
  * @public
  */
-
 assert.notInstanceOf = function (val, type, msg) {
   new Assertion(val, msg, assert.notInstanceOf, true)
     .to.not.be.instanceOf(type);
@@ -927,7 +884,6 @@ assert.notInstanceOf = function (val, type, msg) {
  * @namespace Assert
  * @public
  */
-
 assert.include = function (exp, inc, msg) {
   new Assertion(exp, msg, assert.include, true).include(inc);
 };
@@ -963,7 +919,6 @@ assert.include = function (exp, inc, msg) {
  * @namespace Assert
  * @public
  */
-
 assert.notInclude = function (exp, inc, msg) {
   new Assertion(exp, msg, assert.notInclude, true).not.include(inc);
 };
@@ -988,7 +943,6 @@ assert.notInclude = function (exp, inc, msg) {
  * @namespace Assert
  * @public
  */
-
 assert.deepInclude = function (exp, inc, msg) {
   new Assertion(exp, msg, assert.deepInclude, true).deep.include(inc);
 };
@@ -1013,7 +967,6 @@ assert.deepInclude = function (exp, inc, msg) {
  * @namespace Assert
  * @public
  */
-
 assert.notDeepInclude = function (exp, inc, msg) {
   new Assertion(exp, msg, assert.notDeepInclude, true).not.deep.include(inc);
 };
@@ -1038,7 +991,6 @@ assert.notDeepInclude = function (exp, inc, msg) {
  * @namespace Assert
  * @public
  */
-
 assert.nestedInclude = function (exp, inc, msg) {
   new Assertion(exp, msg, assert.nestedInclude, true).nested.include(inc);
 };
@@ -1063,7 +1015,6 @@ assert.nestedInclude = function (exp, inc, msg) {
  * @namespace Assert
  * @public
  */
-
 assert.notNestedInclude = function (exp, inc, msg) {
   new Assertion(exp, msg, assert.notNestedInclude, true)
     .not.nested.include(inc);
@@ -1089,7 +1040,6 @@ assert.notNestedInclude = function (exp, inc, msg) {
  * @namespace Assert
  * @public
  */
-
 assert.deepNestedInclude = function(exp, inc, msg) {
   new Assertion(exp, msg, assert.deepNestedInclude, true)
     .deep.nested.include(inc);
@@ -1115,7 +1065,6 @@ assert.deepNestedInclude = function(exp, inc, msg) {
  * @namespace Assert
  * @public
  */
-
 assert.notDeepNestedInclude = function(exp, inc, msg) {
   new Assertion(exp, msg, assert.notDeepNestedInclude, true)
     .not.deep.nested.include(inc);
@@ -1137,7 +1086,6 @@ assert.notDeepNestedInclude = function(exp, inc, msg) {
  * @namespace Assert
  * @public
  */
-
 assert.ownInclude = function(exp, inc, msg) {
   new Assertion(exp, msg, assert.ownInclude, true).own.include(inc);
 };
@@ -1160,7 +1108,6 @@ assert.ownInclude = function(exp, inc, msg) {
  * @namespace Assert
  * @public
  */
-
 assert.notOwnInclude = function(exp, inc, msg) {
   new Assertion(exp, msg, assert.notOwnInclude, true).not.own.include(inc);
 };
@@ -1181,7 +1128,6 @@ assert.notOwnInclude = function(exp, inc, msg) {
  * @namespace Assert
  * @public
  */
-
 assert.deepOwnInclude = function(exp, inc, msg) {
   new Assertion(exp, msg, assert.deepOwnInclude, true)
     .deep.own.include(inc);
@@ -1203,7 +1149,6 @@ assert.deepOwnInclude = function(exp, inc, msg) {
  * @namespace Assert
  * @public
  */
-
 assert.notDeepOwnInclude = function(exp, inc, msg) {
   new Assertion(exp, msg, assert.notDeepOwnInclude, true)
     .not.deep.own.include(inc);
@@ -1223,7 +1168,6 @@ assert.notDeepOwnInclude = function(exp, inc, msg) {
  * @namespace Assert
  * @public
  */
-
 assert.match = function (exp, re, msg) {
   new Assertion(exp, msg, assert.match, true).to.match(re);
 };
@@ -1242,7 +1186,6 @@ assert.match = function (exp, re, msg) {
  * @namespace Assert
  * @public
  */
-
 assert.notMatch = function (exp, re, msg) {
   new Assertion(exp, msg, assert.notMatch, true).to.not.match(re);
 };
@@ -1263,7 +1206,6 @@ assert.notMatch = function (exp, re, msg) {
  * @namespace Assert
  * @public
  */
-
 assert.property = function (obj, prop, msg) {
   new Assertion(obj, msg, assert.property, true).to.have.property(prop);
 };
@@ -1283,7 +1225,6 @@ assert.property = function (obj, prop, msg) {
  * @namespace Assert
  * @public
  */
-
 assert.notProperty = function (obj, prop, msg) {
   new Assertion(obj, msg, assert.notProperty, true)
     .to.not.have.property(prop);
@@ -1306,7 +1247,6 @@ assert.notProperty = function (obj, prop, msg) {
  * @namespace Assert
  * @public
  */
-
 assert.propertyVal = function (obj, prop, val, msg) {
   new Assertion(obj, msg, assert.propertyVal, true)
     .to.have.property(prop, val);
@@ -1330,7 +1270,6 @@ assert.propertyVal = function (obj, prop, val, msg) {
  * @namespace Assert
  * @public
  */
-
 assert.notPropertyVal = function (obj, prop, val, msg) {
   new Assertion(obj, msg, assert.notPropertyVal, true)
     .to.not.have.property(prop, val);
@@ -1352,7 +1291,6 @@ assert.notPropertyVal = function (obj, prop, val, msg) {
  * @namespace Assert
  * @public
  */
-
 assert.deepPropertyVal = function (obj, prop, val, msg) {
   new Assertion(obj, msg, assert.deepPropertyVal, true)
     .to.have.deep.property(prop, val);
@@ -1376,7 +1314,6 @@ assert.deepPropertyVal = function (obj, prop, val, msg) {
  * @namespace Assert
  * @public
  */
-
 assert.notDeepPropertyVal = function (obj, prop, val, msg) {
   new Assertion(obj, msg, assert.notDeepPropertyVal, true)
     .to.not.have.deep.property(prop, val);
@@ -1396,7 +1333,6 @@ assert.notDeepPropertyVal = function (obj, prop, val, msg) {
  * @param {String} message
  * @public
  */
-
 assert.ownProperty = function (obj, prop, msg) {
   new Assertion(obj, msg, assert.ownProperty, true)
     .to.have.own.property(prop);
@@ -1417,7 +1353,6 @@ assert.ownProperty = function (obj, prop, msg) {
  * @param {String} message
  * @public
  */
-
 assert.notOwnProperty = function (obj, prop, msg) {
   new Assertion(obj, msg, assert.notOwnProperty, true)
     .to.not.have.own.property(prop);
@@ -1439,7 +1374,6 @@ assert.notOwnProperty = function (obj, prop, msg) {
  * @param {String} message
  * @public
  */
-
 assert.ownPropertyVal = function (obj, prop, value, msg) {
   new Assertion(obj, msg, assert.ownPropertyVal, true)
     .to.have.own.property(prop, value);
@@ -1462,7 +1396,6 @@ assert.ownPropertyVal = function (obj, prop, value, msg) {
  * @param {String} message
  * @public
  */
-
 assert.notOwnPropertyVal = function (obj, prop, value, msg) {
   new Assertion(obj, msg, assert.notOwnPropertyVal, true)
     .to.not.have.own.property(prop, value);
@@ -1484,7 +1417,6 @@ assert.notOwnPropertyVal = function (obj, prop, value, msg) {
  * @param {String} message
  * @public
  */
-
 assert.deepOwnPropertyVal = function (obj, prop, value, msg) {
   new Assertion(obj, msg, assert.deepOwnPropertyVal, true)
     .to.have.deep.own.property(prop, value);
@@ -1509,7 +1441,6 @@ assert.deepOwnPropertyVal = function (obj, prop, value, msg) {
  * @param {String} message
  * @public
  */
-
 assert.notDeepOwnPropertyVal = function (obj, prop, value, msg) {
   new Assertion(obj, msg, assert.notDeepOwnPropertyVal, true)
     .to.not.have.deep.own.property(prop, value);
@@ -1531,7 +1462,6 @@ assert.notDeepOwnPropertyVal = function (obj, prop, value, msg) {
  * @namespace Assert
  * @public
  */
-
 assert.nestedProperty = function (obj, prop, msg) {
   new Assertion(obj, msg, assert.nestedProperty, true)
     .to.have.nested.property(prop);
@@ -1553,7 +1483,6 @@ assert.nestedProperty = function (obj, prop, msg) {
  * @namespace Assert
  * @public
  */
-
 assert.notNestedProperty = function (obj, prop, msg) {
   new Assertion(obj, msg, assert.notNestedProperty, true)
     .to.not.have.nested.property(prop);
@@ -1576,7 +1505,6 @@ assert.notNestedProperty = function (obj, prop, msg) {
  * @namespace Assert
  * @public
  */
-
 assert.nestedPropertyVal = function (obj, prop, val, msg) {
   new Assertion(obj, msg, assert.nestedPropertyVal, true)
     .to.have.nested.property(prop, val);
@@ -1600,7 +1528,6 @@ assert.nestedPropertyVal = function (obj, prop, val, msg) {
  * @namespace Assert
  * @public
  */
-
 assert.notNestedPropertyVal = function (obj, prop, val, msg) {
   new Assertion(obj, msg, assert.notNestedPropertyVal, true)
     .to.not.have.nested.property(prop, val);
@@ -1623,7 +1550,6 @@ assert.notNestedPropertyVal = function (obj, prop, val, msg) {
  * @namespace Assert
  * @public
  */
-
 assert.deepNestedPropertyVal = function (obj, prop, val, msg) {
   new Assertion(obj, msg, assert.deepNestedPropertyVal, true)
     .to.have.deep.nested.property(prop, val);
@@ -1648,7 +1574,6 @@ assert.deepNestedPropertyVal = function (obj, prop, val, msg) {
  * @namespace Assert
  * @public
  */
-
 assert.notDeepNestedPropertyVal = function (obj, prop, val, msg) {
   new Assertion(obj, msg, assert.notDeepNestedPropertyVal, true)
     .to.not.have.deep.nested.property(prop, val);
@@ -1671,7 +1596,6 @@ assert.notDeepNestedPropertyVal = function (obj, prop, val, msg) {
  * @namespace Assert
  * @public
  */
-
 assert.lengthOf = function (exp, len, msg) {
   new Assertion(exp, msg, assert.lengthOf, true).to.have.lengthOf(len);
 };
@@ -1695,7 +1619,6 @@ assert.lengthOf = function (exp, len, msg) {
  * @namespace Assert
  * @public
  */
-
 assert.hasAnyKeys = function (obj, keys, msg) {
   new Assertion(obj, msg, assert.hasAnyKeys, true).to.have.any.keys(keys);
 }
@@ -1719,7 +1642,6 @@ assert.hasAnyKeys = function (obj, keys, msg) {
  * @namespace Assert
  * @public
  */
-
 assert.hasAllKeys = function (obj, keys, msg) {
   new Assertion(obj, msg, assert.hasAllKeys, true).to.have.all.keys(keys);
 }
@@ -1747,7 +1669,6 @@ assert.hasAllKeys = function (obj, keys, msg) {
  * @namespace Assert
  * @public
  */
-
 assert.containsAllKeys = function (obj, keys, msg) {
   new Assertion(obj, msg, assert.containsAllKeys, true)
     .to.contain.all.keys(keys);
@@ -1772,7 +1693,6 @@ assert.containsAllKeys = function (obj, keys, msg) {
  * @namespace Assert
  * @public
  */
-
 assert.doesNotHaveAnyKeys = function (obj, keys, msg) {
   new Assertion(obj, msg, assert.doesNotHaveAnyKeys, true)
     .to.not.have.any.keys(keys);
@@ -1797,7 +1717,6 @@ assert.doesNotHaveAnyKeys = function (obj, keys, msg) {
  * @namespace Assert
  * @public
  */
-
 assert.doesNotHaveAllKeys = function (obj, keys, msg) {
   new Assertion(obj, msg, assert.doesNotHaveAllKeys, true)
     .to.not.have.all.keys(keys);
@@ -1826,7 +1745,6 @@ assert.doesNotHaveAllKeys = function (obj, keys, msg) {
  * @namespace Assert
  * @public
  */
-
 assert.hasAnyDeepKeys = function (obj, keys, msg) {
   new Assertion(obj, msg, assert.hasAnyDeepKeys, true)
     .to.have.any.deep.keys(keys);
@@ -1853,7 +1771,6 @@ assert.hasAnyDeepKeys = function (obj, keys, msg) {
  * @namespace Assert
  * @public
  */
-
 assert.hasAllDeepKeys = function (obj, keys, msg) {
   new Assertion(obj, msg, assert.hasAllDeepKeys, true)
     .to.have.all.deep.keys(keys);
@@ -1880,7 +1797,6 @@ assert.hasAllDeepKeys = function (obj, keys, msg) {
  * @namespace Assert
  * @public
  */
-
 assert.containsAllDeepKeys = function (obj, keys, msg) {
   new Assertion(obj, msg, assert.containsAllDeepKeys, true)
     .to.contain.all.deep.keys(keys);
@@ -1907,7 +1823,6 @@ assert.containsAllDeepKeys = function (obj, keys, msg) {
  * @namespace Assert
  * @public
  */
-
 assert.doesNotHaveAnyDeepKeys = function (obj, keys, msg) {
   new Assertion(obj, msg, assert.doesNotHaveAnyDeepKeys, true)
     .to.not.have.any.deep.keys(keys);
@@ -1934,7 +1849,6 @@ assert.doesNotHaveAnyDeepKeys = function (obj, keys, msg) {
  * @namespace Assert
  * @public
  */
-
 assert.doesNotHaveAllDeepKeys = function (obj, keys, msg) {
   new Assertion(obj, msg, assert.doesNotHaveAllDeepKeys, true)
     .to.not.have.all.deep.keys(keys);
@@ -1970,7 +1884,6 @@ assert.doesNotHaveAllDeepKeys = function (obj, keys, msg) {
  * @namespace Assert
  * @public
  */
-
 assert.throws = function (fn, errorLike, errMsgMatcher, msg) {
   if ('string' === typeof errorLike || errorLike instanceof RegExp) {
     errMsgMatcher = errorLike;
@@ -2010,7 +1923,6 @@ assert.throws = function (fn, errorLike, errMsgMatcher, msg) {
  * @namespace Assert
  * @public
  */
-
 assert.doesNotThrow = function (fn, errorLike, errMsgMatcher, msg) {
   if ('string' === typeof errorLike || errorLike instanceof RegExp) {
     errMsgMatcher = errorLike;
@@ -2037,7 +1949,6 @@ assert.doesNotThrow = function (fn, errorLike, errMsgMatcher, msg) {
  * @namespace Assert
  * @public
  */
-
 assert.operator = function (val, operator, val2, msg) {
   var ok;
   switch(operator) {
@@ -2095,7 +2006,6 @@ assert.operator = function (val, operator, val2, msg) {
  * @namespace Assert
  * @public
  */
-
 assert.closeTo = function (act, exp, delta, msg) {
   new Assertion(act, msg, assert.closeTo, true).to.be.closeTo(exp, delta);
 };
@@ -2115,7 +2025,6 @@ assert.closeTo = function (act, exp, delta, msg) {
  * @namespace Assert
  * @public
  */
-
 assert.approximately = function (act, exp, delta, msg) {
   new Assertion(act, msg, assert.approximately, true)
     .to.be.approximately(exp, delta);
@@ -2136,7 +2045,6 @@ assert.approximately = function (act, exp, delta, msg) {
  * @namespace Assert
  * @public
  */
-
 assert.sameMembers = function (set1, set2, msg) {
   new Assertion(set1, msg, assert.sameMembers, true)
     .to.have.same.members(set2);
@@ -2157,7 +2065,6 @@ assert.sameMembers = function (set1, set2, msg) {
  * @namespace Assert
  * @public
  */
-
 assert.notSameMembers = function (set1, set2, msg) {
   new Assertion(set1, msg, assert.notSameMembers, true)
     .to.not.have.same.members(set2);
@@ -2178,7 +2085,6 @@ assert.notSameMembers = function (set1, set2, msg) {
  * @namespace Assert
  * @public
  */
-
 assert.sameDeepMembers = function (set1, set2, msg) {
   new Assertion(set1, msg, assert.sameDeepMembers, true)
     .to.have.same.deep.members(set2);
@@ -2199,7 +2105,6 @@ assert.sameDeepMembers = function (set1, set2, msg) {
  * @namespace Assert
  * @public
  */
-
 assert.notSameDeepMembers = function (set1, set2, msg) {
   new Assertion(set1, msg, assert.notSameDeepMembers, true)
     .to.not.have.same.deep.members(set2);
@@ -2220,7 +2125,6 @@ assert.notSameDeepMembers = function (set1, set2, msg) {
  * @namespace Assert
  * @public
  */
-
 assert.sameOrderedMembers = function (set1, set2, msg) {
   new Assertion(set1, msg, assert.sameOrderedMembers, true)
     .to.have.same.ordered.members(set2);
@@ -2241,7 +2145,6 @@ assert.sameOrderedMembers = function (set1, set2, msg) {
  * @namespace Assert
  * @public
  */
-
 assert.notSameOrderedMembers = function (set1, set2, msg) {
   new Assertion(set1, msg, assert.notSameOrderedMembers, true)
     .to.not.have.same.ordered.members(set2);
@@ -2262,7 +2165,6 @@ assert.notSameOrderedMembers = function (set1, set2, msg) {
  * @namespace Assert
  * @public
  */
-
 assert.sameDeepOrderedMembers = function (set1, set2, msg) {
   new Assertion(set1, msg, assert.sameDeepOrderedMembers, true)
     .to.have.same.deep.ordered.members(set2);
@@ -2284,7 +2186,6 @@ assert.sameDeepOrderedMembers = function (set1, set2, msg) {
  * @namespace Assert
  * @public
  */
-
 assert.notSameDeepOrderedMembers = function (set1, set2, msg) {
   new Assertion(set1, msg, assert.notSameDeepOrderedMembers, true)
     .to.not.have.same.deep.ordered.members(set2);
@@ -2305,7 +2206,6 @@ assert.notSameDeepOrderedMembers = function (set1, set2, msg) {
  * @namespace Assert
  * @public
  */
-
 assert.includeMembers = function (superset, subset, msg) {
   new Assertion(superset, msg, assert.includeMembers, true)
     .to.include.members(subset);
@@ -2326,7 +2226,6 @@ assert.includeMembers = function (superset, subset, msg) {
  * @namespace Assert
  * @public
  */
-
 assert.notIncludeMembers = function (superset, subset, msg) {
   new Assertion(superset, msg, assert.notIncludeMembers, true)
     .to.not.include.members(subset);
@@ -2347,7 +2246,6 @@ assert.notIncludeMembers = function (superset, subset, msg) {
  * @namespace Assert
  * @public
  */
-
 assert.includeDeepMembers = function (superset, subset, msg) {
   new Assertion(superset, msg, assert.includeDeepMembers, true)
     .to.include.deep.members(subset);
@@ -2368,7 +2266,6 @@ assert.includeDeepMembers = function (superset, subset, msg) {
  * @namespace Assert
  * @public
  */
-
 assert.notIncludeDeepMembers = function (superset, subset, msg) {
   new Assertion(superset, msg, assert.notIncludeDeepMembers, true)
     .to.not.include.deep.members(subset);
@@ -2390,7 +2287,6 @@ assert.notIncludeDeepMembers = function (superset, subset, msg) {
  * @namespace Assert
  * @public
  */
-
 assert.includeOrderedMembers = function (superset, subset, msg) {
   new Assertion(superset, msg, assert.includeOrderedMembers, true)
     .to.include.ordered.members(subset);
@@ -2413,7 +2309,6 @@ assert.includeOrderedMembers = function (superset, subset, msg) {
  * @namespace Assert
  * @public
  */
-
 assert.notIncludeOrderedMembers = function (superset, subset, msg) {
   new Assertion(superset, msg, assert.notIncludeOrderedMembers, true)
     .to.not.include.ordered.members(subset);
@@ -2435,7 +2330,6 @@ assert.notIncludeOrderedMembers = function (superset, subset, msg) {
  * @namespace Assert
  * @public
  */
-
 assert.includeDeepOrderedMembers = function (superset, subset, msg) {
   new Assertion(superset, msg, assert.includeDeepOrderedMembers, true)
     .to.include.deep.ordered.members(subset);
@@ -2459,7 +2353,6 @@ assert.includeDeepOrderedMembers = function (superset, subset, msg) {
  * @namespace Assert
  * @public
  */
-
 assert.notIncludeDeepOrderedMembers = function (superset, subset, msg) {
   new Assertion(superset, msg, assert.notIncludeDeepOrderedMembers, true)
     .to.not.include.deep.ordered.members(subset);
@@ -2479,7 +2372,6 @@ assert.notIncludeDeepOrderedMembers = function (superset, subset, msg) {
  * @namespace Assert
  * @public
  */
-
 assert.oneOf = function (inList, list, msg) {
   new Assertion(inList, msg, assert.oneOf, true).to.be.oneOf(list);
 }
@@ -2501,7 +2393,6 @@ assert.oneOf = function (inList, list, msg) {
  * @namespace Assert
  * @public
  */
-
 assert.changes = function (fn, obj, prop, msg) {
   if (arguments.length === 3 && typeof obj === 'function') {
     msg = prop;
@@ -2529,7 +2420,6 @@ assert.changes = function (fn, obj, prop, msg) {
  * @namespace Assert
  * @public
  */
-
 assert.changesBy = function (fn, obj, prop, delta, msg) {
   if (arguments.length === 4 && typeof obj === 'function') {
     var tmpMsg = delta;
@@ -2561,7 +2451,6 @@ assert.changesBy = function (fn, obj, prop, delta, msg) {
  * @namespace Assert
  * @public
  */
-
 assert.doesNotChange = function (fn, obj, prop, msg) {
   if (arguments.length === 3 && typeof obj === 'function') {
     msg = prop;
@@ -2590,7 +2479,6 @@ assert.doesNotChange = function (fn, obj, prop, msg) {
  * @namespace Assert
  * @public
  */
-
 assert.changesButNotBy = function (fn, obj, prop, delta, msg) {
   if (arguments.length === 4 && typeof obj === 'function') {
     var tmpMsg = delta;
@@ -2622,7 +2510,6 @@ assert.changesButNotBy = function (fn, obj, prop, delta, msg) {
  * @namespace Assert
  * @public
  */
-
 assert.increases = function (fn, obj, prop, msg) {
   if (arguments.length === 3 && typeof obj === 'function') {
     msg = prop;
@@ -2651,7 +2538,6 @@ assert.increases = function (fn, obj, prop, msg) {
  * @namespace Assert
  * @public
  */
-
 assert.increasesBy = function (fn, obj, prop, delta, msg) {
   if (arguments.length === 4 && typeof obj === 'function') {
     var tmpMsg = delta;
@@ -2683,7 +2569,6 @@ assert.increasesBy = function (fn, obj, prop, delta, msg) {
  * @namespace Assert
  * @public
  */
-
 assert.doesNotIncrease = function (fn, obj, prop, msg) {
   if (arguments.length === 3 && typeof obj === 'function') {
     msg = prop;
@@ -2712,7 +2597,6 @@ assert.doesNotIncrease = function (fn, obj, prop, msg) {
  * @namespace Assert
  * @public
  */
-
 assert.increasesButNotBy = function (fn, obj, prop, delta, msg) {
   if (arguments.length === 4 && typeof obj === 'function') {
     var tmpMsg = delta;
@@ -2744,7 +2628,6 @@ assert.increasesButNotBy = function (fn, obj, prop, delta, msg) {
  * @namespace Assert
  * @public
  */
-
 assert.decreases = function (fn, obj, prop, msg) {
   if (arguments.length === 3 && typeof obj === 'function') {
     msg = prop;
@@ -2773,7 +2656,6 @@ assert.decreases = function (fn, obj, prop, msg) {
  * @namespace Assert
  * @public
  */
-
 assert.decreasesBy = function (fn, obj, prop, delta, msg) {
   if (arguments.length === 4 && typeof obj === 'function') {
     var tmpMsg = delta;
@@ -2805,7 +2687,6 @@ assert.decreasesBy = function (fn, obj, prop, delta, msg) {
  * @namespace Assert
  * @public
  */
-
 assert.doesNotDecrease = function (fn, obj, prop, msg) {
   if (arguments.length === 3 && typeof obj === 'function') {
     msg = prop;
@@ -2834,7 +2715,6 @@ assert.doesNotDecrease = function (fn, obj, prop, msg) {
  * @namespace Assert
  * @public
  */
-
 assert.doesNotDecreaseBy = function (fn, obj, prop, delta, msg) {
   if (arguments.length === 4 && typeof obj === 'function') {
     var tmpMsg = delta;
@@ -2867,7 +2747,6 @@ assert.doesNotDecreaseBy = function (fn, obj, prop, delta, msg) {
  * @namespace Assert
  * @public
  */
-
 assert.decreasesButNotBy = function (fn, obj, prop, delta, msg) {
   if (arguments.length === 4 && typeof obj === 'function') {
     var tmpMsg = delta;
@@ -2897,7 +2776,6 @@ assert.decreasesButNotBy = function (fn, obj, prop, delta, msg) {
  * @namespace Assert
  * @public
  */
-
 assert.ifError = function (val) {
   if (val) {
     throw(val);
@@ -2918,7 +2796,6 @@ assert.ifError = function (val) {
  * @namespace Assert
  * @public
  */
-
 assert.isExtensible = function (obj, msg) {
   new Assertion(obj, msg, assert.isExtensible, true).to.be.extensible;
 };
@@ -2943,7 +2820,6 @@ assert.isExtensible = function (obj, msg) {
  * @namespace Assert
  * @public
  */
-
 assert.isNotExtensible = function (obj, msg) {
   new Assertion(obj, msg, assert.isNotExtensible, true).to.not.be.extensible;
 };
@@ -2967,7 +2843,6 @@ assert.isNotExtensible = function (obj, msg) {
  * @namespace Assert
  * @public
  */
-
 assert.isSealed = function (obj, msg) {
   new Assertion(obj, msg, assert.isSealed, true).to.be.sealed;
 };
@@ -2986,7 +2861,6 @@ assert.isSealed = function (obj, msg) {
  * @namespace Assert
  * @public
  */
-
 assert.isNotSealed = function (obj, msg) {
   new Assertion(obj, msg, assert.isNotSealed, true).to.not.be.sealed;
 };
@@ -3007,7 +2881,6 @@ assert.isNotSealed = function (obj, msg) {
  * @namespace Assert
  * @public
  */
-
 assert.isFrozen = function (obj, msg) {
   new Assertion(obj, msg, assert.isFrozen, true).to.be.frozen;
 };
@@ -3026,7 +2899,6 @@ assert.isFrozen = function (obj, msg) {
  * @namespace Assert
  * @public
  */
-
 assert.isNotFrozen = function (obj, msg) {
   new Assertion(obj, msg, assert.isNotFrozen, true).to.not.be.frozen;
 };
@@ -3052,7 +2924,6 @@ assert.isNotFrozen = function (obj, msg) {
  * @namespace Assert
  * @public
  */
-
 assert.isEmpty = function(val, msg) {
   new Assertion(val, msg, assert.isEmpty, true).to.be.empty;
 };
@@ -3078,7 +2949,6 @@ assert.isEmpty = function(val, msg) {
  * @namespace Assert
  * @public
  */
-
 assert.isNotEmpty = function(val, msg) {
   new Assertion(val, msg, assert.isNotEmpty, true).to.not.be.empty;
 };
@@ -3086,7 +2956,6 @@ assert.isNotEmpty = function(val, msg) {
 /*!
  * Aliases.
  */
-
 (function alias(name, as){
   assert[as] = assert[name];
   return alias;

--- a/lib/chai/interface/expect.js
+++ b/lib/chai/interface/expect.js
@@ -13,6 +13,7 @@ function expect(val, message) {
 }
 
 export {expect};
+
 /**
  * ### .fail([message])
  * ### .fail(actual, expected, [message], [operator])
@@ -34,7 +35,6 @@ export {expect};
  * @namespace BDD
  * @public
  */
-
 expect.fail = function (actual, expected, message, operator) {
   if (arguments.length < 2) {
       message = actual;

--- a/lib/chai/interface/expect.js
+++ b/lib/chai/interface/expect.js
@@ -32,7 +32,7 @@ export {expect};
  * @param {unknown} expected
  * @param {String} message
  * @param {String} operator
- * @namespace BDD
+ * @namespace expect
  * @public
  */
 expect.fail = function (actual, expected, message, operator) {

--- a/lib/chai/interface/expect.js
+++ b/lib/chai/interface/expect.js
@@ -32,7 +32,7 @@ export {expect};
  * @param {String} message
  * @param {String} operator
  * @namespace BDD
- * @api public
+ * @public
  */
 
 expect.fail = function (actual, expected, message, operator) {

--- a/lib/chai/interface/expect.js
+++ b/lib/chai/interface/expect.js
@@ -28,8 +28,8 @@ export {expect};
  *     expect.fail(1, 2, undefined, ">");
  *
  * @name fail
- * @param {Mixed} actual
- * @param {Mixed} expected
+ * @param {unknown} actual
+ * @param {unknown} expected
  * @param {String} message
  * @param {String} operator
  * @namespace BDD

--- a/lib/chai/interface/should.js
+++ b/lib/chai/interface/should.js
@@ -57,8 +57,8 @@ function loadShould () {
    *
    *
    * @name fail
-   * @param {Mixed} actual
-   * @param {Mixed} expected
+   * @param {unknown} actual
+   * @param {unknown} expected
    * @param {String} message
    * @param {String} operator
    * @namespace BDD
@@ -86,8 +86,8 @@ function loadShould () {
    *     should.equal(3, '3', '== coerces values to strings');
    *
    * @name equal
-   * @param {Mixed} actual
-   * @param {Mixed} expected
+   * @param {unknown} actual
+   * @param {unknown} expected
    * @param {String} message
    * @namespace Should
    * @public
@@ -151,8 +151,8 @@ function loadShould () {
    *     should.not.equal(3, 4, 'these numbers are not equal');
    *
    * @name not.equal
-   * @param {Mixed} actual
-   * @param {Mixed} expected
+   * @param {unknown} actual
+   * @param {unknown} expected
    * @param {String} message
    * @namespace Should
    * @public

--- a/lib/chai/interface/should.js
+++ b/lib/chai/interface/should.js
@@ -62,7 +62,7 @@ function loadShould () {
    * @param {String} message
    * @param {String} operator
    * @namespace BDD
-   * @api public
+   * @public
    */
 
   should.fail = function (actual, expected, message, operator) {
@@ -91,7 +91,7 @@ function loadShould () {
    * @param {Mixed} expected
    * @param {String} message
    * @namespace Should
-   * @api public
+   * @public
    */
 
   should.equal = function (val1, val2, msg) {
@@ -119,7 +119,7 @@ function loadShould () {
    * @param {String} message
    * @see https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Error#Error_types
    * @namespace Should
-   * @api public
+   * @public
    */
 
   should.Throw = function (fn, errt, errs, msg) {
@@ -137,7 +137,7 @@ function loadShould () {
    *
    * @name exist
    * @namespace Should
-   * @api public
+   * @public
    */
 
   should.exist = function (val, msg) {
@@ -159,7 +159,7 @@ function loadShould () {
    * @param {Mixed} expected
    * @param {String} message
    * @namespace Should
-   * @api public
+   * @public
    */
 
   should.not.equal = function (val1, val2, msg) {
@@ -183,7 +183,7 @@ function loadShould () {
    * @param {String} message
    * @see https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Error#Error_types
    * @namespace Should
-   * @api public
+   * @public
    */
 
   should.not.Throw = function (fn, errt, errs, msg) {
@@ -201,7 +201,7 @@ function loadShould () {
    *
    * @name not.exist
    * @namespace Should
-   * @api public
+   * @public
    */
 
   should.not.exist = function (val, msg) {

--- a/lib/chai/interface/should.js
+++ b/lib/chai/interface/should.js
@@ -64,7 +64,6 @@ function loadShould () {
    * @namespace BDD
    * @public
    */
-
   should.fail = function (actual, expected, message, operator) {
     if (arguments.length < 2) {
         message = actual;
@@ -93,7 +92,6 @@ function loadShould () {
    * @namespace Should
    * @public
    */
-
   should.equal = function (val1, val2, msg) {
     new Assertion(val1, msg).to.equal(val2);
   };
@@ -121,7 +119,6 @@ function loadShould () {
    * @namespace Should
    * @public
    */
-
   should.Throw = function (fn, errt, errs, msg) {
     new Assertion(fn, msg).to.Throw(errt, errs);
   };
@@ -139,7 +136,6 @@ function loadShould () {
    * @namespace Should
    * @public
    */
-
   should.exist = function (val, msg) {
     new Assertion(val, msg).to.exist;
   }
@@ -161,7 +157,6 @@ function loadShould () {
    * @namespace Should
    * @public
    */
-
   should.not.equal = function (val1, val2, msg) {
     new Assertion(val1, msg).to.not.equal(val2);
   };
@@ -185,7 +180,6 @@ function loadShould () {
    * @namespace Should
    * @public
    */
-
   should.not.Throw = function (fn, errt, errs, msg) {
     new Assertion(fn, msg).to.not.Throw(errt, errs);
   };
@@ -203,7 +197,6 @@ function loadShould () {
    * @namespace Should
    * @public
    */
-
   should.not.exist = function (val, msg) {
     new Assertion(val, msg).to.not.exist;
   }


### PR DESCRIPTION
I wanna get more usage out of JSDoc comments. This is a sort of cleanup before adding a linter for JSDoc comments which would prevent us from writing invalid or otherwise wrong JSDocs in the future.