### PR TITLE
docs: fix dead fork-a-repo link in CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,7 +95,7 @@ Please adhere to the coding conventions used throughout a project (indentation, 
 
 Follow this process if you'd like your work considered for inclusion in the project:
 
-1. [Fork](http://help.github.com/fork-a-repo/) the project, clone your fork, and configure the remotes:
+1. [Fork](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/fork-a-repo) the project, clone your fork, and configure the remotes:
 
 ```bash
 # Clone your fork of the repo into the current directory


### PR DESCRIPTION
Step 1 of the contributing guide links to `http://help.github.com/fork-a-repo/`, which 404s — help.github.com was retired and folded into docs.github.com. New contributors hit a dead page on the very first instruction.

Replaced with the current guide, which returns 200:
https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/fork-a-repo

I checked every external link in the repo's markdown. The only other 404s are in `History.md` and `ReleaseNotes.md` (a few deleted GitHub user profiles and the old visionmedia/mocha and wiki.ecmascript.org URLs). Those are historical release records, so I left them untouched — happy to fix them too if you'd prefer.