### PR TITLE
fix: keep function/class names in bundle

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "main": "./index.js",
   "scripts": {
-    "build": "esbuild --bundle --format=esm --outfile=index.js lib/chai.js",
+    "build": "esbuild --bundle --format=esm --keep-names --outfile=index.js lib/chai.js",
     "prebuild": "npm run clean",
     "format": "prettier --write lib",
     "pretest": "npm run lint",


### PR DESCRIPTION
This changes the esbuild args so we enable `keep-names`.

This means classes and functions retain their original `name`, which various plugins depend on.
