### PR TITLE
test: cover throws() when the thrown value is not an Error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@web/test-runner-playwright": "^1.0.0",
         "assertion-error": "^2.0.1",
         "c8": "^12.0.0",
-        "check-error": "^2.1.1",
+        "check-error": "^2.1.3",
         "deep-eql": "^5.0.1",
         "esbuild": "^0.28.0",
         "eslint": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "@web/test-runner-playwright": "^1.0.0",
     "assertion-error": "^2.0.1",
     "c8": "^12.0.0",
-    "check-error": "^2.1.1",
+    "check-error": "^2.1.3",
     "deep-eql": "^5.0.1",
     "esbuild": "^0.28.0",
     "eslint": "^10.0.0",

--- a/test/assert.js
+++ b/test/assert.js
@@ -1730,6 +1730,16 @@ describe('assert', function () {
       err(function () {
         assert[throws]({}, Error, 'testing', 'blah');
       }, "blah: expected {} to be a function");
+
+      // GH-1752: a thrown non-Error object must fail the message matcher
+      // as an assertion, not as TypeError from reading `.message.indexOf`.
+      err(function () {
+        assert[throws](function () { throw { body: { message: 'Custom error type' } }; }, 'boom!');
+      }, "expected [Function] to throw error including 'boom!' but got ''");
+
+      err(function () {
+        assert[throws](function () { throw { body: { message: 'Custom error type' } }; }, /boom/);
+      }, "expected [Function] to throw error matching /boom/ but got ''");
     });
   });
 

--- a/test/expect.js
+++ b/test/expect.js
@@ -3218,6 +3218,14 @@ describe('expect', function () {
     err(function () {
       expect({}).to.throw(Error, 'testing', 'blah');
     }, "blah: expected {} to be a function");
+
+    err(function () {
+      expect(function () { throw { body: { message: 'Custom error type' } }; }).to.throw('boom!');
+    }, "expected [Function] to throw error including 'boom!' but got ''");
+
+    err(function () {
+      expect(function () { throw { body: { message: 'Custom error type' } }; }).to.throw(/boom/);
+    }, "expected [Function] to throw error matching /boom/ but got ''");
   });
 
   it('respondTo', function(){


### PR DESCRIPTION
`expect(fn).throws('boom!')` currently TypeErrors when `fn` throws a plain object with no `.message`, instead of failing as an assertion. Reproduced on published 6.2.2.

check-error 2.1.3 already returns false for that case (chaijs/check-error#66). This bumps the minimum to that version and adds a regression so the next chai release keeps the assertion path.

```js
expect(() => { throw { body: { message: 'Custom' } }; }).throws('boom!');
// TypeError: Cannot read properties of undefined (reading 'indexOf')
```

Closes #1752
