### PR TITLE
chore: change `main` to point at chai directly

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "typescript": "~5.7.3"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@75lb/deep-merge": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "bugs": {
     "url": "https://github.com/chaijs/chai/issues"
   },
-  "main": "./chai.js",
+  "main": "./lib/chai.js",
   "scripts": {
     "prebuild": "npm run clean",
     "build": "npm run build:esm",


### PR DESCRIPTION
Instead of using a top-level re-export, we can just point `main` at the
chai entrypoint directly.

Later in life, we can remove `index.js` and `chai.js`.
