### PR TITLE
Drop `NODE_AUTH_TOKEN` from publish script

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -38,5 +38,3 @@ jobs:
         env:
           TAG_NAME: ${{ github.ref_name }}
       - run: npm publish --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.npm_secret }}


### PR DESCRIPTION
This now uses OIDC for publishing