### PR TITLE
Correct Mocha import instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,9 +98,9 @@ import { expect, use } from 'chai';  // Creates local variables `expect` and `us
 ### Usage with Mocha
 
 ```bash
-mocha spec.js -r chai/register-assert.js  # Using Assert style
-mocha spec.js -r chai/register-expect.js  # Using Expect style
-mocha spec.js -r chai/register-should.js  # Using Should style
+mocha spec.js --require chai/register-assert.js  # Using Assert style
+mocha spec.js --require chai/register-expect.js  # Using Expect style
+mocha spec.js --require chai/register-should.js  # Using Should style
 ```
 
 [Read more about these styles in our docs](http://chaijs.com/guide/styles/).

--- a/README.md
+++ b/README.md
@@ -98,9 +98,9 @@ import { expect, use } from 'chai';  // Creates local variables `expect` and `us
 ### Usage with Mocha
 
 ```bash
-mocha spec.js -r chai/register-assert  # Using Assert style
-mocha spec.js -r chai/register-expect  # Using Expect style
-mocha spec.js -r chai/register-should  # Using Should style
+mocha spec.js -r chai/register-assert.js  # Using Assert style
+mocha spec.js -r chai/register-expect.js  # Using Expect style
+mocha spec.js -r chai/register-should.js  # Using Should style
 ```
 
 [Read more about these styles in our docs](http://chaijs.com/guide/styles/).


### PR DESCRIPTION
Fix #1455.

I also suggest to use long options to make it clearer for users what the option does exactly. Feel free to merge only https://github.com/chaijs/chai/commit/7720f82b00a8c67cf205b731a5482f0387d6a9e0 if that is not desired 🙂 