### PR TITLE
Enable chaining of chai plugins

### DIFF
--- a/lib/chai.js
+++ b/lib/chai.js
@@ -13,8 +13,6 @@ import {Assertion} from './chai/assertion.js';
 import * as should from './chai/interface/should.js';
 import {assert} from './chai/interface/assert.js';
 
-const used = [];
-
 // Assertion Error
 export {AssertionError};
 
@@ -35,16 +33,14 @@ export function use(fn) {
     expect,
     assert,
     Assertion,
-    ...should
+    use,
+    ...should,
   };
 
-  if (!~used.indexOf(fn)) {
-    fn(exports, util);
-    used.push(fn);
-  }
+  fn(exports, util);
 
   return exports;
-};
+}
 
 // Utility Functions
 export {util};

--- a/test/plugins.js
+++ b/test/plugins.js
@@ -3,6 +3,8 @@ import {use, expect, Should} from '../index.js';
 function plugin(chai) {
   if (chai.Assertion.prototype.testing) return;
 
+  chai.assert.testing = 'successful';
+
   Object.defineProperty(chai.Assertion.prototype, 'testing', {
     get: function () {
       return 'successful';
@@ -12,6 +14,8 @@ function plugin(chai) {
 
 function anotherPlugin(chai) {
   if (chai.Assertion.prototype.moreTesting) return;
+
+  chai.assert.moreTesting = 'more success';
 
   Object.defineProperty(chai.Assertion.prototype, 'moreTesting', {
     get: function () {
@@ -77,6 +81,26 @@ describe('plugins', function () {
       const {expect} = use(anotherPlugin);
 
       expect(expect('').moreTesting).to.equal('more success');
+    });
+  });
+
+  describe('assert', () => {
+    it('basic usage', function () {
+      const {assert} = use(plugin);
+      expect(assert.testing).to.equal('successful');
+    });
+
+    it('multiple plugins apply all changes', function () {
+      const chai = use(plugin).use(anotherPlugin);
+
+      expect(chai.assert.testing).to.equal('successful');
+      expect(chai.assert.moreTesting).to.equal('more success');
+    });
+
+    it('.use detached from chai object', function () {
+      const {assert} = use(anotherPlugin);
+
+      expect(assert.moreTesting).to.equal('more success');
     });
   });
 });

--- a/test/plugins.js
+++ b/test/plugins.js
@@ -1,4 +1,4 @@
-import {use, expect} from '../index.js';
+import {use, expect, Should} from '../index.js';
 
 function plugin(chai) {
   if (chai.Assertion.prototype.testing) return;
@@ -30,27 +30,53 @@ function brokenPlugin(chai) {
 }
 
 describe('plugins', function () {
-  it('basic usage', function () {
-    const {expect} = use(plugin);
-    expect(expect('').testing).to.equal('successful');
-  });
-
-  it('multiple plugins apply all changes', function () {
-    const chai = use(plugin).use(anotherPlugin);
-
-    expect(chai.expect('').testing).to.equal('successful');
-    expect(chai.expect('').moreTesting).to.equal('more success');
-  });
-
   it("doesn't crash when there's a bad plugin", function () {
     expect(() => {
       use(brokenPlugin).use(brokenPlugin).use(brokenPlugin);
     }).to.not.throw;
   });
 
-  it('.use detached from chai object', function () {
-    const {expect} = use(anotherPlugin);
+  describe('should', () => {
+    before(() => {
+      Should();
+    });
 
-    expect(expect('').moreTesting).to.equal('more success');
+    it('basic usage', function () {
+      use(plugin);
+      expect((42).should.testing).to.equal('successful');
+    });
+
+    it('multiple plugins apply all changes', function () {
+      use(plugin).use(anotherPlugin);
+
+      expect((42).should.testing).to.equal('successful');
+      expect((42).should.moreTesting).to.equal('more success');
+    });
+
+    it('.use detached from chai object', function () {
+      use(anotherPlugin);
+
+      expect((42).should.moreTesting).to.equal('more success');
+    });
+  });
+
+  describe('expect', () => {
+    it('basic usage', function () {
+      const {expect} = use(plugin);
+      expect(expect('').testing).to.equal('successful');
+    });
+
+    it('multiple plugins apply all changes', function () {
+      const chai = use(plugin).use(anotherPlugin);
+
+      expect(chai.expect('').testing).to.equal('successful');
+      expect(chai.expect('').moreTesting).to.equal('more success');
+    });
+
+    it('.use detached from chai object', function () {
+      const {expect} = use(anotherPlugin);
+
+      expect(expect('').moreTesting).to.equal('more success');
+    });
   });
 });

--- a/test/plugins.js
+++ b/test/plugins.js
@@ -20,6 +20,15 @@ function anotherPlugin(chai) {
   });
 }
 
+function brokenPlugin(chai) {
+  chai.overwriteProperty('equal', function (_super) {
+    if (something) {
+      return _super.call(this);
+    }
+    return someOtherThing();
+  });
+}
+
 describe('plugins', function () {
   it('basic usage', function () {
     const {expect} = use(plugin);
@@ -30,6 +39,11 @@ describe('plugins', function () {
     expect(function () {
       use(plugin).use(anotherPlugin);
     }).to.not.throw();
+
+  it("doesn't crash when there's a bad plugin", function () {
+    expect(() => {
+      use(brokenPlugin).use(brokenPlugin).use(brokenPlugin);
+    }).to.not.throw;
   });
 
   it('.use detached from chai object', function () {

--- a/test/plugins.js
+++ b/test/plugins.js
@@ -1,5 +1,10 @@
-import {use, expect, Should} from '../index.js';
+import {use, assert, expect, Should} from '../index.js';
 
+/**
+ * A chai plugin that adds the `testing` property on chai assertions.
+ *
+ * @param {unknown} chai
+ */
 function plugin(chai) {
   if (chai.Assertion.prototype.testing) return;
 
@@ -12,6 +17,11 @@ function plugin(chai) {
   });
 }
 
+/**
+ * A chai plugin that adds the `moreTesting` property on chai assertions.
+ *
+ * @param {unknown} chai
+ */
 function anotherPlugin(chai) {
   if (chai.Assertion.prototype.moreTesting) return;
 
@@ -24,6 +34,11 @@ function anotherPlugin(chai) {
   });
 }
 
+/**
+ * A exmple of a "bad" plugin for chai that overwrites the `equal` property.
+ *
+ * @param {unknown} chai
+ */
 function brokenPlugin(chai) {
   chai.overwriteProperty('equal', function (_super) {
     if (something) {
@@ -34,6 +49,10 @@ function brokenPlugin(chai) {
 }
 
 describe('plugins', function () {
+  // Plugins are not applied "immutably" on chai so we want to just apply them
+  // here globally and then run all the tests.
+  use(plugin).use(anotherPlugin);
+
   it("doesn't crash when there's a bad plugin", function () {
     expect(() => {
       use(brokenPlugin).use(brokenPlugin).use(brokenPlugin);
@@ -46,60 +65,45 @@ describe('plugins', function () {
     });
 
     it('basic usage', function () {
-      use(plugin);
       expect((42).should.testing).to.equal('successful');
     });
 
     it('multiple plugins apply all changes', function () {
-      use(plugin).use(anotherPlugin);
-
       expect((42).should.testing).to.equal('successful');
       expect((42).should.moreTesting).to.equal('more success');
     });
 
     it('.use detached from chai object', function () {
-      use(anotherPlugin);
-
       expect((42).should.moreTesting).to.equal('more success');
     });
   });
 
   describe('expect', () => {
     it('basic usage', function () {
-      const {expect} = use(plugin);
       expect(expect('').testing).to.equal('successful');
     });
 
     it('multiple plugins apply all changes', function () {
-      const chai = use(plugin).use(anotherPlugin);
-
-      expect(chai.expect('').testing).to.equal('successful');
-      expect(chai.expect('').moreTesting).to.equal('more success');
+      expect(expect('').testing).to.equal('successful');
+      expect(expect('').moreTesting).to.equal('more success');
     });
 
     it('.use detached from chai object', function () {
-      const {expect} = use(anotherPlugin);
-
       expect(expect('').moreTesting).to.equal('more success');
     });
   });
 
   describe('assert', () => {
     it('basic usage', function () {
-      const {assert} = use(plugin);
       expect(assert.testing).to.equal('successful');
     });
 
     it('multiple plugins apply all changes', function () {
-      const chai = use(plugin).use(anotherPlugin);
-
-      expect(chai.assert.testing).to.equal('successful');
-      expect(chai.assert.moreTesting).to.equal('more success');
+      expect(assert.testing).to.equal('successful');
+      expect(assert.moreTesting).to.equal('more success');
     });
 
     it('.use detached from chai object', function () {
-      const {assert} = use(anotherPlugin);
-
       expect(assert.moreTesting).to.equal('more success');
     });
   });

--- a/test/plugins.js
+++ b/test/plugins.js
@@ -1,42 +1,40 @@
-import * as chai from '../index.js';
+import {use, expect} from '../index.js';
+
+function plugin(chai) {
+  if (chai.Assertion.prototype.testing) return;
+
+  Object.defineProperty(chai.Assertion.prototype, 'testing', {
+    get: function () {
+      return 'successful';
+    },
+  });
+}
+
+function anotherPlugin(chai) {
+  if (chai.Assertion.prototype.moreTesting) return;
+
+  Object.defineProperty(chai.Assertion.prototype, 'moreTesting', {
+    get: function () {
+      return 'more success';
+    },
+  });
+}
 
 describe('plugins', function () {
-
-  function plugin (chai) {
-    if (chai.Assertion.prototype.testing) return;
-
-    Object.defineProperty(chai.Assertion.prototype, 'testing', {
-      get: function () {
-        return 'successful';
-      }
-    });
-  }
-
   it('basic usage', function () {
-    chai.use(plugin);
-    var expect = chai.expect;
+    const {expect} = use(plugin);
     expect(expect('').testing).to.equal('successful');
   });
 
-  it('double plugin', function () {
-    chai.expect(function () {
-      chai.use(plugin);
+  it('multiple plugins', function () {
+    expect(function () {
+      use(plugin).use(anotherPlugin);
     }).to.not.throw();
   });
 
   it('.use detached from chai object', function () {
-    function anotherPlugin (chai) {
-      Object.defineProperty(chai.Assertion.prototype, 'moreTesting', {
-        get: function () {
-          return 'more success';
-        }
-      });
-    }
+    const {expect} = use(anotherPlugin);
 
-    var use = chai.use;
-    use(anotherPlugin);
-
-    var expect = chai.expect;
     expect(expect('').moreTesting).to.equal('more success');
   });
 });

--- a/test/plugins.js
+++ b/test/plugins.js
@@ -35,10 +35,12 @@ describe('plugins', function () {
     expect(expect('').testing).to.equal('successful');
   });
 
-  it('multiple plugins', function () {
-    expect(function () {
-      use(plugin).use(anotherPlugin);
-    }).to.not.throw();
+  it('multiple plugins apply all changes', function () {
+    const chai = use(plugin).use(anotherPlugin);
+
+    expect(chai.expect('').testing).to.equal('successful');
+    expect(chai.expect('').moreTesting).to.equal('more success');
+  });
 
   it("doesn't crash when there's a bad plugin", function () {
     expect(() => {


### PR DESCRIPTION
This changes moves the responsibility of checking if a plugin has already been registered to the plugin itself.

I _think_ this fixes https://github.com/chaijs/chai/issues/1603, if not I probably need a better test to make sure.