### PR TITLE
docs: fix syntax errors in assert examples

### DIFF
--- a/lib/chai/interface/assert.js
+++ b/lib/chai/interface/assert.js
@@ -936,7 +936,7 @@ assert.include = function (exp, inc, msg) {
  *
  *     assert.notInclude([1,2,3], 4, "array doesn't contain value");
  *     assert.notInclude('foobar', 'baz', "string doesn't contain substring");
- *     assert.notInclude({ foo: 'bar', hello: 'universe' }, { foo: 'baz' }, 'object doesn't contain property');
+ *     assert.notInclude({ foo: 'bar', hello: 'universe' }, { foo: 'baz' }, "object doesn't contain property");
  *
  * Strict equality (===) is used. When asserting the absence of a value in an
  * array, the array is searched to confirm the absence of an element that's
@@ -1716,7 +1716,7 @@ assert.hasAnyKeys = function (obj, keys, msg) {
  * will be used as the expected set of keys.
  *
  *     assert.hasAllKeys({foo: 1, bar: 2, baz: 3}, ['foo', 'bar', 'baz']);
- *     assert.hasAllKeys({foo: 1, bar: 2, baz: 3}, {foo: 30, bar: 99, baz: 1337]);
+ *     assert.hasAllKeys({foo: 1, bar: 2, baz: 3}, {foo: 30, bar: 99, baz: 1337});
  *     assert.hasAllKeys(new Map([[{foo: 1}, 'bar'], ['key', 'value']]), [{foo: 1}, 'key']);
  *     assert.hasAllKeys(new Set([{foo: 'bar'}, 'anotherKey']), [{foo: 'bar'}, 'anotherKey']);
  *


### PR DESCRIPTION
There were two syntax errors in the `assert` examples, which this fixes.

I wrote [a script to find all syntax errors in the examples across the repo][0]. This script was largely vibe-coded and is low quality, but worked well enough to find these two mistakes. And I made the fixes manually--everything in this diff was done by hand.

[0]: https://gist.github.com/EvanHahn/5448ed0e49e072a35b6bd239781c4477
