### PR TITLE
chore: improve JSDoc for type checking (round 1)

### DIFF
--- a/lib/chai/utils/addChainableMethod.js
+++ b/lib/chai/utils/addChainableMethod.js
@@ -12,6 +12,12 @@ import {proxify} from './proxify.js';
 import {transferFlags} from './transferFlags.js';
 
 /**
+ * @typedef {Object} ChainableBehavior
+ * @property {() => void} chainingBehavior
+ * @property {(...args: never) => unknown} method
+ */
+
+/**
  * Module variables
  */
 
@@ -38,6 +44,12 @@ let call = Function.prototype.call,
   apply = Function.prototype.apply;
 
 export class PluginAddChainableMethodEvent extends PluginEvent {
+  /**
+   * @param {string} type
+   * @param {string} name
+   * @param {Function} fn
+   * @param {Function} chainingBehavior
+   */
   constructor(type, name, fn, chainingBehavior) {
     super(type, name, fn);
     this.chainingBehavior = chainingBehavior;
@@ -64,35 +76,45 @@ export class PluginAddChainableMethodEvent extends PluginEvent {
  *     expect(fooStr).to.be.foo('bar');
  *     expect(fooStr).to.be.foo.equal('foo');
  *
- * @param {object} ctx object to which the method is added
+ * @template {object} T
+ * @param {T} ctx object to which the method is added
  * @param {string} name of method to add
- * @param {Function} method function to be used for `name`, when called
- * @param {Function} chainingBehavior function to be called every time the property is accessed
+ * @param {(...args: never) => unknown} method function to be used for `name`, when called
+ * @param {(() => void)=} chainingBehavior function to be called every time the property is accessed
  * @namespace Utils
  * @name addChainableMethod
  * @public
  */
 export function addChainableMethod(ctx, name, method, chainingBehavior) {
+  const ctxChainable =
+    /** @type {T & {__methods: Record<PropertyKey, ChainableBehavior>}} */ (
+      ctx
+    );
+
   if (typeof chainingBehavior !== 'function') {
     chainingBehavior = function () {};
   }
 
+  /** @type {ChainableBehavior} */
   let chainableBehavior = {
     method: method,
     chainingBehavior: chainingBehavior
   };
 
   // save the methods so we can overwrite them later, if we need to.
-  if (!ctx.__methods) {
-    ctx.__methods = {};
+  if (!ctxChainable.__methods) {
+    ctxChainable.__methods = {};
   }
-  ctx.__methods[name] = chainableBehavior;
+  ctxChainable.__methods[name] = chainableBehavior;
 
   Object.defineProperty(ctx, name, {
     get: function chainableMethodGetter() {
       chainableBehavior.chainingBehavior.call(this);
 
-      let chainableMethodWrapper = function () {
+      /**
+       * @this {T}
+       */
+      function chainableMethodWrapper() {
         // Setting the `ssfi` flag to `chainableMethodWrapper` causes this
         // function to be the starting point for removing implementation
         // frames from the stack trace of a failed assertion.
@@ -112,7 +134,9 @@ export function addChainableMethod(ctx, name, method, chainingBehavior) {
           flag(this, 'ssfi', chainableMethodWrapper);
         }
 
-        let result = chainableBehavior.method.apply(this, arguments);
+        let result = /** @type {(...args: unknown[]) => unknown} */ (
+          chainableBehavior.method
+        ).apply(this, arguments);
         if (result !== undefined) {
           return result;
         }
@@ -120,7 +144,7 @@ export function addChainableMethod(ctx, name, method, chainingBehavior) {
         let newAssertion = new Assertion();
         transferFlags(this, newAssertion);
         return newAssertion;
-      };
+      }
 
       addLengthGuard(chainableMethodWrapper, name, true);
 
@@ -142,7 +166,9 @@ export function addChainableMethod(ctx, name, method, chainingBehavior) {
           }
 
           let pd = Object.getOwnPropertyDescriptor(ctx, asserterName);
-          Object.defineProperty(chainableMethodWrapper, asserterName, pd);
+          if (pd) {
+            Object.defineProperty(chainableMethodWrapper, asserterName, pd);
+          }
         });
       }
 

--- a/lib/chai/utils/events.js
+++ b/lib/chai/utils/events.js
@@ -8,6 +8,11 @@
 export const events = new EventTarget();
 
 export class PluginEvent extends Event {
+  /**
+   * @param {string} type
+   * @param {string} name
+   * @param {Function} fn
+   */
   constructor(type, name, fn) {
     super(type);
     this.name = String(name);

--- a/lib/chai/utils/flag.js
+++ b/lib/chai/utils/flag.js
@@ -15,7 +15,7 @@
  *     utils.flag(this, 'foo', 'bar'); // setter
  *     utils.flag(this, 'foo'); // getter, returns `bar`
  *
- * @template {{__flags?: {[key: PropertyKey]: unknown}}} T
+ * @template {{__flags?: Record<PropertyKey, unknown>}} T
  * @param {T} obj object constructed Assertion
  * @param {string} key
  * @param {unknown} [value]

--- a/lib/chai/utils/overwriteMethod.js
+++ b/lib/chai/utils/overwriteMethod.js
@@ -36,22 +36,27 @@ import {transferFlags} from './transferFlags.js';
  *
  *     expect(myFoo).to.equal('bar');
  *
+ * @template {object} T
  * @param {object} ctx object whose method is to be overwritten
- * @param {string} name of method to overwrite
+ * @param {PropertyKey} name of method to overwrite
  * @param {Function} method function that returns a function to be used for name
  * @namespace Utils
  * @name overwriteMethod
  * @public
  */
 export function overwriteMethod(ctx, name, method) {
-  let _method = ctx[name],
-    _super = function () {
-      throw new Error(name + ' is not a function');
-    };
+  let _method = /** @type {Record<PropertyKey, unknown>} */ (ctx)[name];
+  /** @type {Function} */
+  let _super = function () {
+    throw new Error(String(name) + ' is not a function');
+  };
 
   if (_method && 'function' === typeof _method) _super = _method;
 
-  let overwritingMethodWrapper = function () {
+  /**
+   * @this {T}
+   */
+  function overwritingMethodWrapper() {
     // Setting the `ssfi` flag to `overwritingMethodWrapper` causes this
     // function to be the starting point for removing implementation frames from
     // the stack trace of a failed assertion.
@@ -83,8 +88,11 @@ export function overwriteMethod(ctx, name, method) {
     let newAssertion = new Assertion();
     transferFlags(this, newAssertion);
     return newAssertion;
-  };
+  }
 
-  addLengthGuard(overwritingMethodWrapper, name, false);
-  ctx[name] = proxify(overwritingMethodWrapper, name);
+  addLengthGuard(overwritingMethodWrapper, String(name), false);
+  /** @type {Record<PropertyKey, unknown>} */ (ctx)[name] = proxify(
+    overwritingMethodWrapper,
+    name
+  );
 }

--- a/lib/chai/utils/overwriteProperty.js
+++ b/lib/chai/utils/overwriteProperty.js
@@ -34,16 +34,18 @@ import {transferFlags} from './transferFlags.js';
  *
  *     expect(myFoo).to.be.ok;
  *
- * @param {object} ctx object whose property is to be overwritten
- * @param {string} name of property to overwrite
+ * @template {object} T
+ * @param {T} ctx object whose property is to be overwritten
+ * @param {PropertyKey} name of property to overwrite
  * @param {Function} getter function that returns a getter function to be used for name
  * @namespace Utils
  * @name overwriteProperty
  * @public
  */
 export function overwriteProperty(ctx, name, getter) {
-  let _get = Object.getOwnPropertyDescriptor(ctx, name),
-    _super = function () {};
+  let _get = Object.getOwnPropertyDescriptor(ctx, name);
+  /** @type {(ctx: T) => unknown} */
+  let _super = function () {};
 
   if (_get && 'function' === typeof _get.get) _super = _get.get;
 

--- a/lib/chai/utils/proxify.js
+++ b/lib/chai/utils/proxify.js
@@ -28,7 +28,7 @@ const builtins = ['__flags', '__methods', '_obj', 'assert'];
  * @namespace Utils
  * @template {object} T
  * @param {T} obj
- * @param {string} [nonChainableMethodName]
+ * @param {PropertyKey=} nonChainableMethodName
  * @returns {T}
  */
 export function proxify(obj, nonChainableMethodName) {
@@ -49,11 +49,11 @@ export function proxify(obj, nonChainableMethodName) {
         if (nonChainableMethodName) {
           throw Error(
             'Invalid Chai property: ' +
-              nonChainableMethodName +
+              String(nonChainableMethodName) +
               '.' +
               property +
               '. See docs for proper usage of "' +
-              nonChainableMethodName +
+              String(nonChainableMethodName) +
               '".'
           );
         }

--- a/lib/chai/utils/test.js
+++ b/lib/chai/utils/test.js
@@ -12,7 +12,7 @@ import {flag} from './flag.js';
  * Test an object for expression.
  *
  * @param {object} obj (constructed Assertion)
- * @param {unknown} args
+ * @param {ArrayLike<unknown>} args
  * @returns {unknown}
  * @namespace Utils
  * @name test

--- a/lib/chai/utils/transferFlags.js
+++ b/lib/chai/utils/transferFlags.js
@@ -20,17 +20,22 @@
  *
  * @param {import('../assertion.js').Assertion} assertion the assertion to transfer the flags from
  * @param {object} object the object to transfer the flags to; usually a new assertion
- * @param {boolean} includeAll
+ * @param {boolean=} includeAll
  * @namespace Utils
  * @name transferFlags
  * @private
  */
 export function transferFlags(assertion, object, includeAll) {
-  let flags = assertion.__flags || (assertion.__flags = Object.create(null));
-
-  if (!object.__flags) {
-    object.__flags = Object.create(null);
-  }
+  const assertionWithFlags =
+    /** @type {{__flags?: Record<PropertyKey, unknown>}} */ (assertion);
+  const objWithFlags = /** @type {{__flags?: Record<PropertyKey, unknown>}} */ (
+    object
+  );
+  let flags =
+    assertionWithFlags.__flags ||
+    (assertionWithFlags.__flags = Object.create(null));
+  const objFlags =
+    objWithFlags.__flags || (objWithFlags.__flags = Object.create(null));
 
   includeAll = arguments.length === 3 ? includeAll : true;
 
@@ -42,7 +47,7 @@ export function transferFlags(assertion, object, includeAll) {
         flag !== 'lockSsfi' &&
         flag != 'message')
     ) {
-      object.__flags[flag] = flags[flag];
+      objFlags[flag] = flags[flag];
     }
   }
 }

--- a/lib/chai/utils/type-detect.js
+++ b/lib/chai/utils/type-detect.js
@@ -11,7 +11,9 @@ export function type(obj) {
     return 'null';
   }
 
-  const stringTag = obj[Symbol.toStringTag];
+  const stringTag = /** @type {Record<PropertyKey, unknown>} */ (obj)[
+    Symbol.toStringTag
+  ];
   if (typeof stringTag === 'string') {
     return stringTag;
   }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "target": "esnext",
+    "rootDir": "lib",
     "module": "nodenext",
     "moduleResolution": "nodenext",
     "types": [],


### PR DESCRIPTION
This improves a few JSDoc types to reduce the number of typescript
errors we have.

Eventually, once we have 0 errors, we will be able to run typescript
over the repo for stronger type checking.
