### PR TITLE
fix: support some virtual contexts in `toThrow`

### DIFF
--- a/lib/chai/core/assertions.js
+++ b/lib/chai/core/assertions.js
@@ -2676,7 +2676,7 @@ function assertThrows (errorLike, errMsgMatcher, msg) {
     , negate = flag(this, 'negate') || false;
   new Assertion(obj, flagMsg, ssfi, true).is.a('function');
 
-  if (errorLike instanceof RegExp || typeof errorLike === 'string') {
+  if (_.isRegExp(errorLike) || typeof errorLike === 'string') {
     errMsgMatcher = errorLike;
     errorLike = null;
   }
@@ -2709,7 +2709,7 @@ function assertThrows (errorLike, errMsgMatcher, msg) {
     }
 
     this.assert(
-        caughtErr
+        caughtErr !== undefined
       , 'expected #{this} to throw ' + errorLikeString
       , 'expected #{this} to not throw an error but #{act} was thrown'
       , errorLike && errorLike.toString()
@@ -2760,7 +2760,7 @@ function assertThrows (errorLike, errMsgMatcher, msg) {
   if (caughtErr && errMsgMatcher !== undefined && errMsgMatcher !== null) {
     // Here we check compatible messages
     var placeholder = 'including';
-    if (errMsgMatcher instanceof RegExp) {
+    if (_.isRegExp(errMsgMatcher)) {
       placeholder = 'matching'
     }
 

--- a/lib/chai/core/assertions.js
+++ b/lib/chai/core/assertions.js
@@ -2681,10 +2681,12 @@ function assertThrows (errorLike, errMsgMatcher, msg) {
     errorLike = null;
   }
 
-  var caughtErr;
+  let caughtErr;
+  let errorWasThrown = false;
   try {
     obj();
   } catch (err) {
+    errorWasThrown = true;
     caughtErr = err;
   }
 
@@ -2708,14 +2710,26 @@ function assertThrows (errorLike, errMsgMatcher, msg) {
       errorLikeString = _.checkError.getConstructorName(errorLike);
     }
 
+    let actual = caughtErr;
+    if (caughtErr instanceof Error) {
+      actual = caughtErr.toString();
+    } else if (typeof caughtErr === 'string') {
+      actual = caughtErr;
+    } else if (caughtErr && (typeof caughtErr === 'object' || typeof caughtErr === 'function')) {
+      try {
+        actual = _.checkError.getConstructorName(caughtErr);
+      } catch (_err) {
+        // somehow wasn't a constructor, maybe we got a function thrown
+        // or similar
+      }
+    }
+
     this.assert(
-        caughtErr !== undefined
+      errorWasThrown
       , 'expected #{this} to throw ' + errorLikeString
       , 'expected #{this} to not throw an error but #{act} was thrown'
       , errorLike && errorLike.toString()
-      , (caughtErr instanceof Error ?
-          caughtErr.toString() : (typeof caughtErr === 'string' ? caughtErr : caughtErr &&
-                                  _.checkError.getConstructorName(caughtErr)))
+      , actual
     );
   }
 

--- a/lib/chai/utils/index.js
+++ b/lib/chai/utils/index.js
@@ -95,6 +95,12 @@ export {isNaN} from './isNaN.js';
 // getOperator method
 export {getOperator} from './getOperator.js';
 
+/**
+ * Determines if an object is a `RegExp`
+ * This is used since `instanceof` will not work in virtual contexts
+ * @param {*} obj Object to test
+ * @return {boolean}
+ */
 export function isRegExp(obj) {
   return Object.prototype.toString.call(obj) === '[object RegExp]';
 }

--- a/lib/chai/utils/index.js
+++ b/lib/chai/utils/index.js
@@ -94,3 +94,7 @@ export {isNaN} from './isNaN.js';
 
 // getOperator method
 export {getOperator} from './getOperator.js';
+
+export function isRegExp(obj) {
+  return Object.prototype.toString.call(obj) === '[object RegExp]';
+}

--- a/lib/chai/utils/index.js
+++ b/lib/chai/utils/index.js
@@ -98,8 +98,9 @@ export {getOperator} from './getOperator.js';
 /**
  * Determines if an object is a `RegExp`
  * This is used since `instanceof` will not work in virtual contexts
+ *
  * @param {*} obj Object to test
- * @return {boolean}
+ * @returns {boolean}
  */
 export function isRegExp(obj) {
   return Object.prototype.toString.call(obj) === '[object RegExp]';

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "assertion-error": "^2.0.1",
-        "check-error": "^2.0.0",
+        "check-error": "^2.1.1",
         "deep-eql": "^5.0.1",
         "loupe": "^3.1.0",
         "pathval": "^2.0.0"
@@ -2027,9 +2027,9 @@
       }
     },
     "node_modules/check-error": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.0.0.tgz",
-      "integrity": "sha512-tjLAOBHKVxtPoHe/SA7kNOMvhCRdCJ3vETdeY0RuAc9popf+hyaSV6ZEg9hr4cpWF7jmo/JSWEnLDrnijS9Tog==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.1.tgz",
+      "integrity": "sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==",
       "engines": {
         "node": ">= 16"
       }

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   },
   "dependencies": {
     "assertion-error": "^2.0.1",
-    "check-error": "^2.0.0",
+    "check-error": "^2.1.1",
     "deep-eql": "^5.0.1",
     "loupe": "^3.1.0",
     "pathval": "^2.0.0"

--- a/test/assert.js
+++ b/test/assert.js
@@ -1635,6 +1635,8 @@ describe('assert', function () {
   });
 
   it('throws / throw / Throw', function() {
+    class CustomError extends Error {}
+
     ['throws', 'throw', 'Throw'].forEach(function (throws) {
       assert[throws](function() { throw new Error('foo'); });
       assert[throws](function() { throw new Error(''); }, '');
@@ -1647,6 +1649,9 @@ describe('assert', function () {
       assert[throws](function() { throw ''; }, '');
       assert[throws](function() { throw ''; }, /^$/);
       assert[throws](function() { throw new Error(''); }, /^$/);
+      assert[throws](function() { throw undefined; });
+      assert[throws](function() { throw new CustomError('foo'); });
+      assert[throws](function() { throw (() => {}); });
 
       var thrownErr = assert[throws](function() { throw new Error('foo'); });
       assert(thrownErr instanceof Error, 'assert.' + throws + ' returns error');

--- a/test/assert.js
+++ b/test/assert.js
@@ -1644,6 +1644,9 @@ describe('assert', function () {
       assert[throws](function() { throw new Error('bar'); }, Error, 'bar');
       assert[throws](function() { throw new Error(''); }, Error, '');
       assert[throws](function() { throw new Error('foo') }, '');
+      assert[throws](function() { throw ''; }, '');
+      assert[throws](function() { throw ''; }, /^$/);
+      assert[throws](function() { throw new Error(''); }, /^$/);
 
       var thrownErr = assert[throws](function() { throw new Error('foo'); });
       assert(thrownErr instanceof Error, 'assert.' + throws + ' returns error');

--- a/test/virtual-machines.js
+++ b/test/virtual-machines.js
@@ -1,0 +1,31 @@
+import vm from 'node:vm';
+import * as chai from '../index.js';
+
+const {assert} = chai;
+const vmContext = {assert};
+vm.createContext(vmContext);
+
+function runCodeInVm(code) {
+  vm.runInContext(code, vmContext);
+}
+
+describe('node virtual machines', function () {
+  it('throws', function() {
+    const shouldNotThrow = [
+      `assert.throws(function() { throw ''; }, /^$/);`,
+      `assert.throws(function() { throw new Error('bleepbloop'); });`,
+      `assert.throws(function() { throw new Error(''); });`,
+      // TODO (43081j): enable this test once check-error supports
+      // cross-vm `Error` objects
+      //`assert.throws(function() { throw new Error('swoosh'); }, /swoosh/);`
+    ];
+
+    for (const code of shouldNotThrow) {
+      assert.doesNotThrow(
+        () => {
+          runCodeInVm(code);
+        }
+      );
+    }
+  });
+});

--- a/test/virtual-machines.js
+++ b/test/virtual-machines.js
@@ -5,6 +5,11 @@ const {assert} = chai;
 const vmContext = {assert};
 vm.createContext(vmContext);
 
+/**
+ * Run the code in a virtual context
+ *
+ * @param {string} code Code to run
+ */
 function runCodeInVm(code) {
   vm.runInContext(code, vmContext);
 }
@@ -15,9 +20,7 @@ describe('node virtual machines', function () {
       `assert.throws(function() { throw ''; }, /^$/);`,
       `assert.throws(function() { throw new Error('bleepbloop'); });`,
       `assert.throws(function() { throw new Error(''); });`,
-      // TODO (43081j): enable this test once check-error supports
-      // cross-vm `Error` objects
-      //`assert.throws(function() { throw new Error('swoosh'); }, /swoosh/);`
+      `assert.throws(function() { throw new Error('swoosh'); }, /swoosh/);`
     ];
 
     for (const code of shouldNotThrow) {

--- a/web-test-runner.config.js
+++ b/web-test-runner.config.js
@@ -5,7 +5,10 @@ const commonjs = fromRollup(rollupCommonjs);
 
 export default {
   nodeResolve: true,
-  files: ["test/*.js"],
+  files: [
+    "test/*.js",
+    "!test/virtual-machines.js"
+  ],
   plugins: [
     commonjs({
       include: [


### PR DESCRIPTION
This adds support for VM situations where we pass a `RegExp` from another process.

Note that we don't have a full fix for this stuff until `check-error` also supports `Error` being from another origin.

**There's also a tiny fix in here for supporting `throw ''`.** I have left a PR comment by the relevant line of code