### PR TITLE
fix: preserve literal template tags in assertion values

### DIFF
--- a/lib/chai/utils/getMessage.js
+++ b/lib/chai/utils/getMessage.js
@@ -37,16 +37,23 @@ export function getMessage(obj, args) {
 
   if (typeof msg === 'function') msg = msg();
   msg = msg || '';
-  msg = msg
-    .replace(/#\{this\}/g, function () {
-      return objDisplay(val);
-    })
-    .replace(/#\{act\}/g, function () {
-      return objDisplay(actual);
-    })
-    .replace(/#\{exp\}/g, function () {
+  msg = msg.replace(
+    /#\{(this|act|exp)\}/g,
+    /**
+     * @param {string} _
+     * @param {string} tag
+     * @returns {string}
+     */
+    function (_, tag) {
+      if (tag === 'this') {
+        return objDisplay(val);
+      }
+      if (tag === 'act') {
+        return objDisplay(actual);
+      }
       return objDisplay(expected);
-    });
+    }
+  );
 
   return flagMsg ? flagMsg + ': ' + msg : msg;
 }

--- a/test/expect.js
+++ b/test/expect.js
@@ -9,6 +9,16 @@ describe('expect', function () {
     expect('foo').to.equal('foo');
   });
 
+  it('preserves literal template tags in assertion values', function () {
+    err(function () {
+      expect('#{exp}', 'custom message').to.equal('different');
+    }, "custom message: expected '#{exp}' to equal 'different'");
+
+    err(function () {
+      expect('#{exp}').to.not.equal('#{exp}');
+    }, "expected '#{exp}' to not equal '#{exp}'");
+  });
+
   describe('safeguards', function () {
     before(function () {
       chai.util.addProperty(chai.Assertion.prototype, 'tmpProperty', function () {

--- a/test/utilities.js
+++ b/test/utilities.js
@@ -687,6 +687,22 @@ describe('utilities', function () {
               template: '#{this}#{act}#{exp}#{act}#{this}',
               expected: '\'' + objName + '\'\'' + actualValue + '\'\'' + expectedValue + '\'\'' + actualValue + '\'\'' + objName + '\''
           },
+          // template tags inside substituted values remain literal
+          {
+              objName: '#{this} #{act} #{exp}',
+              template: '#{this}',
+              expected: "'#{this} #{act} #{exp}'"
+          },
+          {
+              actualValue: '#{this} #{act} #{exp}',
+              template: '#{act}',
+              expected: "'#{this} #{act} #{exp}'"
+          },
+          {
+              expectedValue: '#{this} #{act} #{exp}',
+              template: '#{exp}',
+              expected: "'#{this} #{act} #{exp}'"
+          },
           // immune to string.prototype.replace() `$` substitution
           {
               objName: '-$$-',


### PR DESCRIPTION
Chai currently expands template tags inside values already inserted into an assertion message. For example, `expect('#{exp}').to.equal('different')` reports `expected ''different'' to equal 'different'`, hiding the actual input.

Substitute the original message's tags in one pass so inserted values stay literal. Tests cover all three tags, positive and negated assertions, and a custom message; existing dollar-substitution coverage is retained.

Validation:
- Both added regression paths fail before the source fix.
- `npm run build` and `npm test` pass: lint, 512 Node tests, and 511 Chromium tests.
- `npm run test-chrome -- --browsers firefox` passes: 511 tests.
- Additional `npm run lint:types` check fails on both unchanged `main` and this branch, with the same diagnostics after ignoring line locations.

AI assistance: implemented and tested with OpenAI Codex.
