### PR TITLE
Convert comments in "legal comments" format to jsdoc or normal comments

### DIFF
--- a/lib/chai.js
+++ b/lib/chai.js
@@ -15,10 +15,7 @@ import {assert} from './chai/interface/assert.js';
 
 const used = [];
 
-/*!
- * Assertion Error
- */
-
+// Assertion Error
 export {AssertionError};
 
 /**
@@ -30,7 +27,6 @@ export {AssertionError};
  * @returns {this} for chaining
  * @api public
  */
-
 export function use(fn) {
   const exports = {
     AssertionError,
@@ -50,38 +46,20 @@ export function use(fn) {
   return exports;
 };
 
-/*!
- * Utility Functions
- */
-
+// Utility Functions
 export {util};
 
-/*!
- * Configuration
- */
-
+// Configuration
 export {config};
 
-/*!
- * Primary `Assertion` prototype
- */
-
+// Primary `Assertion` prototype
 export * from './chai/assertion.js';
 
-/*!
- * Expect interface
- */
-
+// Expect interface
 export * from './chai/interface/expect.js';
 
-/*!
- * Should interface
- */
-
+// Should interface
 export * from './chai/interface/should.js';
 
-/*!
- * Assert interface
- */
-
+// Assert interface
 export * from './chai/interface/assert.js';

--- a/lib/chai/assertion.js
+++ b/lib/chai/assertion.js
@@ -9,7 +9,7 @@ import {config} from './config.js';
 import {AssertionError} from 'assertion-error';
 import * as util from './utils/index.js';
 
-/*!
+/**
  * Assertion Constructor
  *
  * Creates object for chaining.
@@ -147,14 +147,13 @@ Assertion.prototype.assert = function (expr, msg, negateMsg, expected, _actual, 
   }
 };
 
-/*!
+/**
  * ### ._obj
  *
  * Quick reference to stored `actual` value for plugin developers.
  *
  * @api private
  */
-
 Object.defineProperty(Assertion.prototype, '_obj',
   { get: function () {
       return util.flag(this, 'object');

--- a/lib/chai/interface/assert.js
+++ b/lib/chai/interface/assert.js
@@ -2883,7 +2883,7 @@ assert.decreasesButNotBy = function (fn, obj, prop, delta, msg) {
     .to.decrease(obj, prop).but.not.by(delta);
 }
 
-/*!
+/**
  * ### .ifError(object)
  *
  * Asserts if value is not a false value, and throws if it is a true value.
@@ -3084,7 +3084,7 @@ assert.isNotEmpty = function(val, msg) {
   new Assertion(val, msg, assert.isNotEmpty, true).to.not.be.empty;
 };
 
-/*!
+/**
  * Aliases.
  */
 

--- a/lib/chai/utils/addChainableMethod.js
+++ b/lib/chai/utils/addChainableMethod.js
@@ -4,17 +4,13 @@
  * MIT Licensed
  */
 
-/*!
- * Module dependencies
- */
-
 import {Assertion} from '../assertion.js';
 import {addLengthGuard} from './addLengthGuard.js';
 import {flag} from './flag.js';
 import {proxify} from './proxify.js';
 import {transferFlags} from './transferFlags.js';
 
-/*!
+/**
  * Module variables
  */
 

--- a/lib/chai/utils/compareByInspect.js
+++ b/lib/chai/utils/compareByInspect.js
@@ -4,10 +4,6 @@
  * MIT Licensed
  */
 
-/*!
- * Module dependencies
- */
-
 import {inspect} from './inspect.js';
 
 /**

--- a/lib/chai/utils/getMessage.js
+++ b/lib/chai/utils/getMessage.js
@@ -4,10 +4,6 @@
  * MIT Licensed
  */
 
-/*!
- * Module dependencies
- */
-
 import {flag} from './flag.js';
 import {getActual} from './getActual.js';
 import {objDisplay} from './objDisplay.js';

--- a/lib/chai/utils/getOwnEnumerableProperties.js
+++ b/lib/chai/utils/getOwnEnumerableProperties.js
@@ -4,10 +4,6 @@
  * MIT Licensed
  */
 
-/*!
- * Module dependencies
- */
-
 import {getOwnEnumerablePropertySymbols} from './getOwnEnumerablePropertySymbols.js';
 
 /**

--- a/lib/chai/utils/index.js
+++ b/lib/chai/utils/index.js
@@ -4,171 +4,88 @@
  * MIT Licensed
  */
 
-/*!
- * Dependencies that are used for multiple exports are required here only once
- */
-
+// Dependencies that are used for multiple exports are required here only once
 import * as checkError from 'check-error';
 
-/*!
- * test utility
- */
-
+// test utility
 export {test} from './test.js';
 
-/*!
- * type utility
- */
-
+// type utility
 export {type} from './type-detect.js';
 
-/*!
- * expectTypes utility
- */
+// expectTypes utility
 export {expectTypes} from './expectTypes.js';
 
-/*!
- * message utility
- */
-
+// message utility
 export {getMessage} from './getMessage.js';
 
-/*!
- * actual utility
- */
-
+// actual utility
 export {getActual} from './getActual.js';
 
-/*!
- * Inspect util
- */
-
+// Inspect util
 export {inspect} from './inspect.js';
 
-/*!
- * Object Display util
- */
-
+// Object Display util
 export {objDisplay} from './objDisplay.js';
 
-/*!
- * Flag utility
- */
-
+// Flag utility
 export {flag} from './flag.js';
 
-/*!
- * Flag transferring utility
- */
-
+// Flag transferring utility
 export {transferFlags} from './transferFlags.js';
 
-/*!
- * Deep equal utility
- */
-
+// Deep equal utility
 export {default as eql} from 'deep-eql';
 
-/*!
- * Deep path info
- */
-
+// Deep path info
 export {getPathInfo, hasProperty} from 'pathval';
 
-/*!
- * Function name
- */
-
+// Function name
 export function getName(fn) {
   return fn.name
 }
 
-/*!
- * add Property
- */
-
+// add Property
 export {addProperty} from './addProperty.js';
 
-/*!
- * add Method
- */
-
+// add Method
 export {addMethod} from './addMethod.js';
 
-/*!
- * overwrite Property
- */
-
+// overwrite Property
 export {overwriteProperty} from './overwriteProperty.js';
 
-/*!
- * overwrite Method
- */
-
+// overwrite Method
 export {overwriteMethod} from './overwriteMethod.js';
 
-/*!
- * Add a chainable method
- */
-
+// Add a chainable method
 export {addChainableMethod} from './addChainableMethod.js';
 
-/*!
- * Overwrite chainable method
- */
-
+// Overwrite chainable method
 export {overwriteChainableMethod} from './overwriteChainableMethod.js';
 
-/*!
- * Compare by inspect method
- */
-
+// Compare by inspect method
 export {compareByInspect} from './compareByInspect.js';
 
-/*!
- * Get own enumerable property symbols method
- */
-
+// Get own enumerable property symbols method
 export {getOwnEnumerablePropertySymbols} from './getOwnEnumerablePropertySymbols.js';
 
-/*!
- * Get own enumerable properties method
- */
-
+// Get own enumerable properties method
 export {getOwnEnumerableProperties} from './getOwnEnumerableProperties.js';
 
-/*!
- * Checks error against a given set of criteria
- */
-
+// Checks error against a given set of criteria
 export {checkError};
 
-/*!
- * Proxify util
- */
-
+// Proxify util
 export {proxify} from './proxify.js';
 
-/*!
- * addLengthGuard util
- */
-
+// addLengthGuard util
 export {addLengthGuard} from './addLengthGuard.js';
 
-/*!
- * isProxyEnabled helper
- */
-
+// isProxyEnabled helper
 export {isProxyEnabled} from './isProxyEnabled.js';
 
-/*!
- * isNaN method
- */
-
+// isNaN method
 export {isNaN} from './isNaN.js';
 
-/*!
- * getOperator method
- */
-
+// getOperator method
 export {getOperator} from './getOperator.js';

--- a/lib/chai/utils/objDisplay.js
+++ b/lib/chai/utils/objDisplay.js
@@ -4,10 +4,6 @@
  * MIT Licensed
  */
 
-/*!
- * Module dependencies
- */
-
 import {inspect} from './inspect.js';
 import {config} from '../config.js';
 

--- a/lib/chai/utils/test.js
+++ b/lib/chai/utils/test.js
@@ -4,10 +4,6 @@
  * MIT Licensed
  */
 
-/*!
- * Module dependencies
- */
-
 import {flag} from './flag.js';
 
 /**


### PR DESCRIPTION
These are preserved by default in some bundlers (not sure why you'd bundle chai but 🤷🏻 ). Figured this was more correct than not.

See https://esbuild.github.io/api/#legal-comments

Fixes https://github.com/chaijs/chai/issues/1425