### PR TITLE
fix: only consider unique expected keys in keys()

### DIFF
--- a/lib/chai/core/assertions.js
+++ b/lib/chai/core/assertions.js
@@ -2538,9 +2538,11 @@ function assertKeys(keys) {
     all = true;
   }
 
+  const uniqueExpected = [...new Set(expected)];
+
   // Has any
   if (any) {
-    ok = expected.some(function (expectedKey) {
+    ok = uniqueExpected.some(function (expectedKey) {
       return actual.some(function (actualKey) {
         return isEql(expectedKey, actualKey);
       });
@@ -2549,14 +2551,14 @@ function assertKeys(keys) {
 
   // Has all
   if (all) {
-    ok = expected.every(function (expectedKey) {
+    ok = uniqueExpected.every(function (expectedKey) {
       return actual.some(function (actualKey) {
         return isEql(expectedKey, actualKey);
       });
     });
 
     if (!flag(this, 'contains')) {
-      ok = ok && keys.length == actual.length;
+      ok = ok && uniqueExpected.length == actual.length;
     }
   }
 

--- a/test/expect.js
+++ b/test/expect.js
@@ -3028,6 +3028,11 @@ describe('expect', function () {
       expect(expected).deep.equal(original_order);
   });
 
+  it('duplicate keys dont contribute to key count', () => {
+    const obj = { a: 1, b: 2, c: 3 };
+    expect(obj).to.have.all.keys('a', 'b', 'c', 'a', 'b');
+  });
+
   it('chaining', function(){
     var tea = { name: 'chai', extras: ['milk', 'sugar', 'smile'] };
     expect(tea).to.have.property('extras').with.lengthOf(3);


### PR DESCRIPTION
Fixes #1705.

Basically there's a bug where `{ a: 5, b: 6}` and `keys(['a', 'a'])`
will pass because we're incorrectly assuming the key count equalling the
actual key count must mean it has all of them.

This fixes it by using a `Set` (widely available since node 0.x).
