### PR TITLE
fix: don't show a misleading diff for ordering assertions

### DIFF
--- a/lib/chai/core/assertions.js
+++ b/lib/chai/core/assertions.js
@@ -1287,14 +1287,17 @@ function assertAbove(n, msg) {
         ' above #{exp} but got #{act}',
       'expected #{this} to not have a ' + descriptor + ' above #{exp}',
       n,
-      itemsCount
+      itemsCount,
+      false
     );
   } else {
     this.assert(
       obj > n,
       'expected #{this} to be above #{exp}',
       'expected #{this} to be at most #{exp}',
-      n
+      n,
+      undefined,
+      false
     );
   }
 }
@@ -1394,14 +1397,17 @@ function assertLeast(n, msg) {
         ' at least #{exp} but got #{act}',
       'expected #{this} to have a ' + descriptor + ' below #{exp}',
       n,
-      itemsCount
+      itemsCount,
+      false
     );
   } else {
     this.assert(
       obj >= n,
       'expected #{this} to be at least #{exp}',
       'expected #{this} to be below #{exp}',
-      n
+      n,
+      undefined,
+      false
     );
   }
 }
@@ -1500,14 +1506,17 @@ function assertBelow(n, msg) {
         ' below #{exp} but got #{act}',
       'expected #{this} to not have a ' + descriptor + ' below #{exp}',
       n,
-      itemsCount
+      itemsCount,
+      false
     );
   } else {
     this.assert(
       obj < n,
       'expected #{this} to be below #{exp}',
       'expected #{this} to be at least #{exp}',
-      n
+      n,
+      undefined,
+      false
     );
   }
 }
@@ -1607,14 +1616,17 @@ function assertMost(n, msg) {
         ' at most #{exp} but got #{act}',
       'expected #{this} to have a ' + descriptor + ' above #{exp}',
       n,
-      itemsCount
+      itemsCount,
+      false
     );
   } else {
     this.assert(
       obj <= n,
       'expected #{this} to be at most #{exp}',
       'expected #{this} to be above #{exp}',
-      n
+      n,
+      undefined,
+      false
     );
   }
 }

--- a/test/expect.js
+++ b/test/expect.js
@@ -889,6 +889,21 @@ describe('expect', function () {
     }, "blah: Target cannot be null or undefined.");
   });
 
+  it('ordering assertions do not show a misleading diff (#1518)', function(){
+    // above/below/least/most compare a value against a bound rather than
+    // asserting equality, so a "+ expected - actual" diff wrongly implies
+    // that the two operands were supposed to be equal.
+    err(function(){ expect(2).to.be.above(3); }, { showDiff: false });
+    err(function(){ expect(5).to.be.below(3); }, { showDiff: false });
+    err(function(){ expect(2).to.be.at.least(3); }, { showDiff: false });
+    err(function(){ expect(2).to.be.at.most(1); }, { showDiff: false });
+
+    var now = new Date();
+    var later = new Date(now.getTime() + 1000);
+    err(function(){ expect(now).to.be.above(later); }, { showDiff: false });
+    err(function(){ expect(now).to.be.at.least(later); }, { showDiff: false });
+  });
+
   it('least(n)', function(){
     expect(5).to.be.at.least(2);
     expect(5).to.be.at.least(5);


### PR DESCRIPTION
## Problem

The `above`/`below`/`least`/`most` assertions (and their `length`/`size` variants) compare a value against a bound rather than asserting equality. Passing `expected` to `this.assert` made the reporter render a `+ expected - actual` diff, wrongly implying the two operands were meant to be equal (e.g. `isAtLeast(a, b)` showed `a`/`b` as an equality diff).

## Fix

Pass `showDiff = false` for these comparisons so only the descriptive message is shown, not a misleading equality diff.

## Testing

Added a test in `test/expect.js` asserting that ordering assertions (`above`, `below`, `at.least`, `at.most`) fail with `showDiff: false`, covering both numeric and `Date` operands.

Closes #1518
