### PR TITLE
chore: drop old CJS entrypoints

### DIFF
--- a/register-assert.cjs
+++ b/register-assert.cjs
@@ -1,3 +1,0 @@
-const {assert} = require('./chai.cjs');
-
-globalThis.assert = assert;

--- a/register-expect.cjs
+++ b/register-expect.cjs
@@ -1,3 +1,0 @@
-const {expect} = require('./chai.cjs');
-
-globalThis.expect = expect;

--- a/register-should.cjs
+++ b/register-should.cjs
@@ -1,3 +1,0 @@
-const {should} = require('./chai.cjs');
-
-globalThis.should = should();


### PR DESCRIPTION
Removes the old `register-*.cjs` entrypoints as they have been broken since we shipped ESM-only (since `chai.cjs` doesn't exist anymore).