### PR TITLE
Update core contributors

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ concerns. We will do our best to respond in a timely manner.
 ### Core Contributor Alumni
 
 This project would not be what it is without the contributions from our prior
-contributors, for whom we are forever grateful:
+core contributors, for whom we are forever grateful:
 
 [![Jake Luer](https://avatars3.githubusercontent.com/u/58988?v=3&s=50)](https://github.com/logicalparadox)
 [![Veselin Todorov](https://avatars3.githubusercontent.com/u/330048?v=3&s=50)](https://github.com/vesln)


### PR DESCRIPTION
We should acknowledge the current active maintainers of this project, and the work they do for it, while also respecting the space (while acknowledging our gratitude) of those who are no longer contributing so actively.