### PR TITLE
feat(events): add addChainableMethod event

### DIFF
--- a/lib/chai/utils/addChainableMethod.js
+++ b/lib/chai/utils/addChainableMethod.js
@@ -5,6 +5,7 @@
  */
 
 import {Assertion} from '../assertion.js';
+import {PluginEvent, events} from './events.js';
 import {addLengthGuard} from './addLengthGuard.js';
 import {flag} from './flag.js';
 import {proxify} from './proxify.js';
@@ -35,6 +36,13 @@ let excludeNames = Object.getOwnPropertyNames(testFn).filter(function (name) {
 // Cache `Function` properties
 let call = Function.prototype.call,
   apply = Function.prototype.apply;
+
+export class PluginAddChainableMethodEvent extends PluginEvent {
+  constructor(type, name, fn, chainingBehavior) {
+    super(type, name, fn);
+    this.chainingBehavior = chainingBehavior;
+  }
+}
 
 /**
  * ### .addChainableMethod(ctx, name, method, chainingBehavior)
@@ -143,4 +151,13 @@ export function addChainableMethod(ctx, name, method, chainingBehavior) {
     },
     configurable: true
   });
+
+  events.dispatchEvent(
+    new PluginAddChainableMethodEvent(
+      'addChainableMethod',
+      name,
+      method,
+      chainingBehavior
+    )
+  );
 }

--- a/test/utilities.js
+++ b/test/utilities.js
@@ -1552,5 +1552,32 @@ describe('utilities', function () {
 
       expect(calledTimes).to.equal(1);
     });
+
+    it('emits addChainableMethod', function () {
+      var calledTimes = 0;
+
+      chai.use(function(_chai, _utils) {
+        const method = function () {
+          new chai.Assertion(this._obj).to.be.equal('x');
+        }
+        const _chainingBehavior = function () {
+          if (this._obj === Object(this._obj)) {
+            this._obj.__x = 'X!'
+          }
+        }
+
+        chai.util.events.addEventListener("addChainableMethod", eventHandler = function({ name, fn, chainingBehavior }) {
+          if (name === 'x' && fn === method && chainingBehavior === _chainingBehavior)
+            calledTimes++;
+        });
+        _chai.Assertion.addChainableMethod('x',
+          method
+        , _chainingBehavior
+        )
+
+      });
+
+      expect(calledTimes).to.equal(1);
+    });
   });
 });


### PR DESCRIPTION
I was working on the PR for `dirty-chai` when I noticed that I missed, they are also [overriding `addChainableMethod`](https://github.com/perrin4869/dirty-chai/blob/bb5d007b40a57080205afb81f7405cd1e8b89e84/lib/dirty-chai.js#L191) 🤦🏼
sorry for my oversight! This should do it  