### PR TITLE
feat: add assert deepMatch methods

### DIFF
--- a/lib/chai/core/assertions.js
+++ b/lib/chai/core/assertions.js
@@ -2247,6 +2247,49 @@ Assertion.addMethod('match', assertMatch);
 Assertion.addMethod('matches', assertMatch);
 
 /**
+ * ### .match(re[, msg])
+ *
+ * Asserts that the target matches the given regular expression `re`.
+ *
+ *     expect('foobar').to.match(/^foo/);
+ *
+ * Add `.not` earlier in the chain to negate `.match`.
+ *
+ *     expect('foobar').to.not.match(/taco/);
+ *
+ * `.match` accepts an optional `msg` argument which is a custom error message
+ * to show when the assertion fails. The message can also be given as the
+ * second argument to `expect`.
+ *
+ *     expect('foobar').to.match(/taco/, 'nooo why fail??');
+ *     expect('foobar', 'nooo why fail??').to.match(/taco/);
+ *
+ * The alias `.matches` can be used interchangeably with `.match`.
+ *
+ * @name match
+ * @alias matches
+ * @param {RegExp} re
+ * @param {string} msg _optional_
+ * @namespace BDD
+ * @public
+ */
+function assertDeepMatch(re, msg) {
+  if (msg) flag(this, 'message', msg);
+  var obj = flag(this, 'object');
+  const matches = re.exec(obj); 
+  this.assert(
+    matches !== null ? matches[0] == obj : null
+    , 'expected #{this} to match ' + re
+    , 'expected #{this} not to match ' + re
+  );
+}
+
+Assertion.addMethod('deepMatch', assertDeepMatch);
+Assertion.addMethod('deepMatches', assertDeepMatch);
+
+
+
+/**
  * ### .string(str[, msg])
  *
  * Asserts that the target string contains the given substring `str`.

--- a/lib/chai/interface/assert.js
+++ b/lib/chai/interface/assert.js
@@ -1152,6 +1152,44 @@ assert.notDeepOwnInclude = function(exp, inc, msg) {
     .not.deep.own.include(inc);
 };
 
+
+
+/**
+ * ### .deepMatch(value, regexp, [message])
+ *
+ * Asserts that `value` completely matches the regular expression `regexp`.
+ *
+ *     assert.deepMatch('foobar', /^foo/, 'regexp matches');
+ *
+ * @name deepMatch
+ * @param {unknown} exp
+ * @param {RegExp} re
+ * @param {string} msg
+ * @namespace Assert
+ * @public
+ */
+assert.deepMatch = function (exp, re, msg) {
+  new Assertion(exp, msg, assert.deepMatch, true).to.deepMatch(re);
+};
+
+/**
+ * ### .notDeepMatch(value, regexp, [message])
+ *
+ * Asserts that `value` does not deep match the regular expression `regexp`.
+ *
+ *     assert.notDeepMatch('foobar', /^foo/, 'regexp does not match');
+ *
+ * @name notDeepMatch
+ * @param {unknown} exp
+ * @param {RegExp} re
+ * @param {string} msg
+ * @namespace Assert
+ * @public
+ */
+assert.notDeepMatch = function (exp, re, msg) {
+  new Assertion(exp, msg, assert.notDeepMatch, true).to.not.deepMatch(re);
+};
+
 /**
  * ### .match(value, regexp, [message])
  *

--- a/test/assert.js
+++ b/test/assert.js
@@ -1450,6 +1450,21 @@ describe('assert', function () {
     }, "blah: expected 'foobar' not to match /^foo/i");
   });
 
+  it("deepMatch", function () {
+    assert.deepMatch('foo', /^foo/);
+    assert.notDeepMatch('foobar', /^bar/);
+
+    err(function () {
+      assert.deepMatch('foobar', /^bar/i, 'blah');
+    }, "blah: expected 'foobar' to match /^bar/i");
+
+    err(function () {
+      assert.notDeepMatch('foobar', /^foobar/i, 'blah');
+    }, "blah: expected 'foobar' not to match /^foobar/i");
+
+    assert.notDeepMatch("fr33 mon3y", /fr[e3]|[e3]|[e3] money/i);
+  });
+
   it('property', function () {
     var obj = { foo: { bar: 'baz' } };
     var simpleObj = { foo: 'bar' };


### PR DESCRIPTION
This adds and test two brand new assert methods. The methods are `assert.deepMatch` and `assert.notDeepMatch`. The purpose of these two methods are to ensure that full regex matches are caught like in the case of the regex "/fr[e3]|[e3]|[e3] money/i"  and the test string "fr33 mon3y". While there are partial methods, there wasn't a way to assert there weren't.

Appropriate tests have been added. 

Closes #1643. 