### PR TITLE
fix: not.deep.oneOf failure message is missing the not

### DIFF
--- a/lib/chai/core/assertions.js
+++ b/lib/chai/core/assertions.js
@@ -3416,7 +3416,7 @@ function oneOf(list, msg) {
           return eql(expected, possibility);
         }),
         'expected #{this} to deeply equal one of #{exp}',
-        'expected #{this} to deeply equal one of #{exp}',
+        'expected #{this} to not deeply equal one of #{exp}',
         list,
         expected
       );

--- a/test/expect.js
+++ b/test/expect.js
@@ -3398,6 +3398,10 @@ describe('expect', function () {
     err(function () {
       expect([[1]]).to.not.deep.contain.oneOf([[1]]);
     }, "expected [ [ 1 ] ] to not deeply contain one of [ [ 1 ] ]");
+
+    err(function () {
+      expect({a: 1}).to.not.deep.oneOf([{a: 1}, {b: 2}]);
+    }, "expected { a: 1 } to not deeply equal one of [ { a: 1 }, { b: 2 } ]");
   });
 
   it('include.members', function() {


### PR DESCRIPTION
Found this while poking around `oneOf`. In the plain (non-`contains`) deep branch, the positive and negative messages passed to `this.assert` are identical - looks like the negative one got copy-pasted without updating it:

```js
this.assert(
  list.some(function (possibility) {
    return eql(expected, possibility);
  }),
  'expected #{this} to deeply equal one of #{exp}',
  'expected #{this} to deeply equal one of #{exp}', // same as above
  ...
```

So a failing `expect(x).to.not.deep.oneOf([...])` prints "expected X to deeply equal one of Y" with no "not", which reads like the assertion passed. The `contains` branch right above it and the non-deep `else` branch right below both already have distinct pass/fail wording, so this looks like a straightforward oversight rather than intentional.

Fixed by adding "not" to the negative message, and added a test asserting on the actual message text for a failing negated case (the existing `oneOf` test only covers the passing path for plain `deep.oneOf`).
