### PR TITLE
chore: disable renovate for 4.x.x

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "baseBranchPatterns": ["main", "4.x.x"],
+  "baseBranchPatterns": ["main"],
   "extends": ["config:recommended"],
   "packageRules": [
     {


### PR DESCRIPTION
We don't have CI anymore and many of the updates require reworks we
already did in 5.x. Turning this off and we can handle important updates
(security) manually.
