### PR TITLE
fix: bump check-error to ^2.1.2 to fix TypeError on non-error thrown values

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "@web/test-runner-playwright": "^0.11.0",
     "assertion-error": "^2.0.1",
     "c8": "^11.0.0",
-    "check-error": "^2.1.1",
+    "check-error": "^2.1.2",
     "deep-eql": "^5.0.1",
     "esbuild": "^0.28.0",
     "eslint": "^10.0.0",


### PR DESCRIPTION
# Problem

`expect(func).throws("boom!")` crashes with `TypeError: Cannot read properties of undefined (reading 'indexOf')` when `func` throws a non-Error object that doesn't have a `.message` property.

## Root Cause

The `compatibleMessage` function in check-error v2.1.1 accesses `thrown.message` without guarding against undefined. When the thrown value is a plain object like `{ body: { message: 'test' } }`, `thrown.message` is `undefined`, and calling `.indexOf()` on it throws a TypeError.

## Fix

check-error v2.1.2 already has the fix (https://github.com/chaijs/check-error/releases/tag/v2.1.2). This PR bumps the dependency range from `^2.1.1` to `^2.1.2` so the fix is included.

Closes #1752