### PR TITLE
assertion-error should be in dependencies, not devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,23 +48,25 @@
   "engines": {
     "node": ">=18"
   },
+  "dependencies": {
+    "assertion-error": "^2.0.1",
+    "check-error": "^2.1.1",
+    "deep-eql": "^5.0.1",
+    "loupe": "^3.1.0",
+    "pathval": "^2.0.0"
+  },
   "devDependencies": {
     "@eslint/js": "^9.17.0",
     "@rollup/plugin-commonjs": "^29.0.0",
     "@web/dev-server-rollup": "^0.6.1",
     "@web/test-runner": "^0.20.0",
     "@web/test-runner-playwright": "^0.11.0",
-    "assertion-error": "^2.0.1",
     "c8": "^10.1.3",
-    "check-error": "^2.1.1",
-    "deep-eql": "^5.0.1",
     "esbuild": "^0.27.0",
     "eslint": "^9.0.0",
     "eslint-plugin-jsdoc": "^61.0.0",
     "globals": "^16.3.0",
-    "loupe": "^3.1.0",
     "mocha": "^11.0.0",
-    "pathval": "^2.0.0",
     "prettier": "^3.4.2",
     "typescript": "~5.9.0"
   }


### PR DESCRIPTION
## Issue: `assertion-error` should be in `dependencies`, not `devDependencies`

### **Summary**
The `assertion-error` package is being used at runtime throughout the Chai library (e.g., in `chai.js`, `assertion.js`, `assertions.js`, etc.), but it is currently listed under `devDependencies` in `package.json`.

---

### **Problem**
Because `assertion-error` is listed as a development dependency, end users who install Chai via npm will not automatically receive it as a transitive dependency.  
This can cause **runtime import errors** when the library tries to require or import `assertion-error`.

---

### **Root Cause**
`assertion-error` is a **runtime dependency**, not a development-only one.  
It was incorrectly categorised under `devDependencies` instead of `dependencies`.

---

### **Proposed Solution**
Move the following entry:

----------------------------------------------------------------------------------------------------------------------------
Previous
----------------------------------------------------------------------------------------------------------------------------
<img width="366" height="443" alt="Screenshot 2025-11-12 at 11 16 11 PM" src="https://github.com/user-attachments/assets/17b9700a-0a13-4b10-af6c-4be9152828db" />

----------------------------------------------------------------------------------------------------------------------------
Updated
----------------------------------------------------------------------------------------------------------------------------
<img width="403" height="489" alt="Screenshot 2025-11-12 at 11 16 57 PM" src="https://github.com/user-attachments/assets/37dd1545-90a1-4dd2-a731-c6b36e6c0fd2" />

----------------------------------------------------------------------------------------------------------------------------
```json
"assertion-error": "^2.0.1" 

