### PR TITLE
fix: support deep include oneOf assertions

### DIFF
--- a/lib/chai/core/assertions.js
+++ b/lib/chai/core/assertions.js
@@ -3394,14 +3394,18 @@ function oneOf(list, msg) {
         return (
           expected.indexOf(possibility) > -1 ||
           (isDeep &&
-            typeof expected.some === 'function' &&
+            Array.isArray(expected) &&
             expected.some(function (item) {
               return eql(item, possibility);
             }))
         );
       }),
-      'expected #{this} to contain one of #{exp}',
-      'expected #{this} to not contain one of #{exp}',
+      'expected #{this} to ' +
+        (isDeep ? 'deeply ' : '') +
+        'contain one of #{exp}',
+      'expected #{this} to not ' +
+        (isDeep ? 'deeply ' : '') +
+        'contain one of #{exp}',
       list,
       expected
     );

--- a/lib/chai/core/assertions.js
+++ b/lib/chai/core/assertions.js
@@ -3391,7 +3391,14 @@ function oneOf(list, msg) {
   if (contains) {
     this.assert(
       list.some(function (possibility) {
-        return expected.indexOf(possibility) > -1;
+        return (
+          expected.indexOf(possibility) > -1 ||
+          (isDeep &&
+            typeof expected.some === 'function' &&
+            expected.some(function (item) {
+              return eql(item, possibility);
+            }))
+        );
       }),
       'expected #{this} to contain one of #{exp}',
       'expected #{this} to not contain one of #{exp}',

--- a/test/expect.js
+++ b/test/expect.js
@@ -3360,6 +3360,8 @@ describe('expect', function () {
 
     expect([1, 2]).to.contain.oneOf([4,2,5]);
     expect([3, 4]).to.not.contain.oneOf([2,1,5]);
+    expect([[1], [2]]).to.deep.include.oneOf([[1], [2]]);
+    expect([[3], [4]]).to.not.deep.include.oneOf([[1], [2]]);
 
     expect('The quick brown fox jumps over the lazy dog').to.contain.oneOf(['cat', 'dog', 'bird']);
     expect('The quick brown fox jumps over the lazy dog').to.not.contain.oneOf(['elephant', 'pigeon', 'lynx']);

--- a/test/expect.js
+++ b/test/expect.js
@@ -3360,8 +3360,9 @@ describe('expect', function () {
 
     expect([1, 2]).to.contain.oneOf([4,2,5]);
     expect([3, 4]).to.not.contain.oneOf([2,1,5]);
-    expect([[1], [2]]).to.deep.include.oneOf([[1], [2]]);
-    expect([[3], [4]]).to.not.deep.include.oneOf([[1], [2]]);
+    expect([[1], [2]]).to.deep.contain.oneOf([[1], [2]]);
+    expect([[3], [4]]).to.not.deep.contain.oneOf([[1], [2]]);
+    expect([[[1]]]).to.deep.contain.oneOf([[[1]]]);
 
     expect('The quick brown fox jumps over the lazy dog').to.contain.oneOf(['cat', 'dog', 'bird']);
     expect('The quick brown fox jumps over the lazy dog').to.not.contain.oneOf(['elephant', 'pigeon', 'lynx']);
@@ -3389,6 +3390,14 @@ describe('expect', function () {
     err(function () {
       expect(1, 'blah').to.be.oneOf({});
     }, "blah: expected {} to be an array");
+
+    err(function () {
+      expect([[1]]).to.deep.contain.oneOf([[2]]);
+    }, "expected [ [ 1 ] ] to deeply contain one of [ [ 2 ] ]");
+
+    err(function () {
+      expect([[1]]).to.not.deep.contain.oneOf([[1]]);
+    }, "expected [ [ 1 ] ] to not deeply contain one of [ [ 1 ] ]");
   });
 
   it('include.members', function() {


### PR DESCRIPTION
Fixes #1493.

`deep.include.oneOf` currently takes the same strict containment path as `include.oneOf`, so nested arrays or objects are compared by identity even when the `deep` flag is present. For example, `expect([[1], [2]]).to.deep.include.oneOf([[1], [2]])` fails on current `main`.

This keeps the existing strict `indexOf` path, and falls back to Chai's configured deep equality comparison when `.deep` is set and the target supports array-style iteration.

Validation:
- `npm run build && npx mocha --require ./test/bootstrap/index.js test/expect.js --grep "oneOf"`
- `npm run lint`
- `npm run test-node`
- `npm run test-chrome`