### PR TITLE
fix: reject ordered member sequences longer than the target

### DIFF
--- a/lib/chai/core/assertions.js
+++ b/lib/chai/core/assertions.js
@@ -3176,6 +3176,7 @@ Assertion.addMethod('approximately', closeTo);
 function isSubsetOf(_subset, _superset, cmp, contains, ordered) {
   let superset = Array.from(_superset);
   let subset = Array.from(_subset);
+  if (ordered && subset.length > superset.length) return false;
   if (!contains) {
     if (subset.length !== superset.length) return false;
     superset = superset.slice();

--- a/test/assert.js
+++ b/test/assert.js
@@ -2127,6 +2127,12 @@ describe('assert', function () {
 
   it('includeOrderedMembers', function() {
     assert.includeOrderedMembers([1, 2, 3], [1, 2]);
+    assert.includeOrderedMembers([], []);
+    assert.includeOrderedMembers([1, undefined], [1, undefined]);
+
+    err(function() {
+      assert.includeOrderedMembers([1], [1, undefined]);
+    }, 'expected [ 1 ] to be an ordered superset of [ 1, undefined ]');
 
     err(function() {
       assert.includeOrderedMembers([1, 2, 3], [2, 1], 'blah');
@@ -2134,6 +2140,9 @@ describe('assert', function () {
   });
 
   it('notIncludeOrderedMembers', function() {
+    assert.notIncludeOrderedMembers([], [undefined]);
+    assert.notIncludeOrderedMembers([1], [1, undefined]);
+    assert.notIncludeOrderedMembers([1, undefined], [1, undefined, undefined]);
     assert.notIncludeOrderedMembers([1, 2, 3], [2, 1]);
     assert.notIncludeOrderedMembers([1, 2, 3], [2, 3]);
     assert.notIncludeOrderedMembers([1, 2, 3], [1, 2, 2]);
@@ -2145,6 +2154,12 @@ describe('assert', function () {
 
   it('includeDeepOrderedMembers', function() {
     assert.includeDeepOrderedMembers([{a: 1}, {b: 2}, {c: 3}], [{a: 1}, {b: 2}]);
+    assert.includeDeepOrderedMembers([], []);
+    assert.includeDeepOrderedMembers([{a: 1}, undefined], [{a: 1}, undefined]);
+
+    err(function() {
+      assert.includeDeepOrderedMembers([{a: 1}], [{a: 1}, undefined]);
+    }, 'expected [ { a: 1 } ] to be an ordered superset of [ { a: 1 }, undefined ]');
 
     err(function() {
       assert.includeDeepOrderedMembers([{a: 1}, {b: 2}, {c: 3}], [{b: 2}, {a: 1}], 'blah');
@@ -2152,6 +2167,9 @@ describe('assert', function () {
   });
 
   it('notIncludeDeepOrderedMembers', function() {
+    assert.notIncludeDeepOrderedMembers([], [undefined]);
+    assert.notIncludeDeepOrderedMembers([{a: 1}], [{a: 1}, undefined]);
+    assert.notIncludeDeepOrderedMembers([{a: 1}, undefined], [{a: 1}, undefined, undefined]);
     assert.notIncludeDeepOrderedMembers([{a: 1}, {b: 2}, {c: 3}], [{b: 2}, {a: 1}]);
     assert.notIncludeDeepOrderedMembers([{a: 1}, {b: 2}, {c: 3}], [{a: 1}, {f: 5}]);
     assert.notIncludeDeepOrderedMembers([{a: 1}, {b: 2}, {c: 3}], [{a: 1}, {b: 2}, {b: 2}]);

--- a/test/expect.js
+++ b/test/expect.js
@@ -3550,6 +3550,11 @@ describe('expect', function () {
 
   it('include.ordered.members', function() {
     expect([1, 2, 3]).include.ordered.members([1, 2]);
+    expect([]).include.ordered.members([]);
+    expect([1, undefined]).include.ordered.members([1, undefined]);
+    expect([]).not.include.ordered.members([undefined]);
+    expect([1]).not.include.ordered.members([1, undefined]);
+    expect([1, undefined]).not.include.ordered.members([1, undefined, undefined]);
     expect([1, 2, 3]).not.include.ordered.members([2, 1]);
     expect([1, 2, 3]).not.include.ordered.members([2, 3]);
     expect([1, 2, 3]).not.include.ordered.members([1, 2, 2]);
@@ -3592,6 +3597,11 @@ describe('expect', function () {
 
   it('include.deep.ordered.members', function() {
     expect([{a: 1}, {b: 2}, {c: 3}]).include.deep.ordered.members([{a: 1}, {b: 2}]);
+    expect([]).include.deep.ordered.members([]);
+    expect([{a: 1}, undefined]).include.deep.ordered.members([{a: 1}, undefined]);
+    expect([]).not.include.deep.ordered.members([undefined]);
+    expect([{a: 1}]).not.include.deep.ordered.members([{a: 1}, undefined]);
+    expect([{a: 1}, undefined]).not.include.deep.ordered.members([{a: 1}, undefined, undefined]);
     expect([{a: 1}, {b: 2}, {c: 3}]).not.include.deep.ordered.members([{b: 2}, {a: 1}]);
     expect([{a: 1}, {b: 2}, {c: 3}]).not.include.deep.ordered.members([{b: 2}, {c: 3}]);
     expect([{a: 1}, {b: 2}, {c: 3}]).not.include.deep.ordered.members([{a: 1}, {b: 2}, {b: 2}]);

--- a/test/should.js
+++ b/test/should.js
@@ -2903,6 +2903,11 @@ describe('should', function() {
 
   it('include.ordered.members', function() {
     [1, 2, 3].should.include.ordered.members([1, 2]);
+    [].should.include.ordered.members([]);
+    [1, undefined].should.include.ordered.members([1, undefined]);
+    [].should.not.include.ordered.members([undefined]);
+    [1].should.not.include.ordered.members([1, undefined]);
+    [1, undefined].should.not.include.ordered.members([1, undefined, undefined]);
     [1, 2, 3].should.not.include.ordered.members([2, 1]);
     [1, 2, 3].should.not.include.ordered.members([2, 3]);
     [1, 2, 3].should.not.include.ordered.members([1, 2, 2]);
@@ -2937,6 +2942,11 @@ describe('should', function() {
 
   it('include.deep.ordered.members', function() {
     [{a: 1}, {b: 2}, {c: 3}].should.include.deep.ordered.members([{a: 1}, {b: 2}]);
+    [].should.include.deep.ordered.members([]);
+    [{a: 1}, undefined].should.include.deep.ordered.members([{a: 1}, undefined]);
+    [].should.not.include.deep.ordered.members([undefined]);
+    [{a: 1}].should.not.include.deep.ordered.members([{a: 1}, undefined]);
+    [{a: 1}, undefined].should.not.include.deep.ordered.members([{a: 1}, undefined, undefined]);
     [{a: 1}, {b: 2}, {c: 3}].should.not.include.deep.ordered.members([{b: 2}, {a: 1}]);
     [{a: 1}, {b: 2}, {c: 3}].should.not.include.deep.ordered.members([{b: 2}, {c: 3}]);
     [{a: 1}, {b: 2}, {c: 3}].should.not.include.deep.ordered.members([{a: 1}, {b: 2}, {b: 2}]);


### PR DESCRIPTION
Ordered member inclusion currently accepts expected sequences that extend past the target with `undefined` values. For example, `expect([1]).to.include.ordered.members([1, undefined])` passes because reading past the target's end produces `undefined`.

Check the sequence lengths before ordered comparison. Regression coverage exercises strict and deep comparisons through `expect`, `should`, and `assert`, including empty targets, trailing `undefined` values, valid equal-length matches, and negation.

Validation on Node.js v24.16.0 (Windows):

- Before the fix: all 8 affected test cases fail with the added regressions.
- After the fix: all 8 affected test cases pass.
- `npm run test-node -- --reporter dot`: 511 passing.
- `npm run lint`: passes with the existing JSDoc warnings.
- Browser suite: 510 passing on Chromium 151.0.7922.34, using the repository's browser configuration with a local executable path override.

Developed with assistance from OpenAI Codex; reproduction and tests were run locally.
