### PR TITLE
fix(inspect): disable string-based customInspect to avoid .inspect collisions

### DIFF
--- a/lib/chai/utils/inspect.js
+++ b/lib/chai/utils/inspect.js
@@ -25,7 +25,8 @@ export function inspect(obj, showHidden, depth, colors) {
     colors: colors,
     depth: typeof depth === 'undefined' ? 2 : depth,
     showHidden: showHidden,
-    truncate: config.truncateThreshold ? config.truncateThreshold : Infinity
+    truncate: config.truncateThreshold ? config.truncateThreshold : Infinity,
+    customInspect: false 
   };
   return _inspect(obj, options);
 }


### PR DESCRIPTION
### Summary (#1708)

This PR fixes a long-standing issue where Chai's `inspect` wrapper
accidentally enables loupe's string-based custom inspection behavior,
causing collisions with user-defined `.inspect()` methods.

Because Chai hardcodes the options passed to loupe's `inspect` and does
not currently expose a way to configure `customInspect`, loupe ends up
calling any object's enumerable `.inspect()` method—even if it is not
intended as a Node.js inspection hook.

This results in objects being printed incorrectly or throwing errors
when their `.inspect()` method expects different parameters.

### Root Cause

loupe still interprets a plain string-keyed `.inspect` property as a
custom inspector when `customInspect` is true. Since Chai does not set
this option, the default behavior triggers unintentionally.

### Fix

This PR explicitly sets:

```js
customInspect: false
