### PR TITLE
docs: fix nestedInclude path and notMatch example in assert JSDoc

### DIFF
--- a/lib/chai/interface/assert.js
+++ b/lib/chai/interface/assert.js
@@ -1020,7 +1020,7 @@ assert.notDeepInclude = function (exp, inc, msg) {
  * properties.
  * '[]' and '.' in property names can be escaped using double backslashes.
  *
- *     assert.nestedInclude({'.a': {'b': 'x'}}, {'\\.a.[b]': 'x'});
+ *     assert.nestedInclude({'.a': {'b': 'x'}}, {'\\.a.b': 'x'});
  *     assert.nestedInclude({'a': {'[b]': 'x'}}, {'a.\\[b\\]': 'x'});
  *
  * @name nestedInclude
@@ -1221,7 +1221,7 @@ assert.match = function (exp, re, msg) {
  *
  * Asserts that `value` does not match the regular expression `regexp`.
  *
- *     assert.notMatch('foobar', /^foo/, 'regexp does not match');
+ *     assert.notMatch('barfoo', /^foo/, 'regexp does not match');
  *
  * @name notMatch
  * @param {unknown} exp


### PR DESCRIPTION
## Summary
- Correct the `assert.nestedInclude` JSDoc example so the escaped path is `\\.a.b` (matching `notNestedInclude` and the object shape `{'.a': {'b': 'x'}}`).
- Change the `assert.notMatch` example from `'foobar'` to `'barfoo'` so the sample actually fails `/^foo/` as the comment describes.

Fixes #1299

## Test plan
- [x] Confirm examples match the patterns already used in neighboring JSDoc (`notNestedInclude`)
- [ ] Docs site regenerates from assert.js JSDoc on next publish