### PR TITLE
Assert interface fix 

### DIFF
--- a/lib/chai/interface/assert.js
+++ b/lib/chai/interface/assert.js
@@ -1633,7 +1633,7 @@ assert.hasAnyKeys = function (obj, keys, msg) {
  *     assert.hasAllKeys({foo: 1, bar: 2, baz: 3}, ['foo', 'bar', 'baz']);
  *     assert.hasAllKeys({foo: 1, bar: 2, baz: 3}, {foo: 30, bar: 99, baz: 1337]);
  *     assert.hasAllKeys(new Map([[{foo: 1}, 'bar'], ['key', 'value']]), [{foo: 1}, 'key']);
- *     assert.hasAllKeys(new Set([{foo: 'bar'}, 'anotherKey'], [{foo: 'bar'}, 'anotherKey']);
+ *     assert.hasAllKeys(new Set([{foo: 'bar'}, 'anotherKey']), [{foo: 'bar'}, 'anotherKey']);
  *
  * @name hasAllKeys
  * @param {unknown} object
@@ -1659,8 +1659,8 @@ assert.hasAllKeys = function (obj, keys, msg) {
  *     assert.containsAllKeys({foo: 1, bar: 2, baz: 3}, {foo: 30, bar: 99, baz: 1337});
  *     assert.containsAllKeys(new Map([[{foo: 1}, 'bar'], ['key', 'value']]), [{foo: 1}]);
  *     assert.containsAllKeys(new Map([[{foo: 1}, 'bar'], ['key', 'value']]), [{foo: 1}, 'key']);
- *     assert.containsAllKeys(new Set([{foo: 'bar'}, 'anotherKey'], [{foo: 'bar'}]);
- *     assert.containsAllKeys(new Set([{foo: 'bar'}, 'anotherKey'], [{foo: 'bar'}, 'anotherKey']);
+ *     assert.containsAllKeys(new Set([{foo: 'bar'}, 'anotherKey']), [{foo: 'bar'}]);
+ *     assert.containsAllKeys(new Set([{foo: 'bar'}, 'anotherKey']), [{foo: 'bar'}, 'anotherKey']);
  *
  * @name containsAllKeys
  * @param {unknown} object
@@ -1684,7 +1684,7 @@ assert.containsAllKeys = function (obj, keys, msg) {
  *     assert.doesNotHaveAnyKeys({foo: 1, bar: 2, baz: 3}, ['one', 'two', 'example']);
  *     assert.doesNotHaveAnyKeys({foo: 1, bar: 2, baz: 3}, {one: 1, two: 2, example: 'foo'});
  *     assert.doesNotHaveAnyKeys(new Map([[{foo: 1}, 'bar'], ['key', 'value']]), [{one: 'two'}, 'example']);
- *     assert.doesNotHaveAnyKeys(new Set([{foo: 'bar'}, 'anotherKey'], [{one: 'two'}, 'example']);
+ *     assert.doesNotHaveAnyKeys(new Set([{foo: 'bar'}, 'anotherKey']), [{one: 'two'}, 'example']);
  *
  * @name doesNotHaveAnyKeys
  * @param {unknown} object
@@ -1708,7 +1708,7 @@ assert.doesNotHaveAnyKeys = function (obj, keys, msg) {
  *     assert.doesNotHaveAllKeys({foo: 1, bar: 2, baz: 3}, ['one', 'two', 'example']);
  *     assert.doesNotHaveAllKeys({foo: 1, bar: 2, baz: 3}, {one: 1, two: 2, example: 'foo'});
  *     assert.doesNotHaveAllKeys(new Map([[{foo: 1}, 'bar'], ['key', 'value']]), [{one: 'two'}, 'example']);
- *     assert.doesNotHaveAllKeys(new Set([{foo: 'bar'}, 'anotherKey'], [{one: 'two'}, 'example']);
+ *     assert.doesNotHaveAllKeys(new Set([{foo: 'bar'}, 'anotherKey']), [{one: 'two'}, 'example']);
  *
  * @name doesNotHaveAllKeys
  * @param {unknown} object

--- a/lib/chai/interface/assert.js
+++ b/lib/chai/interface/assert.js
@@ -1093,7 +1093,7 @@ assert.ownInclude = function(exp, inc, msg) {
 /**
  * ### .notOwnInclude(haystack, needle, [message])
  *
- * Asserts that 'haystack' includes 'needle'.
+ * Asserts that 'haystack' does not include 'needle'.
  * Can be used to assert the absence of a subset of properties in an
  * object while ignoring inherited properties.
  *
@@ -1136,7 +1136,7 @@ assert.deepOwnInclude = function(exp, inc, msg) {
  /**
  * ### .notDeepOwnInclude(haystack, needle, [message])
  *
- * Asserts that 'haystack' includes 'needle'.
+ * Asserts that 'haystack' does not include 'needle'.
  * Can be used to assert the absence of a subset of properties in an
  * object while ignoring inherited properties and checking for deep equality.
  *


### PR DESCRIPTION
- notOwnInclude, notDeepOwnInclude description modify include negative expression
- ")" is added to the example code where there is a syntax error because it does not have ")"
