### PR TITLE
feat: remove unbundled sources

### DIFF
--- a/chai.js
+++ b/chai.js
@@ -1,1 +1,0 @@
-export * from './index.js';

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,24 +8,22 @@
       "name": "chai",
       "version": "0.0.0-development",
       "license": "MIT",
-      "dependencies": {
-        "assertion-error": "^2.0.1",
-        "check-error": "^2.1.1",
-        "deep-eql": "^5.0.1",
-        "loupe": "^3.1.0",
-        "pathval": "^2.0.0"
-      },
       "devDependencies": {
         "@eslint/js": "^9.17.0",
         "@rollup/plugin-commonjs": "^25.0.7",
         "@web/dev-server-rollup": "^0.6.1",
         "@web/test-runner": "^0.18.0",
         "@web/test-runner-playwright": "^0.11.0",
+        "assertion-error": "^2.0.1",
         "c8": "^10.1.3",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
         "esbuild": "^0.25.9",
         "eslint": "^8.56.0",
         "eslint-plugin-jsdoc": "^48.0.4",
+        "loupe": "^3.1.0",
         "mocha": "^10.2.0",
+        "pathval": "^2.0.0",
         "prettier": "^3.4.2",
         "typescript": "~5.7.3"
       },
@@ -2027,6 +2025,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
       "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
       "engines": {
         "node": ">=12"
       }
@@ -2568,6 +2567,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.1.tgz",
       "integrity": "sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==",
+      "dev": true,
       "engines": {
         "node": ">= 16"
       }
@@ -2938,6 +2938,7 @@
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
       "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -4963,9 +4964,10 @@
       }
     },
     "node_modules/loupe": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.0.tgz",
-      "integrity": "sha512-2NCfZcT5VGVNX9mSZIxLRkEAegDGBpuQZBy13desuHeVORmBDyAET4TkJr4SjqQy3A8JDofMN6LpkK8Xcm/dlw==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/lru-cache": {
@@ -5569,9 +5571,11 @@
       }
     },
     "node_modules/pathval": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.0.tgz",
-      "integrity": "sha512-vE7JKRyES09KiunauX7nd2Q9/L7lhok4smP9RZTDeD4MVs72Dp2qNFVz39Nz5a0FVEW0BJR6C0DYrq6unoziZA==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 14.16"
       }

--- a/package.json
+++ b/package.json
@@ -11,9 +11,7 @@
     "chai"
   ],
   "files": [
-    "chai.js",
     "index.js",
-    "lib",
     "register-*.js"
   ],
   "homepage": "http://chaijs.com",

--- a/package.json
+++ b/package.json
@@ -48,24 +48,22 @@
   "engines": {
     "node": ">=18"
   },
-  "dependencies": {
-    "assertion-error": "^2.0.1",
-    "check-error": "^2.1.1",
-    "deep-eql": "^5.0.1",
-    "loupe": "^3.1.0",
-    "pathval": "^2.0.0"
-  },
   "devDependencies": {
     "@eslint/js": "^9.17.0",
     "@rollup/plugin-commonjs": "^25.0.7",
     "@web/dev-server-rollup": "^0.6.1",
     "@web/test-runner": "^0.18.0",
     "@web/test-runner-playwright": "^0.11.0",
+    "assertion-error": "^2.0.1",
     "c8": "^10.1.3",
+    "check-error": "^2.1.1",
+    "deep-eql": "^5.0.1",
     "esbuild": "^0.25.9",
     "eslint": "^8.56.0",
     "eslint-plugin-jsdoc": "^48.0.4",
+    "loupe": "^3.1.0",
     "mocha": "^10.2.0",
+    "pathval": "^2.0.0",
     "prettier": "^3.4.2",
     "typescript": "~5.7.3"
   }


### PR DESCRIPTION
We used to ship two of everything:

- `lib` - the unbundled sources
- `chai.js` - the bundle

We then moved to only shipping `lib`, but this results in a slower and slightly larger package.

This reverses that decision, such that we have only `index.js` (a bundle, what was `chai.js` before), and no longer have `lib`.

### BREAKING CHANGE

If we want to do any other breaks, now is the time since this'll result in a new major